### PR TITLE
Remove activerecord-deprecated_finders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rails', '4.2.1'
 
 # Legacy Rails feature gems - will no longer be supported in Rails 5.0
 gem 'protected_attributes'
-gem 'activerecord-deprecated_finders', require: 'active_record/deprecated_finders'
 gem 'actionpack-action_caching'
 gem 'actionpack-page_caching'
 gem 'responders'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ GEM
       activemodel (= 4.2.1)
       activesupport (= 4.2.1)
       arel (~> 6.0)
-    activerecord-deprecated_finders (1.0.4)
     activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -271,7 +270,6 @@ PLATFORMS
 DEPENDENCIES
   actionpack-action_caching
   actionpack-page_caching
-  activerecord-deprecated_finders
   airbrake
   annotate
   attr_encrypted

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -61,7 +61,7 @@ class Admin::AdminUsersController < Admin::AdminController
     user.departments.reverse.each do |department|
       user.departments.delete(department) unless department_ids.include?(department.id.to_s)
     end
-    department_ids.map { |department_id| Department.find_by_id(department_id) }.compact.each do |department|
+    department_ids.map { |department_id| Department.find_by(id: department_id) }.compact.each do |department|
       user.departments << department unless user.departments.include?(department)
     end
   end

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -106,7 +106,7 @@ class Admin::PetitionsController < Admin::AdminController
     @petition.rejection_text = params[:petition][:rejection_text]
 
     # if a petition is rejected for a reason that means it should be hidden, then set the state accordingly
-    reason = RejectionReason.find_by_code(@petition.rejection_code)
+    reason = RejectionReason.for_code(@petition.rejection_code)
     if reason and ! reason.published
       @petition.state = Petition::HIDDEN_STATE
     else

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -190,11 +190,11 @@ class Petition < ActiveRecord::Base
   end
 
   def rejection_reason
-    RejectionReason.find_by_code(self.rejection_code).title
+    RejectionReason.for_code(self.rejection_code).title
   end
 
   def rejection_description
-    RejectionReason.find_by_code(self.rejection_code).description
+    RejectionReason.for_code(self.rejection_code).description
   end
 
   def editable_by?(user)

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -46,7 +46,7 @@ class SystemSetting < ActiveRecord::Base
   end
 
   def self.value_of_key(key)
-    ss = SystemSetting.find_by_key(key)
+    ss = SystemSetting.find_by(key: key)
     ss && ss.value
   end
 end

--- a/db/seeds/departments.rb
+++ b/db/seeds/departments.rb
@@ -102,7 +102,7 @@ departments = [
 ]
 
 departments.each do |department|
-  d = Department.find_or_initialize_by_name(department[:name])
+  d = Department.find_or_initialize_by(name: department[:name])
   if d.new_record?
     d.update_attributes!(department)
   end

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -27,7 +27,7 @@ end
 
 Given /^I am logged in as a moderator for the "([^"]*)"$/ do |department_name|
   step "I am logged in as an admin"
-  @user.departments << Department.find_by_name(department_name)
+  @user.departments << Department.find_by(name: department_name)
 end
 
 Given /^the admin user is logged in$/ do

--- a/features/step_definitions/department_assignment_steps.rb
+++ b/features/step_definitions/department_assignment_steps.rb
@@ -1,6 +1,6 @@
 Given /^there is a petition "([^"]*)" that has been assigned between two departments several times$/ do |petition_title|
-  cabinet_office = Department.find_by_name('Cabinet Office')
-  treasury       = Department.find_by_name('Treasury')
+  cabinet_office = Department.find_by(name: 'Cabinet Office')
+  treasury       = Department.find_by(name: 'Treasury')
   petition = FactoryGirl.create(:validated_petition, :title => petition_title, :department => treasury)
 
   assignments = petition.department_assignments
@@ -10,6 +10,6 @@ Given /^there is a petition "([^"]*)" that has been assigned between two departm
 end
 
 When /^I view the "([^"]*)" admin edit page$/ do |petition_title|
-  petition = Petition.find_by_title(petition_title)
+  petition = Petition.find_by(title: petition_title)
   visit edit_admin_petition_path(petition)
 end

--- a/features/step_definitions/department_steps.rb
+++ b/features/step_definitions/department_steps.rb
@@ -17,7 +17,7 @@ When /^I view the (open|closed|rejected) petitions for the "([^"]*)"$/ do |petit
 end
 
 Then /^I (should|should not) see the petitions belonging to the "([^"]*)"$/ do |should_or_not, department_name|
