### PR TITLE
Fix email reminder spec

### DIFF
--- a/spec/lib/email_reminder_spec.rb
+++ b/spec/lib/email_reminder_spec.rb
@@ -68,7 +68,7 @@ describe EmailReminder do
       expect(email_no_new - email_no).to eq(1)
       email = ActionMailer::Base.deliveries.last
       expect(email.from).to eq(["no-reply@example.gov"])
-      expect(email.to).to eq(["peter@directgov.uk", "richard@directgov.uk"])
+      expect(email.to).to match_array(["peter@directgov.uk", "richard@directgov.uk"])
       expect(email.subject).to eq('e-Petitions alert')
     end
 


### PR DESCRIPTION
Fixes an email reminder spec that was occasionally failing. The
spec was comparing arrays with '==' instead of asserting that
array included the wanted values.