### PR TITLE
Remove department details from petition view

### DIFF
--- a/app/views/petitions/show.html.erb
+++ b/app/views/petitions/show.html.erb
@@ -12,9 +12,6 @@
 <div class="petition_view">
   <div class="content">
     <h1><%= @petition.title %></h1>
-    <% if @petition.department %>
-      <p class='department'>Responsible department: <%= @petition.department.name %></p>
-    <% end %>
     <p class='description'><%= raw auto_link(simple_format(h(@petition.description)), :html => { :target => '_blank' }) %></p>
 
     <% if @petition.rejected? -%>


### PR DESCRIPTION
I only removed the HTML code for the department label and field. Not much else to do, the tests were not testing for the existence of the department details, so nothing to change there.

Addresses https://www.pivotaltracker.com/story/show/93907446