### PR TITLE
No more departments for admin users

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -1,6 +1,5 @@
 class Admin::AdminUsersController < Admin::AdminController
   before_filter :require_sysadmin
-  before_filter :assign_departments, :only => [:new, :edit]
 
   def index
     @users = AdminUser.by_name.paginate(:page => params[:page], :per_page => 20)
@@ -12,12 +11,10 @@ class Admin::AdminUsersController < Admin::AdminController
 
   def create
     @user = AdminUser.create(admin_user_params)
-    update_departments(@user)
     if @user.save
       flash[:notice] = "User was successfully created"
       redirect_to admin_admin_users_path
     else
-      assign_departments
       render :action => 'new'
     end
   end
@@ -28,13 +25,10 @@ class Admin::AdminUsersController < Admin::AdminController
 
   def update
     @user = AdminUser.find(params[:id])
-
-    update_departments(@user)
     if @user.update_attributes(admin_user_params)
       flash[:notice] = "User was successfully updated"
       redirect_to admin_admin_users_path
     else
-      assign_departments
       render :action => 'edit'
     end
   end
@@ -54,17 +48,6 @@ class Admin::AdminUsersController < Admin::AdminController
   end
 
   protected
-
-  def update_departments(user)
-    department_ids = params[:department_ids].values
-    # loop through backwards so deleting has no effect on subsequent elements
-    user.departments.reverse.each do |department|
-      user.departments.delete(department) unless department_ids.include?(department.id.to_s)
-    end
-    department_ids.map { |department_id| Department.find_by(id: department_id) }.compact.each do |department|
-      user.departments << department unless user.departments.include?(department)
-    end
-  end
 
   def admin_user_params
     params.

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -4,12 +4,7 @@ class Admin::PetitionsController < Admin::AdminController
   respond_to :html
 
   def index
-    if current_user.is_a_sysadmin? or current_user.is_a_threshold?
-      @petitions = Petition
-    else
-      @petitions = Petition.for_departments(current_user.departments)
-    end
-    @petitions = @petitions.moderated.order(:signature_count)
+    @petitions = Petition.moderated.order(:signature_count)
     @petitions = @petitions.for_state(params[:state]) unless params[:state].blank?
     @petitions = @petitions.paginate(:page => params[:page], :per_page => params[:per_page] || 20)
   end
@@ -85,9 +80,9 @@ class Admin::PetitionsController < Admin::AdminController
     @petition.save!
     redirect_to admin_petitions_path
   end
-  
+
   protected
-  
+
   def publish
     @petition.state = Petition::OPEN_STATE
     @petition.open_at = Time.zone.now

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -4,9 +4,8 @@ class Admin::ReportsController < Admin::AdminController
     @counts = Petition.counts_by_state
     @departments = Department.by_petition_count
 
-    departments_for_trending = current_user.can_see_all_trending_petitions? ? Department.all : current_user.departments
     @number_of_days_to_trend  = params[:number_of_days_to_trend].present? ? params[:number_of_days_to_trend].to_i : 1
-    @trending_petitions = Petition.for_departments(departments_for_trending).trending(@number_of_days_to_trend)
+    @trending_petitions = Petition.trending(@number_of_days_to_trend)
   end
 
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -16,11 +16,4 @@ module AdminHelper
                         :method => :delete
                       }
   end
-
-  def setup_admin_user(admin_user)
-    4.times do
-      admin_user.departments.build
-    end
-    admin_user
-  end
 end

--- a/app/lib/email_reminder.rb
+++ b/app/lib/email_reminder.rb
@@ -4,14 +4,14 @@ class EmailReminder
   def self.admin_email_reminder
     admin_users = AdminUser.by_role(AdminUser::ADMIN_ROLE)
     admin_users.each do |user|
-      petitions = Petition.for_departments(user.departments).for_state(Petition::VALIDATED_STATE).order('created_at desc')
+      petitions = Petition.for_state(Petition::VALIDATED_STATE).order('created_at desc')
       # only email if there are one or more petitions
       if petitions.any?
 
         # how many new petitions?
         # look back 3 days if today is Monday since emails only get sent on a week day
         since_when = Time.zone.now.strftime('%u') == '1' ? 3.days.ago : 1.day.ago
