### PR TITLE
Remove petition filtering by department on admin todolist

### DIFF
--- a/app/controllers/admin/todolist_controller.rb
+++ b/app/controllers/admin/todolist_controller.rb
@@ -1,11 +1,6 @@
 class Admin::TodolistController < Admin::AdminController
   
   def index
-    if current_user.is_a_sysadmin? or current_user.is_a_threshold?
-      scope = Petition
-    else
-      scope = Petition.for_departments(current_user.departments)
-    end
-    @petitions = scope.for_state(Petition::VALIDATED_STATE).order(:created_at).paginate(:page => params[:page], :per_page => params[:per_page] || 20)
+    @petitions = Petition.for_state(Petition::VALIDATED_STATE).order(:created_at).paginate(:page => params[:page], :per_page => params[:per_page] || 20)
   end
 end

--- a/features/admin/todolist.feature
+++ b/features/admin/todolist.feature
@@ -30,7 +30,8 @@ Feature: Dashboard todo list
     When I go to the admin todolist page
     Then I should see the following admin index table:
       | Title      | Date       |
-      | Petition 4 | 01-01-2010 |
+      | Petition 1 | 10-02-2009 |
+      | Petition 4 | 01-01-2010 |	
       | Petition 3 | 11-11-2010 |
 
   Scenario: Pending petitions are paginated

--- a/spec/controllers/admin/todolist_controller_spec.rb
+++ b/spec/controllers/admin/todolist_controller_spec.rb
@@ -96,9 +96,9 @@ describe Admin::TodolistController do
             expect(response).to be_success
           end
 
-          it "should return validated petitions for the user's department(s)" do
+          it "should return all validated petitions ordered by created_at" do
             get :index
-            expect(assigns[:petitions]).to eq([@p2, @p1])
+            expect(assigns[:petitions]).to eq([@p2, @p3, @p1])
           end
         end
       end


### PR DESCRIPTION
Removed the scope for departments in the todolist controller and updated the rspec and cucumber tests.