### PR TITLE
Replace protected_attributes with strong parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.1'
 
 # Legacy Rails feature gems - will no longer be supported in Rails 5.0
-gem 'protected_attributes'
 gem 'actionpack-action_caching'
 gem 'actionpack-page_caching'
 gem 'responders'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,8 +146,6 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     pr_geohash (1.0.0)
-    protected_attributes (1.0.9)
-      activemodel (>= 4.0.1, < 5.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -292,7 +290,6 @@ DEPENDENCIES
   nokogiri
   pickle
   poltergeist
-  protected_attributes
   pry
   rabl
   rails (= 4.2.1)

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -1,17 +1,17 @@
 class Admin::AdminUsersController < Admin::AdminController
   before_filter :require_sysadmin
   before_filter :assign_departments, :only => [:new, :edit]
-  
+
   def index
     @users = AdminUser.by_name.paginate(:page => params[:page], :per_page => 20)
   end
-  
+
   def new
     @user = AdminUser.new
   end
-  
+
   def create
-    @user = AdminUser.create(params[:admin_user])
+    @user = AdminUser.create(admin_user_params)
     update_departments(@user)
     if @user.save
       flash[:notice] = "User was successfully created"
@@ -21,16 +21,16 @@ class Admin::AdminUsersController < Admin::AdminController
       render :action => 'new'
     end
   end
-  
+
   def edit
     @user = AdminUser.find(params[:id])
   end
-  
+
   def update
     @user = AdminUser.find(params[:id])
-    
+
     update_departments(@user)
-    if @user.update_attributes(params[:admin_user])
+    if @user.update_attributes(admin_user_params)
       flash[:notice] = "User was successfully updated"
       redirect_to admin_admin_users_path
     else
@@ -38,10 +38,10 @@ class Admin::AdminUsersController < Admin::AdminController
       render :action => 'edit'
     end
   end
-  
+
   def destroy
     @user = AdminUser.find(params[:id])
-    
+
     # only destroy if user is not the logged in user and there are at least 2 users
     if @user == current_user
       flash[:error] = "You are not allowed to delete yourself!"
@@ -52,9 +52,9 @@ class Admin::AdminUsersController < Admin::AdminController
     end
     redirect_to admin_admin_users_path
   end
-  
+
   protected
-  
+
   def update_departments(user)
     department_ids = params[:department_ids].values
     # loop through backwards so deleting has no effect on subsequent elements
@@ -64,5 +64,13 @@ class Admin::AdminUsersController < Admin::AdminController
     department_ids.map { |department_id| Department.find_by(id: department_id) }.compact.each do |department|
       user.departments << department unless user.departments.include?(department)
     end
+  end
+
+  def admin_user_params
+    params.
+      require(:admin_user).
+      permit(:password, :password_confirmation, :first_name,
+             :last_name, :role, :email, :force_password_reset,
+             :account_disabled)
   end
 end

--- a/app/controllers/admin/profile_controller.rb
+++ b/app/controllers/admin/profile_controller.rb
@@ -11,14 +11,22 @@ class Admin::ProfileController < Admin::AdminController
     current_user.password_changed_at = Time.zone.now
     current_user.force_password_reset = false
 
+    update_params = admin_user_params_for_update
+
     if ! current_user.valid_password?(params[:current_password])
       current_user.errors.add(:current_password, "is incorrect")
     elsif params[:current_password] == params[:admin_user][:password]
       current_user.errors.add(:password, "is the same as the current password")
-    elsif params[:admin_user][:password].present? and current_user.update_attributes(params[:admin_user])
+    elsif update_params[:password].present? and current_user.update_attributes(update_params)
       flash[:notice] = "Password was successfully updated"
       redirect_to admin_root_path and return
     end
     render :edit
+  end
+
+  def admin_user_params_for_update
+    params.
+      require(:admin_user).
+      permit(:password, :password_confirmation)
   end
 end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -25,9 +25,10 @@ class PetitionsController < ApplicationController
   end
 
   def create
-    params[:petition][:creator_signature_attributes][:humanity] = Captcha.verify(params[:captcha_response_field], params[:captcha_string])
+    create_params = petition_params_for_create
+    create_params[:creator_signature_attributes][:humanity] = Captcha.verify(params[:captcha_response_field], params[:captcha_string])
 
-    @petition = Petition.new(params[:petition])
+    @petition = Petition.new(create_params)
     @petition.creator_signature.email.strip!
     if @petition.creator_signature
       @petition.creator_signature.ip_address = request.remote_ip
@@ -83,5 +84,16 @@ class PetitionsController < ApplicationController
 
   def send_email_to_verify_petition_creator(petition)
     PetitionMailer.email_confirmation_for_creator(petition.creator_signature).deliver_now
+  end
+
+  def petition_params_for_create
+    params.
+      require(:petition).
+      permit(:title, :description, :duration, :department_id,
+             creator_signature_attributes: [
+               :name, :email, :email_confirmation, :address, :town,
+               :postcode, :country, :uk_citizenship,
+               :terms_and_conditions, :notify_by_email
+             ])
   end
 end

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -9,9 +9,9 @@ class SignaturesController < ApplicationController
   end
 
   def create
-    params[:signature][:humanity] = Captcha.verify(params[:captcha_response_field], params[:captcha_string])
-
-    @signature = Signature.new(params[:signature])
+    create_params = signature_params_for_create
+    create_params[:humanity] = Captcha.verify(params[:captcha_response_field], params[:captcha_string])
+    @signature = Signature.new(create_params)
     @signature.email.strip!
     @signature.petition = @petition
     if (@signature.save)
@@ -55,5 +55,13 @@ class SignaturesController < ApplicationController
 
   def send_email_to_petition_signer(signature)
     PetitionMailer.email_confirmation_for_signer(signature).deliver_now
+  end
+
+  def signature_params_for_create
+    params.
+      require(:signature).
+      permit(:name, :email, :email_confirmation, :address, :town,
+             :postcode, :country, :uk_citizenship,
+             :terms_and_conditions, :notify_by_email)
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -40,9 +40,9 @@ class AdminUser < ActiveRecord::Base
     config.merge_validates_confirmation_of_password_field_options :unless => Proc.new { |user| user.password.blank? }
   end
 
-  attr_accessible :password, :password_confirmation, :first_name,
-                  :last_name, :role, :email, :force_password_reset,
-                  :account_disabled
+  # attr_accessible :password, :password_confirmation, :first_name,
+  #                 :last_name, :role, :email, :force_password_reset,
+  #                 :account_disabled
 
   # = Relationships =
   has_and_belongs_to_many :departments

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -40,10 +40,6 @@ class AdminUser < ActiveRecord::Base
     config.merge_validates_confirmation_of_password_field_options :unless => Proc.new { |user| user.password.blank? }
   end
 
-  # attr_accessible :password, :password_confirmation, :first_name,
-  #                 :last_name, :role, :email, :force_password_reset,
-  #                 :account_disabled
-
   # = Relationships =
   has_and_belongs_to_many :departments
 

--- a/app/models/department_assignment.rb
+++ b/app/models/department_assignment.rb
@@ -14,7 +14,5 @@ class DepartmentAssignment < ActiveRecord::Base
   belongs_to :petition
   belongs_to :department
 
-  # attr_accessible :department, :assigned_on
-
   validates_presence_of :assigned_on, :department, :petition
 end

--- a/app/models/department_assignment.rb
+++ b/app/models/department_assignment.rb
@@ -14,7 +14,7 @@ class DepartmentAssignment < ActiveRecord::Base
   belongs_to :petition
   belongs_to :department
 
-  attr_accessible :department, :assigned_on
+  # attr_accessible :department, :assigned_on
 
   validates_presence_of :assigned_on, :department, :petition
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -28,7 +28,7 @@
 class Petition < ActiveRecord::Base
   include State
 
-  attr_accessible :title, :description, :duration, :department_id, :creator_signature_attributes
+  # attr_accessible :title, :description, :duration, :department_id, :creator_signature_attributes
   after_create :set_petition_on_creator_signature
 
   searchable do

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -28,7 +28,6 @@
 class Petition < ActiveRecord::Base
   include State
 
-  # attr_accessible :title, :description, :duration, :department_id, :creator_signature_attributes
   after_create :set_petition_on_creator_signature
 
   searchable do

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -22,7 +22,6 @@ class Signature < ActiveRecord::Base
   VALIDATED_STATE = 'validated'
   STATES = [PENDING_STATE, VALIDATED_STATE]
 
-  # attr_accessible :name, :email, :email_confirmation, :address, :town, :postcode, :country, :humanity, :uk_citizenship, :terms_and_conditions, :notify_by_email
   before_create :set_perishable_token
 
   class EmailDowncaser

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -22,7 +22,7 @@ class Signature < ActiveRecord::Base
   VALIDATED_STATE = 'validated'
   STATES = [PENDING_STATE, VALIDATED_STATE]
 
-  attr_accessible :name, :email, :email_confirmation, :address, :town, :postcode, :country, :humanity, :uk_citizenship, :terms_and_conditions, :notify_by_email
+  # attr_accessible :name, :email, :email_confirmation, :address, :town, :postcode, :country, :humanity, :uk_citizenship, :terms_and_conditions, :notify_by_email
   before_create :set_perishable_token
 
   class EmailDowncaser

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -14,8 +14,6 @@ class SystemSetting < ActiveRecord::Base
   THRESHOLD_SIGNATURE_COUNT = "threshold_signature_count"
   GET_AN_MP_SIGNATURE_COUNT = "get_an_mp_signature_count"
 
-  # attr_accessible :key, :value, :description
-
   # = Validations =
   validates_length_of :key, :maximum => 64
   validates_uniqueness_of :key

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -14,7 +14,7 @@ class SystemSetting < ActiveRecord::Base
   THRESHOLD_SIGNATURE_COUNT = "threshold_signature_count"
   GET_AN_MP_SIGNATURE_COUNT = "get_an_mp_signature_count"
 
-  attr_accessible :key, :value, :description
+  # attr_accessible :key, :value, :description
 
   # = Validations =
   validates_length_of :key, :maximum => 64

--- a/app/models/trending_petition.rb
+++ b/app/models/trending_petition.rb
@@ -12,7 +12,7 @@
 class TrendingPetition < ActiveRecord::Base
   belongs_to :petition
 
-  attr_accessible :petition_id, :signatures_in_last_hour
+  # attr_accessible :petition_id, :signatures_in_last_hour
 
   def self.update_homepage_trends
     petitions = Petition.last_hour_trending

--- a/app/models/trending_petition.rb
+++ b/app/models/trending_petition.rb
@@ -12,8 +12,6 @@
 class TrendingPetition < ActiveRecord::Base
   belongs_to :petition
 
-  # attr_accessible :petition_id, :signatures_in_last_hour
-
   def self.update_homepage_trends
     petitions = Petition.last_hour_trending
 


### PR DESCRIPTION
Mostly this is removing the ``attr_accessible`` calls from the models that we had to add during the upgrade in #10 and using the ``require`` and ``permit`` api in the controllers instead.