-        new_petitions_count = Petition.for_departments(user.departments).for_state(Petition::VALIDATED_STATE).where('updated_at > ?', since_when).count
+        new_petitions_count = Petition.for_state(Petition::VALIDATED_STATE).where('updated_at > ?', since_when).count
 
         logger.info(user.email)
         AdminMailer.admin_email_reminder(user, petitions, new_petitions_count).deliver_now

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -81,10 +81,6 @@ class AdminUser < ActiveRecord::Base
     is_a_sysadmin? || is_a_threshold?
   end
 
-  def can_see_all_trending_petitions?
-    is_a_sysadmin? || is_a_threshold?
-  end
-
   def account_disabled
     self.failed_login_count >= DISABLED_LOGIN_COUNT
   end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -40,9 +40,6 @@ class AdminUser < ActiveRecord::Base
     config.merge_validates_confirmation_of_password_field_options :unless => Proc.new { |user| user.password.blank? }
   end
 
-  # = Relationships =
-  has_and_belongs_to_many :departments
-
   # = Validations =
   validates_presence_of :password, :on => :create
   validates_presence_of :email, :first_name, :last_name

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -211,8 +211,9 @@ class Petition < ActiveRecord::Base
   end
 
   def editable_by?(user)
-    return true if user.is_a_threshold? || user.is_a_sysadmin?
-    return true if user.departments.include?(department)
+    # NOTE: we can probably just return true here? or refactor this method
+    # out of existence
+    return true if user.is_a? AdminUser
     return false
   end
 

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, setup_admin_user(@user)], :builder => AdminFormBuilder do |f| -%>
+<%= form_for [:admin, @user], :builder => AdminFormBuilder do |f| -%>
   <%= f.error_messages(:header_message => nil) %>
   <%= f.text_field :first_name, :is_mandatory => true, :autofocus => 'autofocus' %>
   <%= f.text_field :last_name, :is_mandatory => true %>

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -3,25 +3,17 @@
   <%= f.text_field :first_name, :is_mandatory => true, :autofocus => 'autofocus' %>
   <%= f.text_field :last_name, :is_mandatory => true %>
   <%= f.text_field :email, :type => 'email', :is_mandatory => true %>
-  
+
   <%= f.label :role %><br />
   <%= f.select('role', AdminUser::ROLES) %>
-  
+
   <%= f.check_box :force_password_reset, :class => 'checkbox' %>
-  
+
   <%= f.check_box :account_disabled, :class => 'checkbox' %>
-  
+
   <%= "Note, no password needs to be entered unless you want to change it" unless @user.new_record? %>
   <%= f.password_field :password, :autocomplete => 'off', :is_mandatory => @user.new_record? %>
   <%= f.password_field :password_confirmation, :autocomplete => 'off', :is_mandatory => @user.new_record? %>
-  
-  <%= field_set_tag "Departments (only applies to admin users)", :class => 'departments' do %>
-    <% @user.departments.each_with_index do |department, i| -%>
-      <div class="form_field">
-        <%= select_tag "department_ids[#{i}]", options_from_collection_for_select(@departments, :id, :name, department.id.to_s), :include_blank => true %>
-      </div>
-    <% end -%>
-  <% end %>
-  
+
   <%= save_button(f.object) %>
 <% end -%>

--- a/db/migrate/20150513162113_remove_admin_users_departments_join_table.rb
+++ b/db/migrate/20150513162113_remove_admin_users_departments_join_table.rb
@@ -1,0 +1,5 @@
+class RemoveAdminUsersDepartmentsJoinTable < ActiveRecord::Migration
+  def change
+    drop_table 'admin_users_departments'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,14 +36,6 @@ ActiveRecord::Schema.define(version: 20150515100520) do
   add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
   add_index "admin_users", ["last_name", "first_name"], name: "index_admin_users_on_last_name_and_first_name", using: :btree
 
-  create_table "admin_users_departments", id: false, force: :cascade do |t|
-    t.integer "admin_user_id", limit: 4, null: false
-    t.integer "department_id", limit: 4, null: false
-  end
-
-  add_index "admin_users_departments", ["admin_user_id", "department_id"], name: "index_admin_users_departments_on_fks", unique: true, using: :btree
-  add_index "admin_users_departments", ["department_id"], name: "index_admin_users_departments_on_department_id", using: :btree
-
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   limit: 4,     default: 0
     t.integer  "attempts",   limit: 4,     default: 0

--- a/features/admin/admin_users_crud.feature
+++ b/features/admin/admin_users_crud.feature
@@ -5,9 +5,7 @@ Feature: Admin users index and crud
   Background:
     Given I am logged in as a sysadmin with the email "muddy@fox.com", first_name "Sys", last_name "Admin"
     And a threshold user exists with email: "naomi@example.com", first_name: "Naomi", last_name: "Campbell"
