### PR TITLE
Exclude petition creator email from sponsors

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -26,6 +26,12 @@ class Sponsor < ActiveRecord::Base
                           message: "Sponsor Emails for Petition should be unique" }
   validates_presence_of :petition, message: "Needs a petition"
 
+  validates :email, exclusion: {
+    in: -> (sponsor) { Array(sponsor.petition.creator_signature.email) },
+    message: 'Petition creator cannot sponsor the petition',
+    if: :petition
+  }
+
   def build_signature(new_attributes = {})
     super(new_attributes.merge(default_signature_attribtues))
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -86,7 +86,7 @@ FactoryGirl.define do
   end
 
   factory :sponsor do
-    sequence(:email) {|n| "jo#{n}@public.com" }
+    sequence(:email) {|n| "sponsor#{n}@public.com" }
     association :petition
   end
 

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -46,6 +46,12 @@ describe Sponsor do
     it { is_expected.to validate_presence_of(:petition).with_message(/Needs a petition/) }
     it { is_expected.to allow_value('joe@example.com').for(:email) }
     it { is_expected.not_to allow_value('not an email').for(:email) }
+
+    it 'does not accept petition creator email as a sponsor email ' do
+      petition = FactoryGirl.create(:petition)
+      sponsor = FactoryGirl.build(:sponsor, petition: petition, email: petition.creator_signature.email)
+      expect(sponsor).not_to be_valid
+    end
   end
 
   context 'signature association' do


### PR DESCRIPTION
Add a validator for sponsor email to exclude the
petition creator email.