### PR TITLE
Remove address and town fields from front end and back end

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -76,7 +76,7 @@ class PetitionsController < ApplicationController
       permit(:title, :action, :description, :duration, :department_id,
              :sponsor_emails,
              creator_signature: [
-               :name, :email, :email_confirmation, :address, :town,
+               :name, :email, :email_confirmation,
                :postcode, :country, :uk_citizenship,
                :terms_and_conditions, :notify_by_email
              ]).tap do |sanitized|

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -59,7 +59,7 @@ class SignaturesController < ApplicationController
   def signature_params_for_create
     params.
       require(:signature).
-      permit(:name, :email, :email_confirmation, :address, :town,
+      permit(:name, :email, :email_confirmation,
              :postcode, :country, :uk_citizenship,
              :terms_and_conditions, :notify_by_email)
   end

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -53,7 +53,7 @@ class SponsorsController < ApplicationController
   def signature_params_for_create
     params.
       require(:signature).
-      permit(:name, :address, :town,
+      permit(:name,
              :postcode, :country, :uk_citizenship,
              :terms_and_conditions, :notify_by_email)
   end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -68,8 +68,6 @@ class Signature < ActiveRecord::Base
   # = Methods =
   attr_accessor :uk_citizenship
   attr_accessor :terms_and_conditions
-  attr_accessor :address
-  attr_accessor :town
 
   def creator?
     petition.creator_signature == self

--- a/app/models/staged/base/creator_signature.rb
+++ b/app/models/staged/base/creator_signature.rb
@@ -9,7 +9,7 @@ module Staged
       end
       delegate :id, :to_param, :model_name, :to_key,
                :name, :email, :email_confirmation, :uk_citizenship,
-               :address, :town, :postcode, :country, :terms_and_conditions,
+               :postcode, :country, :terms_and_conditions,
                to: :creator_signature
 
       def validation_context

--- a/app/models/staged/validations/signer_details.rb
+++ b/app/models/staged/validations/signer_details.rb
@@ -29,8 +29,6 @@ module Staged
         with_options unless: :persisted? do |creator|
           creator.validates :uk_citizenship,
             acceptance: { allow_nil: false, message: 'You must be a British citizen or normally live in the UK to create or sign petitions.' }
-          creator.validates :address, presence:  { message: 'Address must be completed.' }
-          creator.validates :town, presence: { message: 'Town must be completed.' }
         end
       end
     end

--- a/app/views/petitions/create/_your_details_hidden.html.erb
+++ b/app/views/petitions/create/_your_details_hidden.html.erb
@@ -3,8 +3,6 @@
   <%= csf.hidden_field :email %>
   <%= csf.hidden_field :email_confirmation %>
   <%= csf.hidden_field :uk_citizenship %>
-  <%= csf.hidden_field :address %>
-  <%= csf.hidden_field :town %>
   <%= csf.hidden_field :postcode %>
   <%= csf.hidden_field :country %>
 <% end %>

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -40,18 +40,6 @@
   <%= error_messages_for_field signature, :uk_citizenship %>
 <% end %>
 
-<%= form_row :class => 'address_row', :for => [signature, :address] do %>
-  <%= f.label :address %>
-  <%= f.text_area :address, :class => 'address', :tabindex => increment %>
-  <%= error_messages_for_field signature, :address %>
-<% end %>
-
-<%= form_row :for => [signature, :town] do %>
-  <%= f.label :town %>
-  <%= f.text_field :town, :tabindex => increment %>
-  <%= error_messages_for_field signature, :town %>
-<% end %>
-
 <%= form_row :for => [signature, :postcode] do %>
   <%= f.label :postcode %>
   <%= f.text_field :postcode, :class => 'postcode', :tabindex => increment %>

--- a/app/views/signatures/new.html.erb
+++ b/app/views/signatures/new.html.erb
@@ -57,14 +57,6 @@ $().ready(function() {
     method: [E_PETS.FormController.validation_methods.validate_radio_group_value, '1'],
     message: "You must be a British citizen or normally live in the UK to create or sign e-petitions."
   });
-  signature_form.validates('signature[address]', {
-    method: E_PETS.FormController.validation_methods.validate_presence,
-    message: "Address must be completed."
-  });
-  signature_form.validates('signature[town]', {
-    method: E_PETS.FormController.validation_methods.validate_presence,
-    message: "Town must be completed."
-  });
   signature_form.validates('signature[postcode]', {
     method: E_PETS.FormController.validation_methods.validate_presence,
     message: "Postcode must be completed.",

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -86,8 +86,6 @@ Scenario: Charlie tries to submit an invalid petition
   Then I should see "Name must be completed"
   And I should see "Email must be completed"
   And I should see "You must be a British citizen"
-  And I should see "Address must be completed"
-  And I should see "Town must be completed"
   And I should see "Postcode must be completed"
 
   When I fill in my details with email "wimbledon@womble.com" and confirmation "uncleb@wimbledon.com"

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -58,8 +58,6 @@ When /^I fill in my details$/ do
     And I fill in "Email" with "womboid@wimbledon.com"
     And I fill in "Email confirmation" with "womboid@wimbledon.com"
     And I choose "yes"
-    And I fill in "Address" with "The old oak, 5 leafy grove, Wimbledon common"
-    And I fill in "Town" with "London"
     And I fill in "Postcode" with "SW14 9RQ"
     And I select "United Kingdom" from "Country"
   )

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -25,8 +25,6 @@ When(/^a sponsor supports my e\-petition$/) do
     And they click the first link in the email
     And I fill in "Name" with "Anonymous Sponsor"
     And I choose "yes"
-    And I fill in "Address" with "Sponsor House, Sponsor Street"
-    And I fill in "Town" with "Sponsorton-upon-Spon"
     And I fill in "Postcode" with "SW1A 1AA"
     And I select "United Kingdom" from "Country"
     And I accept the terms and conditions
@@ -73,8 +71,6 @@ When(/^I fill in my details as a sponsor$/) do
   steps %Q(
     When I fill in "Name" with "Laura The Sponsor"
     And I choose "yes"
-    And I fill in "Address" with "A House, On Street"
-    And I fill in "Town" with "Townsville"
     And I fill in "Postcode" with "AB10 1AA"
     And I select "United Kingdom" from "Country"
   )

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -44,7 +44,6 @@ describe PetitionsController do
       {
         :name => 'John Mcenroe', :email => 'john@example.com',
         :email_confirmation => 'john@example.com',
-        :address => 'Rose Cottage', :town => 'London',
         :postcode => 'SE3 4LL', :country => 'United Kingdom',
         :uk_citizenship => '1', :terms_and_conditions => '1'
       }
@@ -147,13 +146,6 @@ describe PetitionsController do
           expect(response).to be_success
         end
 
-        it "should not create a new petition if address is blank" do
-          creator_signature_attributes[:address] = ''
-          do_post
-          expect(Petition.find_by_title('Save the planet')).to be_nil
-          expect(response).to be_success
-        end
-
         it "should not create a new petition if UK citizenship is not confirmed" do
           creator_signature_attributes[:uk_citizenship] = '0'
           do_post
@@ -176,7 +168,7 @@ describe PetitionsController do
           expect(assigns[:stage_manager].stage).to eq 'petition'
         end
 
-        it "has stage of 'creator' if there are errors on name, email, email_confirmation, uk_citizenship, address, town, postcode or country" do
+        it "has stage of 'creator' if there are errors on name, email, email_confirmation, uk_citizenship, postcode or country" do
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:name => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => ''))
@@ -184,10 +176,6 @@ describe PetitionsController do
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => 'dave@example.com', :l_confirmation => 'laura@example.com'))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:uk_citizenship => ''))
-          expect(assigns[:stage_manager].stage).to eq 'creator'
-          do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:address => ''))
-          expect(assigns[:stage_manager].stage).to eq 'creator'
-          do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:town => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:postcode => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -132,7 +132,7 @@ describe SignaturesController do
 
     let(:signature_params) {{:name => 'John Mcenroe', :email => 'john@example.com', :email_confirmation => 'john@example.com',
       :uk_citizenship => "1", :terms_and_conditions => "1",
-      :address => 'Rose Cottage', :town => 'London', :postcode => 'SE3 4LL',
+      :postcode => 'SE3 4LL',
       :country => 'UK'}}
 
     def do_post(options = {})

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -68,8 +68,6 @@ describe SponsorsController do
     let(:signature_params) {
       {
         name: 'S. Ponsor',
-        address: '1 Sponsor St.',
-        town: 'Sponsorsville',
         postcode: 'SP1 1NR',
         country: 'United Kingdom',
         uk_citizenship: '1',

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -82,8 +82,6 @@ FactoryGirl.define do
     sequence(:name) {|n| "Jo Public #{n}" }
     sequence(:email) {|n| "jo#{n}@public.com" }
     email_confirmation  {|sig| sig.email }
-    address             "10 Downing St"
-    town                "London"
     postcode            "SW1A 1AA"
     country             "United Kingdom"
     uk_citizenship       '1'

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -71,8 +71,6 @@ describe Signature do
   context "validations" do
     it { is_expected.to validate_presence_of(:name).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:email).with_message(/must be completed/) }
-    it { is_expected.to validate_presence_of(:address).with_message(/must be completed/) }
-    it { is_expected.to validate_presence_of(:town).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:country).with_message(/must be completed/) }
     it { is_expected.to validate_length_of(:name).is_at_most(255) }
 

--- a/spec/models/staged_petition_creator_spec.rb
+++ b/spec/models/staged_petition_creator_spec.rb
@@ -106,7 +106,6 @@ describe StagedPetitionCreator do
       {
         :name => 'John Mcenroe', :email => 'john@example.com',
         :email_confirmation => 'john@example.com',
-        :address => 'Rose Cottage', :town => 'London',
         :postcode => 'SE3 4LL', :country => 'United Kingdom',
         :uk_citizenship => '1', :terms_and_conditions => '1'
       }


### PR DESCRIPTION
I removed the address and town fields for the petition creator and signer, as well as all the related backend code and tests for the town and address fields.