-    And a department exists with name: "Treasury"
-    And a department exists with name: "DFID"
-    
+
   Scenario: Accessing the admin users index
     When I go to the admin home page
     And I follow "Users" in the admin nav
@@ -25,7 +23,7 @@ Feature: Admin users index and crud
       | Hunt, Helen     | helen@example.com | admin     | Yes      |
       | Jacobi, Derek   | derek@example.com | admin     |          |
     And the markup should be valid
-    
+
   Scenario: Pagination of the users index
     Given 20 admin users exist
     When I go to the admin users index page
@@ -50,11 +48,6 @@ Feature: Admin users index and crud
     And I should see a "Account disabled" checkbox field
     And I should see a "Password" password field
     And I should see a "Password confirmation" password field
-    And I should see 4 dropdowns in the "departments" fieldset
-    And I should see a "department_ids_0" select field with the following options:
-      |          |
-      | DFID     |
-      | Treasury |
 
   Scenario: Creating a new user
     When I go to the admin users index page
@@ -65,14 +58,12 @@ Feature: Admin users index and crud
     And I select "sysadmin" from "Role"
     And I fill in "Password" with "Letmein1!"
     And I fill in "Password confirmation" with "Letmein1!"
-    And I select "Treasury" from "department_ids_0"
     And I press "Save"
     Then I should be on the admin users index page
     And I should see "derek@example.com"
     When I follow "Jacobi, Derek"
     Then the "Role" select field should have "sysadmin" selected
     And the "Account disabled" checkbox should not be checked
-    And the "department_ids_0" select field should have "Treasury" selected
 
   Scenario: Updating a user
     When I go to the admin users index page

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -7,7 +7,6 @@ Feature: An admin user views all petitions
     Given I am logged in as an admin
     And a department "Treasury" exists with name: "Treasury"
     And a department "Cabinet Office" exists with name: "Cabinet Office"
-    And I am associated with the department "Treasury"
 
   Scenario: Viewing all petitions
     Given a set of petitions for the "Treasury"
@@ -51,7 +50,7 @@ Feature: An admin user views all petitions
     When I change the number viewed per page to 50
     And I press "Go"
     Then I should see a list of 25 petitions
-    
+
   Scenario: A sysadmin can view all petitions
     Given I am logged in as a sysadmin
     And an open petition exists with title: "Simply the best"
@@ -63,4 +62,4 @@ Feature: An admin user views all petitions
     And an open petition exists with title: "Simply the best"
     When I view all petitions
     Then I should see "Simply the best"
-    
+

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -56,7 +56,7 @@ Feature: Moderator respond to petition
   @departments
   Scenario: Moderator rejects and hides previously rejected (and public) petition
     And a petition "actually libellous" has been rejected by the "Treasury" with the reason "duplicate"
-    And I am logged in as a moderator for the "Treasury"
+    And I am logged in as an admin
     When I view the petition through the admin interface
     And I change the rejection status of the petition with a reason code "Confidential, libellous, false or defamatory statements (will be hidden)"
     And the petition is not available for searching or viewing

--- a/features/admin/petition_requires_response.feature
+++ b/features/admin/petition_requires_response.feature
@@ -2,21 +2,20 @@ Feature: An admin user updates internal response and marks it for a public respo
   In order to assign a petition to a threshold user
   As any admin user
   I want to be able add an internal response and flag a petition as requiring a public response
-  
+
   Background:
     Given I am logged in as an admin
     And a department "Treasury" exists with name: "Treasury"
     And a department "Cabinet Office" exists with name: "Cabinet Office"
-    And I am associated with the department "Treasury"
-    And an open petition exists with title: "Solidarity with the Unions", department: department "Treasury"
-  
+    And an open petition exists with title: "Solidarity with the Unions"
+
   Scenario: Viewing the update internal response page
     When I am on the admin all petitions page
     And I follow "Solidarity with the Unions"
     Then I should see a "Internal response" textarea field
     And I should see a "Public response required" checkbox field
     And the markup should be valid
-    
+
   Scenario: Updating the internal response and response required
     When I am on the admin all petitions page
     And I follow "Solidarity with the Unions"

--- a/features/admin/reports.feature
+++ b/features/admin/reports.feature
@@ -3,7 +3,7 @@ Feature: Viewing reports
   As Maggie or Terry
   I would like to be able to see summary of number of petitions in particular states
 
