### PR TITLE
Create data model for Sponsors feature

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -52,6 +52,7 @@ class Petition < ActiveRecord::Base
   accepts_nested_attributes_for :creator_signature
   has_many :signatures
   has_many :department_assignments
+  has_many :sponsors
 
   # = Validations =
   validates_presence_of :response, :if => :email_signees, :message => "must be completed when email signees is checked"

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -24,19 +24,11 @@ class Signature < ActiveRecord::Base
 
   before_create :set_perishable_token
 
-  class EmailDowncaser
-    def self.dump(value)
-      value.downcase
-    end
-    def self.load(value)
-      value
-    end
-  end
-
   attr_encrypted :email, :key => AppConfig.email_encryption_key, :attribute => "encrypted_email", :marshal => true, :marshaler => EmailDowncaser
 
   # = Relationships =
   belongs_to :petition
+  has_one :sponsor
 
   # = Validations =
   validates_format_of :email, :with => Authlogic::Regex.email, :unless => 'email.blank?', :message => "Email not recognised."

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,0 +1,68 @@
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id               :integer          not null, primary key
+#  encrypted_email  :string(255)
+#  perishable_token :string(255)
+#  petition_id      :integer
+#  signature_id     :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+
+
+class Sponsor < ActiveRecord::Base
+
+  before_create :set_perishable_token
+
+  attr_encrypted :email,
+                 key: AppConfig.email_encryption_key,
+                 attribute: "encrypted_email",
+                 marshal: true,
+                 marshaler: EmailDowncaser
+
+  # = Relationships =
+  belongs_to :petition
+  belongs_to :signature
+
+  # = Validations =
+  validates :email, presence: true
+  validates_presence_of :petition, message: "Needs a petition"
+
+  validates :encrypted_email,
+            uniqueness: { scope: :petition,
+                          message: "Sponsor Emails for Petition should be unique" }
+
+  validates_format_of :email,
+                      with: Authlogic::Regex.email,
+                      unless: 'email.blank?',
+                      message: "Email not recognised."
+
+  # = Finders =
+  scope :for_email, ->(email) { where(encrypted_email: Signature.encrypt_email(email)) }
+
+  # = Methods =
+
+  # NOTE: These methods for the encrypted_email attribute are
+  #       defined here to prevent attr_encrypted from defining
+  #       it's own attribute accessors using `attr_accessor`
+  # TODO: Remove these methods when attr_encrypted is fixed
+  def encrypted_email
+    super
+  end
+
+  def encrypted_email=(value)
+    super
+  end
+
+  def encrypted_email?
+    super
+  end
+
+
+  private
+  def set_perishable_token
+    self.perishable_token = Authlogic::Random.friendly_token
+  end
+
+end

--- a/db/migrate/20150430103606_create_sponsors.rb
+++ b/db/migrate/20150430103606_create_sponsors.rb
@@ -1,0 +1,12 @@
+class CreateSponsors < ActiveRecord::Migration
+  def change
+    create_table :sponsors do |t|
+      t.string :encrypted_email
+      t.string :perishable_token
+      t.integer :petition_id
+      t.integer :signature_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428141550) do
+ActiveRecord::Schema.define(version: 20150430103606) do
 
   create_table "admin_users", force: :cascade do |t|
     t.string   "email",                limit: 255,                null: false
@@ -154,6 +154,15 @@ ActiveRecord::Schema.define(version: 20150428141550) do
   add_index "signatures_pre_encryption", ["petition_id", "state"], name: "index_signatures_on_petition_id_and_state", using: :btree
   add_index "signatures_pre_encryption", ["state"], name: "index_signatures_on_state", using: :btree
   add_index "signatures_pre_encryption", ["updated_at"], name: "index_signatures_on_updated_at", using: :btree
+
+  create_table "sponsors", force: :cascade do |t|
+    t.string   "encrypted_email",  limit: 255
+    t.string   "perishable_token", limit: 255
+    t.integer  "petition_id",      limit: 4
+    t.integer  "signature_id",     limit: 4
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
 
   create_table "system_settings", force: :cascade do |t|
     t.string   "key",         limit: 64,    null: false

--- a/lib/email_downcaser.rb
+++ b/lib/email_downcaser.rb
@@ -1,0 +1,8 @@
+class EmailDowncaser
+  def self.dump(value)
+    value.downcase
+  end
+  def self.load(value)
+    value
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -84,6 +84,11 @@ FactoryGirl.define do
     state      Signature::VALIDATED_STATE
   end
 
+  factory :sponsor do
+    sequence(:email) {|n| "jo#{n}@public.com" }
+    association :petition
+  end
+
   factory :system_setting do
     sequence(:key)  {|n| "key#{n}"}
   end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,0 +1,50 @@
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id               :integer          not null, primary key
+#  encrypted_email  :string(255)
+#  perishable_token :string(255)
+#  petition_id      :integer
+#  signature_id     :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+require 'rails_helper'
+
+describe Sponsor do
+
+  it "has a valid factory" do
+    expect(FactoryGirl.build(:sponsor)).to be_valid
+  end
+
+  context "defaults" do
+    it "generates perishable token" do
+      s = FactoryGirl.create(:sponsor, :perishable_token => nil)
+      expect(s.perishable_token).not_to be_nil
+    end
+  end
+  
+  context "encryption of email" do
+    let(:sponsor) { FactoryGirl.create(:sponsor,
+                                       email: "foo@example.net") }
+    it "decrypts email correctly" do
+      expect(Sponsor.find(sponsor.id).email).to eq("foo@example.net")
+    end
+    it "is case insensitive" do
+      expect(FactoryGirl.build(:sponsor, :email => "FOO@exAmplE.net")
+              .encrypted_email).to eq(sponsor.encrypted_email)
+    end
+    it "returns the sponsor with unencrypted email" do
+      expect(Sponsor.for_email("foo@example.net")).to eq([sponsor])
+    end
+  end
+
+  context "validations" do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:petition).with_message(/Needs a petition/) }
+    it { is_expected.to allow_value('joe@example.com').for(:email) }
+    it { is_expected.not_to allow_value('not an email').for(:email) }
+  end
+end


### PR DESCRIPTION
Added email uniqueness validation per peitition, allowing one email address
per petition only. May introduce more complex email address validation
later (similar to Signature validation)