-  department = Department.find_by_name(department_name)
+  department = Department.find_by(name: department_name)
   department.petitions.each do |petition|
     petition_link = "a[href*='#{petition_path(petition.id)}']"
     if (should_or_not == "should")

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -1,6 +1,6 @@
 Given /^a set of petitions for the "([^"]*)"$/ do |department_name|
   3.times do |x|
-    @petition = FactoryGirl.create(:open_petition, :title => "Petition #{x}", :description => "description", :department => Department.find_by_name(department_name))
+    @petition = FactoryGirl.create(:open_petition, :title => "Petition #{x}", :description => "description", :department => Department.find_by(name: department_name))
   end
 end
 
@@ -12,13 +12,13 @@ end
 Given /^a(n)? ?(pending|validated|open)? petition "([^"]*)" belonging to the "([^"]*)"$/ do |a_or_an, state, petition_title, department_name|
   @petition = FactoryGirl.create(:open_petition,
     :title => petition_title,
-    :department => Department.find_by_name(department_name),
+    :department => Department.find_by(name: department_name),
     :closed_at => 1.day.from_now,
     :state => state || "open")
 end
 
 Given /^the petition "([^"]*)" has (\d+) validated and (\d+) pending signatures$/ do |title, no_validated, no_pending|
-  petition = Petition.find_by_title(title)
+  petition = Petition.find_by(title: title)
   (no_validated - 1).times { petition.signatures << FactoryGirl.create(:validated_signature) }
   no_pending.times { petition.signatures << FactoryGirl.create(:pending_signature) }
 end
@@ -36,18 +36,18 @@ Given /^I have created an e-petition$/ do
 end
 
 Given /^the petition "([^"]*)" has (\d+) validated signatures$/ do |title, no_validated|
-  petition = Petition.find_by_title(title)
+  petition = Petition.find_by(title: title)
   (no_validated - 1).times { petition.signatures << FactoryGirl.create(:validated_signature) }
 end
 
 Given /^a petition "([^"]*)" belonging to the "([^"]*)" has been closed$/ do |petition_title, department_name|
-  @petition = FactoryGirl.create(:open_petition, :title => petition_title, :closed_at => 1.day.ago, :department => Department.find_by_name(department_name))
+  @petition = FactoryGirl.create(:open_petition, :title => petition_title, :closed_at => 1.day.ago, :department => Department.find_by(name: department_name))
 end
 
 Given /^a libelous petition "([^"]*)" has been rejected by the "([^"]*)"$/ do |petition_title, department_name|
   @petition = FactoryGirl.create(:petition,
     :title => petition_title,
-    :department => Department.find_by_name(department_name),
+    :department => Department.find_by(name: department_name),
     :state => Petition::HIDDEN_STATE,
     :rejection_code => "libellous",
     :rejection_text => "You can't say that!")
@@ -57,7 +57,7 @@ Given /^a petition "([^"]*)" has been rejected by the "([^"]*)"( with the reason
   reason_text = reason.nil? ? "We are the #{department_name}, not television executives" : reason
   @petition = FactoryGirl.create(:petition,
     :title => petition_title,
-    :department => Department.find_by_name(department_name),
+    :department => Department.find_by(name: department_name),
     :state => Petition::REJECTED_STATE,
     :rejection_code => "irrelevant",
     :rejection_text => reason_text)

--- a/features/step_definitions/resend_confirmation_steps.rb
+++ b/features/step_definitions/resend_confirmation_steps.rb
@@ -18,7 +18,7 @@ Then /^I should receive an email with my confirmation link$/ do
 end
 
 Given /^I have already signed the petition "([^"]*)"$/ do |petition_title|
-  petition = Petition.find_by_title(petition_title)
+  petition = Petition.find_by(title: petition_title)
   FactoryGirl.create(:validated_signature, :petition => petition, :email => 'suzie@example.com')
 end
 
@@ -27,12 +27,12 @@ Then /^I should receive an email telling me (?:I|we)'ve already confirmed$/ do
 end
 
 Given /^Sam has signed the petition "([^"]*)" but not confirmed by email$/ do |petition_title|
-  petition = Petition.find_by_title(petition_title)
+  petition = Petition.find_by(title: petition_title)
   FactoryGirl.create(:pending_signature, :petition => petition, :email => 'suzie@example.com')
 end
 
 Given /^Sam has signed the petition "([^"]*)"$/ do |petition_title|
-  petition = Petition.find_by_title(petition_title)
+  petition = Petition.find_by(title: petition_title)
   FactoryGirl.create(:validated_signature, :petition => petition, :email => 'suzie@example.com')
 end
 

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -133,15 +133,15 @@ Then /^I should have signed the petition after confirming my email address$/ do
 end
 
 Then /^there should be a "([^"]*)" signature with email "([^"]*)" and name "([^"]*)"$/ do |state, email, name|