-  Scenario:
+  Scenario: threshold user viewing trending petitions
     Given I am logged in as a threshold user
     And the "Transport" department has 1 pending, 1 validated, 2 open, 3 closed and 3 rejected petitions
     And the "DFID" department has 0 pending, 1 validated, 1 open, 1 closed and 2 rejected petitions
@@ -15,26 +15,23 @@ Feature: Viewing reports
       | Transport       |       1 |         1 |    2 |      3 |        3 |    10 |
       | DFID            |       0 |         1 |    1 |      1 |        2 |     5 |
 
-  Scenario: department moderator viewing trending petitions for their department
-    Given I am logged in as a moderator for the "Transport" department
+  Scenario: admin user viewing trending petitions
+    Given I am logged in as an admin
     And there has been activity on a number of petitions in the last 24 hours
     When I follow "Reports" in the admin nav
     Then I should be on the admin reports page
-    And I should see trending petitions for all my departments for the last 24 hours
-    And I should not see trending petitions for any other department
+    And I should see trending petitions for the last 24 hours
 
-  @departments
   Scenario: Threshold user viewing trending petitions
     Given I am logged in as a threshold user
     And there has been activity on a number of petitions in the last 24 hours
     When I follow "Reports" in the admin nav
     Then I should be on the admin reports page
-    And I should see trending petitions for all my departments for the last 24 hours
+    And I should see trending petitions for the last 24 hours
 
-  @departments
   Scenario: Viewing trends for 7 days
     Given I am logged in as a threshold user
     And there has been activity on a number of petitions in the last 7 days
     When I follow "Reports" in the admin nav
     Then I choose to view 7 days of trends
-    And I should see trending petitions for all my departments for the last 24 hours
+    And I should see trending petitions for the last 24 hours

--- a/features/admin/search_for_petition_by_id.feature
+++ b/features/admin/search_for_petition_by_id.feature
@@ -4,26 +4,20 @@ Feature: Maggie searches for a petition by id
   As Maggie
   I want to enter an id and be taken to the petition for that id, or shown an error if it doesn't exist
 
-  Scenario:
-    Given a set of petitions for the "Treasury"
-    And I am logged in as a moderator for the "Cabinet Office"
-    When I search for a petition by id
-    Then I should see the petition for viewing only
-
-  Scenario: A user from the same department sees the edit page if the petition needs moderation
-    Given a sponsored petition "Loose benefits!" belonging to the "Treasury"
-    And I am logged in as a moderator for the "Treasury"
+  Scenario: A user sees the edit page if the petition needs moderation
+    Given a sponsored petition "Loose benefits!"
+    And I am logged in as an admin
     When I search for a petition by id
     Then I should see the petition for editing
 
-  Scenario: A user from the same department sees the edit internal page if the petition is visible
+  Scenario: A user sees the edit internal page if the petition is visible
     Given a petition "Duplicate" has been rejected by the "Treasury"
-    And I am logged in as a moderator for the "Treasury"
+    And I am logged in as an admin
     When I search for a petition by id
     Then I should see the petition for editing the internal reponse and changing the status
 
   Scenario: A threshold user sees the edit page if the petition needs moderation
-    Given a sponsored petition "Loose benefits!" belonging to the "Treasury"
+    Given a sponsored petition "Loose benefits!"
     And I am logged in as a threshold user
     When I search for a petition by id
     Then I should see the petition for editing
@@ -34,7 +28,7 @@ Feature: Maggie searches for a petition by id
     When I search for a petition by id
     Then I should see the petition for editing the reponses
 
-  Scenario:
+  Scenario: A user doing a search for a petition id that doesn't exist gets an error
     Given I am logged in as a threshold user
     When I search for a petition by id
     Then I should be taken back to the id search form with an error

--- a/features/admin/takedown.feature
+++ b/features/admin/takedown.feature
@@ -4,8 +4,7 @@ Feature: Terry (or Sheila) takes down a petition
   I want to reject a petition after it has been published, which sends the standard rejection email out to the creator and removes the petition from the site
 
   Background:
-    Given a department "Treasury" exists with name: "Treasury"
-    And a petition "Mistakenly published petition" belonging to the "Treasury"
+    Given a petition "Mistakenly published petition"
 
   Scenario:
     Given I am logged in as a sysadmin
@@ -17,5 +16,4 @@ Feature: Terry (or Sheila) takes down a petition
 
   Scenario: Normal admins cannot take down petitions
     Given I am logged in as an admin
-    And I am associated with the department "Treasury"
     Then I should not be able to take down the petition

--- a/features/admin/todolist.feature
+++ b/features/admin/todolist.feature
@@ -1,7 +1,7 @@
 Feature: Dashboard todo list
   In order to see priority items
   I can see a list of validated petitions on my todo list that need moderation
-  
+
   Background:
     Given a department "DFID" exists with name: "DFID"
     And a department "Treasury" exists with name: "Treasury"
@@ -24,15 +24,13 @@ Feature: Dashboard todo list
   And I should be connected to the server via an ssl connection
   And the markup should be valid
 
-  Scenario: An admin sees pending petitions for their department
+  Scenario: An admin sees pending petitions
     Given I am logged in as an admin
-    And I am associated with the department "Treasury"
-    And I am associated with the department "Home Office"
     When I go to the admin todolist page
     Then I should see the following admin index table:
       | Title      | Date       |
       | Petition 1 | 10-02-2009 |
-      | Petition 4 | 01-01-2010 |	
+      | Petition 4 | 01-01-2010 |
       | Petition 3 | 11-11-2010 |
 
   Scenario: Pending petitions are paginated

--- a/features/step_definitions/admin_user_steps.rb
+++ b/features/step_definitions/admin_user_steps.rb
@@ -1,8 +1,3 @@
-Given /^I am associated with the #{capture_model}$/ do |model_name|
-  department = model!(model_name)
-  AdminUser.last.departments << department
-end
-
 Given /^I try the password "([^"]*)" (\d+) times in a row$/ do |password, number|
   number.times do
     steps %Q(

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -21,13 +21,7 @@ end
 
 Given /^I am logged in as an admin$/ do
   @user = FactoryGirl.create(:admin_user)
-  @user.departments <<  FactoryGirl.create(:department)
   step "the admin user is logged in"
-end
-
-Given /^I am logged in as a moderator for the "([^"]*)"$/ do |department_name|
-  step "I am logged in as an admin"
-  @user.departments << Department.find_by(name: department_name)
 end
 
 Given /^the admin user is logged in$/ do

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -1,5 +1,5 @@
 When /^I look at the next petition on my list$/ do
-  @petition = FactoryGirl.create(:sponsored_petition, :title => "Petition 1", :description => "description", :department => AdminUser.first.departments.first)
+  @petition = FactoryGirl.create(:sponsored_petition, :title => "Petition 1", :description => "description")
   visit edit_admin_petition_path(@petition)
 end
 
@@ -57,8 +57,6 @@ Then /^the petition is not available for searching or viewing$/ do
 end
 
 Then /^the petition will still show up in the back\-end reporting$/ do
-  # ensure we are in the right department to see the petition
-  #AdminUser.first.departments << @petition.department
   visit admin_petitions_path
   step %{I should see the petition "#{@petition.title}"}
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -9,12 +9,16 @@ Then /^I am taken to a landing page$/ do
 end
 
 
-Given /^a(n)? ?(pending|validated|sponsored|open)? petition "([^"]*)" belonging to the "([^"]*)"$/ do |a_or_an, state, petition_title, department_name|
-  @petition = FactoryGirl.create(:open_petition,
+Given /^a(n)? ?(pending|validated|sponsored|open)? petition "([^"]*)"(?: belonging to the "([^"]*)")?$/ do |a_or_an, state, petition_title, department_name|
+  petition_args = {
     :title => petition_title,
-    :department => Department.find_by(name: department_name),
     :closed_at => 1.day.from_now,
-    :state => state || "open")
+    :state => state || "open"
+  }
+  if department_name.present?
+    petition_args[:department] = Department.find_or_create_by(name: department_name)
+  end
+  @petition = FactoryGirl.create(:open_petition, petition_args)
 end
 
 Given /^the petition "([^"]*)" has (\d+) validated and (\d+) pending signatures$/ do |title, no_validated, no_pending|