-  expect(Signature.find_by_email_and_name_and_state(email, name, state)).not_to be_nil
+  expect(Signature.for_email(email).find_by(name: name, state: state)).not_to be_nil
 end
 
 Then /^"([^"]*)" wants to be notified about the petition's progress$/ do |name|
-  expect(Signature.find_by_name(name).notify_by_email?).to be_truthy
+  expect(Signature.find_by(name: name).notify_by_email?).to be_truthy
 end
 
 Given /^I have already signed the petition "([^"]*)" but not confirmed my email$/ do |petition_title|
-  petition = Petition.find_by_title(petition_title)
+  petition = Petition.find_by(title: petition_title)
   FactoryGirl.create(:pending_signature, :email => 'suzie@example.com', :petition => petition)
 end
 

--- a/features/step_definitions/threshold_steps.rb
+++ b/features/step_definitions/threshold_steps.rb
@@ -1,5 +1,5 @@
 Then /^the response to "([^"]*)" should be publicly viewable on the petition page$/ do |petition_title|
-  petition = Petition.find_by_title(petition_title)
+  petition = Petition.find_by(title: petition_title)
   visit petition_path(petition)
   expect(page).to have_content(petition.response)
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -36,10 +36,10 @@ module NavigationHelpers
       new_petition_path
 
     when /^the petition page for "([^\"]*)"$/
-      petition_path(Petition.find_by_title($1))
+      petition_path(Petition.find_by(title: $1))
 
     when /^the new signature page for "([^\"]*)"$/
-      new_petition_signature_path(Petition.find_by_title($1))
+      new_petition_signature_path(Petition.find_by(title: $1))
 
     when /^the search results page$/
       search_path
@@ -77,7 +77,7 @@ module NavigationHelpers
       admin_root_path
 
     when /^moderate petitions page for "([^\"]*)"$/
-      edit_admin_petition_path(Petition.find_by_title($1))
+      edit_admin_petition_path(Petition.find_by(title: $1))
 
     when /^threshold page$/
       threshold_admin_petitions_path
@@ -95,7 +95,7 @@ module NavigationHelpers
       edit_admin_profile_path(@user)
 
     when /^edit profile page for "([^\"]*)"$/
-      edit_admin_profile_path(AdminUser.find_by_email($1))
+      edit_admin_profile_path(AdminUser.find_by(email: $1))
 
     when /^reports page$/
       admin_reports_path

--- a/lib/rejection_reason.rb
+++ b/lib/rejection_reason.rb
@@ -5,7 +5,7 @@ class RejectionReason < OpenStruct
   FILE = Rails.root.join(*%w(config rejection_reasons.json))
 
   class << self
-    def find_by_code(code)
+    def for_code(code)
       reasons[code]
     end
 

--- a/lib/tasks/epets.rake
+++ b/lib/tasks/epets.rake
@@ -4,7 +4,7 @@ namespace :epets do
 
   desc 'Add sysadmin user'
   task :add_sysadmin_user => :environment do
-    if AdminUser.find_by_email('admin@example.com').nil?
+    if AdminUser.find_by(email: 'admin@example.com').nil?
        admin = AdminUser.new(:first_name => 'Cool', :last_name => 'Admin', :email => 'admin@example.com')
        admin.role = 'sysadmin'
        admin.password = admin.password_confirmation = 'Letmein1!'

--- a/spec/lib/rejection_reason_spec.rb
+++ b/spec/lib/rejection_reason_spec.rb
@@ -10,16 +10,16 @@ describe RejectionReason do
     end
   end
 
-  describe "#find_by_code" do
+  describe "#for_code" do
     it "should return a hash of the code's attributes" do
-      reason = RejectionReason.find_by_code("duplicate")
+      reason = RejectionReason.for_code("duplicate")
       expect(reason.published).to eq(true)
       expect(reason.title).to eq("Duplicate of an existing e-petition")
       expect(reason.description).to eq("<p>There is already an e-petition about this issue.</p>")
     end
-    
+
     it "should return nil if code is not found" do
-      reason = RejectionReason.find_by_code("will_not_be_found")
+      reason = RejectionReason.for_code("will_not_be_found")
       expect(reason).to be_nil
     end
   end


### PR DESCRIPTION
Mostly just updating ``find_by_blah(xxx)`` to ``find_by(blah: xxx)``.  We also rename ``find_by_code`` on RejectionReason to ``for_code`` because it's not an AR object and I don't want it to look like one (making people thing they can do ``find_by(other: attributes)``).