@@ -47,7 +51,7 @@ end
 Given /^a libelous petition "([^"]*)" has been rejected by the "([^"]*)"$/ do |petition_title, department_name|
   @petition = FactoryGirl.create(:petition,
     :title => petition_title,
-    :department => Department.find_by(name: department_name),
+    :department => Department.find_or_create_by(name: department_name),
     :state => Petition::HIDDEN_STATE,
     :rejection_code => "libellous",
     :rejection_text => "You can't say that!")
@@ -57,7 +61,7 @@ Given /^a petition "([^"]*)" has been rejected by the "([^"]*)"( with the reason
   reason_text = reason.nil? ? "We are the #{department_name}, not television executives" : reason
   @petition = FactoryGirl.create(:petition,
     :title => petition_title,
-    :department => Department.find_by(name: department_name),
+    :department => Department.find_or_create_by(name: department_name),
     :state => Petition::REJECTED_STATE,
     :rejection_code => "irrelevant",
     :rejection_text => reason_text)

--- a/features/step_definitions/reports_steps.rb
+++ b/features/step_definitions/reports_steps.rb
@@ -17,14 +17,8 @@ Then /^I see the following reports table:$/ do |values_table|
   values_table.diff!(actual_table)
 end
 
-Given /^I am logged in as a moderator for the "([^"]*)" department$/ do |department_name|
-  step "I am logged in as an admin"
-  department = FactoryGirl.create(:department, :name => department_name)
-  @user.departments << department
-end
-
-Then /^I should see trending petitions for all my departments for the last (\d+) (hours|days)$/ do |time_period, hours_or_days|
-  @user.departments.each do |department|
+Then /^I should see trending petitions for the last (\d+) (hours|days)$/ do |time_period, hours_or_days|
+  Department.all.each do |department|
     (11..15).each do |petition_number|
       expect(page).to have_css("tr.trending_petition td.title", :text => "#{department.name} Petition ##{petition_number}")
       expect(page).to have_css("tr.trending_petition td.count", :text => "#{petition_number+1}")

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -57,18 +57,20 @@ describe Admin::PetitionsController do
     before :each do
       @user = FactoryGirl.create(:admin_user)
       @treasury = FactoryGirl.create(:department, :name => 'Treasury')
-      @user.departments << @treasury
       login_as(@user)
       @p1 = FactoryGirl.create(:open_petition, :department => @treasury)
+      @p1.update_attribute(:signature_count, 11)
       @p2 = FactoryGirl.create(:open_petition)
+      @p2.update_attribute(:signature_count, 10)
       @p3 = FactoryGirl.create(:closed_petition)
+      @p2.update_attribute(:signature_count, 20)
     end
 
     with_ssl do
-      it "should show moderated petitions assigned to the treasury" do
+      it "should show moderated petitions" do
         get :index
         expect(response).to be_success
-        expect(assigns[:petitions]).to eq([@p1])
+        expect(assigns[:petitions]).to eq([@p3, @p1, @p2])
       end
 
       it "should redirect to all petitions on update of internal response" do
@@ -212,12 +214,12 @@ describe Admin::PetitionsController do
           allow(Petition).to receive(:moderated).and_return(petitions)
         end
 
-        it "shows all moderated petitions for the current user's department" do
+        it "shows all moderated petitions" do
           expect(Petition).to receive(:moderated).and_return(petitions)
           get :index
         end
 
-      it "optionally filters by state" do
+        it "optionally filters by state" do
           expect(petitions).to receive(:for_state).with('open').and_return(petitions)
           get :index, :state => 'open'
         end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -37,45 +37,26 @@ describe Admin::ReportsController do
 
         describe "for trending petitions" do
           let(:trending_petitions) { double }
-          let(:all_petitions) { double(:trending => trending_petitions) }
-          let(:departments) { double }
 
           before do
-            allow(Petition).to receive(:for_departments).with(departments).and_return(all_petitions)
+            allow(Petition).to receive(:trending).and_return(trending_petitions)
             allow(Department).to receive(:by_petition_count).and_return []
           end
 
-          context "viewing as a department moderator" do
-            before(:each) do
-              allow(controller.current_user).to receive(:departments).and_return(departments)
-            end
 
-            it "assigns trending petitions to those from the departments the user can access" do
-              get :index
-              expect(assigns(:trending_petitions)).to eq(trending_petitions)
-            end
+          it "assigns number_of_days_to_trend to the view" do
+            get :index
+            expect(assigns(:number_of_days_to_trend)).to eq(1)
           end
 
-          context "viewing as someone who can see all trending petitions" do
-            before(:each) do
-              allow(controller.current_user).to receive_messages(:can_see_all_trending_petitions? => true)
-              allow(Department).to receive(:all).and_return departments
-            end
+          it "adjusts the number of days to trend if param is passed in" do
+            get :index, :number_of_days_to_trend => 7
+            expect(assigns(:number_of_days_to_trend)).to eq(7)
+          end
 
-            it "assigns number_of_days_to_trend to the view" do
-              get :index
-              expect(assigns(:number_of_days_to_trend)).to eq(1)
-            end
-
-            it "adjusts the number of days to trend if param is passed in" do
-              get :index, :number_of_days_to_trend => 7
-              expect(assigns(:number_of_days_to_trend)).to eq(7)
-            end
-
-            it "assigns departments_for_trending to be all the departments" do
-              get :index
-              expect(assigns(:trending_petitions)).to eq(trending_petitions)
-            end
+          it "assigns trending_petitions" do
+            get :index
+            expect(assigns(:trending_petitions)).to eq(trending_petitions)
           end
         end
       end

--- a/spec/controllers/admin/todolist_controller_spec.rb
+++ b/spec/controllers/admin/todolist_controller_spec.rb
@@ -14,16 +14,14 @@ describe Admin::TodolistController do
   end
 
   context "logged in as admin user but need to reset password" do
-    before :each do
-      @user = FactoryGirl.create(:admin_user, :force_password_reset => true)
-      login_as(@user)
-    end
+    let(:user) { FactoryGirl.create(:admin_user, :force_password_reset => true) }
+    before { login_as(user) }
 
     with_ssl do
       it "should redirect to edit profile page" do
-        expect(@user.has_to_change_password?).to be_truthy
+        expect(user.has_to_change_password?).to be_truthy
         get :index
-        expect(response).to redirect_to(edit_admin_profile_path(@user))
+        expect(response).to redirect_to(edit_admin_profile_path(user))
       end
     end
   end
@@ -41,10 +39,8 @@ describe Admin::TodolistController do
     end
 
     describe "logged in as sysadmin user" do
-      before :each do
-        @user = FactoryGirl.create(:sysadmin_user)
-        login_as(@user)
-      end
+      let(:user) { FactoryGirl.create(:sysadmin_user) }
+      before { login_as(user) }
 
       with_ssl do
         describe "GET 'index'" do
@@ -62,10 +58,8 @@ describe Admin::TodolistController do
     end
 
     describe "logged in as threshold user" do
-      before :each do
-        @user = FactoryGirl.create(:threshold_user)
-        login_as(@user)
-      end
+      let(:user) { FactoryGirl.create(:threshold_user) }
+      before { login_as(user) }
 
       with_ssl do
         describe "GET 'index'" do
@@ -83,11 +77,8 @@ describe Admin::TodolistController do
     end
 
     describe "logged in as admin user" do
-      before :each do
-        @user = FactoryGirl.create(:admin_user)
-        @user.departments << @treasury << @dfid
-        login_as(@user)
-      end
+      let(:user) { FactoryGirl.create(:admin_user) }
+      before { login_as(user) }
 
       with_ssl do
         describe "GET 'index'" do

--- a/spec/lib/email_reminder_spec.rb
+++ b/spec/lib/email_reminder_spec.rb
@@ -8,10 +8,8 @@ describe EmailReminder do
       @d2 = FactoryGirl.create(:department)
       @d3 = FactoryGirl.create(:department)
       @user1 = FactoryGirl.create(:admin_user, :email => 'peter@directgov.uk')
-      @user1.departments << @d1 << @d3
       @user2 = FactoryGirl.create(:sysadmin_user)
       @user3 = FactoryGirl.create(:admin_user)
-      @user3.departments << @d2
       Petition.record_timestamps = false
       @p1 = FactoryGirl.create(:validated_petition, :title => 'King or Queen', :department => @d1, :created_at => 2.days.ago, :updated_at => 25.hours.ago)
       @p2 = FactoryGirl.create(:validated_petition, :title => 'Let us become a republic', :department => @d3, :created_at => 1.day.ago, :updated_at => 5.minutes.ago)
@@ -21,27 +19,35 @@ describe EmailReminder do
       Petition.record_timestamps = true
     end
 
-    it "should email out an alert to admin users who belong to departments that have one or more validated petitions" do
+    it "should email out an alert to admin users about validated petitions" do
       set_up(Chronic.parse("5 July 2011")) # tuesday
-      email_no = ActionMailer::Base.deliveries.size
+      ActionMailer::Base.deliveries.clear
       EmailReminder.admin_email_reminder
-      email_no_new = ActionMailer::Base.deliveries.size
-      expect(email_no_new - email_no).to eq(1)
-      email = ActionMailer::Base.deliveries.last
+      emails_sent = ActionMailer::Base.deliveries.size
+      expect(emails_sent).to eq(2)
+
+      email = ActionMailer::Base.deliveries.detect { |e| e.to == [@user1.email] }
+      expect(email).to be_present
       expect(email.from).to eq(["no-reply@example.gov"])
-      expect(email.to).to eq(["peter@directgov.uk"])
+      expect(email.subject).to eq('e-Petitions alert')
+
+      email = ActionMailer::Base.deliveries.detect { |e| e.to == [@user3.email] }
+      expect(email).to be_present
+      expect(email.from).to eq(["no-reply@example.gov"])
       expect(email.subject).to eq('e-Petitions alert')
     end
 
     it "should email out details of 1 new petition and two validated petitions on a Tuesday" do
       set_up(Chronic.parse("5 July 2011")) # tuesday
-      expect(AdminMailer).to receive(:admin_email_reminder).with(@user1, [@p2, @p1], 1).and_return(double('email', :deliver_now => nil))
+      expect(AdminMailer).to receive(:admin_email_reminder).with(@user1, [@p5, @p2, @p1], 1).and_return(double('email', :deliver_now => nil))
+      expect(AdminMailer).to receive(:admin_email_reminder).with(@user3, [@p5, @p2, @p1], 1).and_return(double('email', :deliver_now => nil))
       EmailReminder.admin_email_reminder
     end
 
     it "should email out details of 2 new petitions and two validated petitions on a Tuesday" do
       set_up(Chronic.parse("4 July 2011")) # monday
-      expect(AdminMailer).to receive(:admin_email_reminder).with(@user1, [@p2, @p1], 2).and_return(double('email', :deliver_now => nil))
+      expect(AdminMailer).to receive(:admin_email_reminder).with(@user1, [@p5, @p2, @p1], 2).and_return(double('email', :deliver_now => nil))
+      expect(AdminMailer).to receive(:admin_email_reminder).with(@user3, [@p5, @p2, @p1], 2).and_return(double('email', :deliver_now => nil))
       EmailReminder.admin_email_reminder
     end
   end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -181,23 +181,6 @@ describe AdminUser do
       end
     end
 
-    context "can_see_all_trending_petitions?" do
-      it "is normally false" do
-        user = FactoryGirl.create(:admin_user, :role => 'admin')
-        expect(user.can_see_all_trending_petitions?).to be_falsey
-      end
-
-      it "is true when the user is a system admin" do
-        user = FactoryGirl.create(:admin_user, :role => 'sysadmin')
-        expect(user.can_see_all_trending_petitions?).to be_truthy
-      end
-
-      it "is true if the user is a threshold user" do
-        user = FactoryGirl.create(:admin_user, :role => 'threshold')
-        expect(user.can_see_all_trending_petitions?).to be_truthy
-      end
-    end
-
     context "account_disabled" do
       it "should return true when user has tried to login 5 times unsuccessfully" do
         user = FactoryGirl.create(:admin_user)

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -533,17 +533,8 @@ describe Petition do
 
   describe "permissions" do
     let(:petition) { FactoryGirl.build(:petition) }
-    let(:user) { double(:is_a_threshold? => false, :is_a_sysadmin? => false) }
+    let(:user) { AdminUser.new }
 
-    it "is editable by moderators in the same department" do
-      allow(user).to receive_messages(:departments => [petition.department])
-      expect(petition.editable_by?(user)).to be_truthy
-    end
-
-    it "is not editable by a moderator in another department" do
-      allow(user).to receive_messages(:departments => [])
-      expect(petition.editable_by?(user)).to be_falsey
-    end
     it "is editable by a threshold user" do
       allow(user).to receive_messages(:is_a_threshold? => true)
       expect(petition.editable_by?(user)).to be_truthy
@@ -552,6 +543,14 @@ describe Petition do
     it "is editable by a sys admin" do
       allow(user).to receive_messages(:is_a_sysadmin? => true)
       expect(petition.editable_by?(user)).to be_truthy
+    end
+
+    it 'is editable by a normal admin user' do
+      expect(petition.editable_by?(user)).to be_truthy
+    end
+
+    it 'is not editable by non admin users' do
+      expect(petition.editable_by?(double)).to be_falsey
     end
 
     it "doesn't allow editing of response generally" do


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/93906180

Admin users no longer have a relationship to departments.  This required a bit of tidy up where the app still assumed they did.  Tidying up the features was a bit brute force to make them pass.  The features will benefit from a fuller review of the steps and scenarios once we've completely removed departments from the app as I'm sure there could be more to cull.