### PR TITLE
Dont ask for a department for a petition

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -73,8 +73,7 @@ class PetitionsController < ApplicationController
   def petition_params_for_create
     params.
       require(:petition).
-      permit(:title, :action, :description, :duration, :department_id,
-             :sponsor_emails,
+      permit(:title, :action, :description, :duration, :sponsor_emails,
              creator_signature: [
                :name, :email, :email_confirmation, :address, :town,
                :postcode, :country, :uk_citizenship,

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -8,7 +8,7 @@
 #  response                :text
 #  state                   :string(10)      default("pending"), not null
 #  open_at                 :datetime
-#  department_id           :integer(4)      not null
+#  department_id           :integer(4)
 #  creator_signature_id    :integer(4)      not null
 #  created_at              :datetime
 #  updated_at              :datetime
@@ -38,7 +38,11 @@ class Petition < ActiveRecord::Base
       creator_signature.name
     end
     text :department_name do
-      department.name
+      if department.present?
+        department.name
+      else
+        ''
+      end
     end
     string :title
     integer :signature_count

--- a/app/models/staged/base/petition.rb
+++ b/app/models/staged/base/petition.rb
@@ -10,7 +10,7 @@ module Staged
       end
 
       delegate :id, :to_param, :model_name, :to_key,
-               :title, :action, :department, :department_id, :description,
+               :title, :action, :description,
                :duration, :sponsor_emails, :creator_signature,
                to: :petition
     end

--- a/app/models/staged/validations/petition_details.rb
+++ b/app/models/staged/validations/petition_details.rb
@@ -14,7 +14,6 @@ module Staged
           presence: { message: 'Description must be completed.' },
           length: { maximum: 1000, unless: ->(pd) { pd.description.blank? }, message: 'Description is too long.' }
         validates :duration, presence: { message: 'Duration must be completed.' }
-        validates :department, presence: { message: "Department must be completed." }
       end
     end
   end

--- a/app/views/petitions/create/_petition_details_hidden.html.erb
+++ b/app/views/petitions/create/_petition_details_hidden.html.erb
@@ -1,5 +1,4 @@
 <%= f.hidden_field :title %>
-<%= f.hidden_field :department_id %>
 <%= f.hidden_field :action %>
 <%= f.hidden_field :description %>
 <%= f.hidden_field :duration %>

--- a/app/views/petitions/create/_petition_details_ui.html.erb
+++ b/app/views/petitions/create/_petition_details_ui.html.erb
@@ -12,17 +12,6 @@
     <p>Maximum 150 Characters</p>
   <% end %>
 
-  <%= form_row :class => 'department_row', :for => [petition, :department] do %>
-    <%= f.label :department_id, raw("Department that looks after your issue#{info_link_to "#department_info", :class => "expandable_link", :tabindex => increment}") %>
-    <%= f.select :department_id, options_from_collection_for_select(@departments, :id, :name, :selected => (petition.department.nil?) ? nil : petition.department.id), { :include_blank => 'Please select...' }, :tabindex => increment  %>
-    <%= error_messages_for_field petition, :department %>
-    <%= new_window_link_to 'Which department does what?', info_departments_path, :tabindex => increment, :target => '_blank' %>
-
-    <div class="expandable_content" id="department_info">
-      <p>You must choose the government department that you believe owns the issue you are raising in your <span class="nowrap">e-petition</span>. This will help us to get it to the right person as quickly as possible.</p>
-    </div>
-  <% end %>
-
   <%= form_row :for => [petition, :action] do %>
     <%= f.label :action %>
     <%= f.text_area :action, :tabindex => increment %>

--- a/app/views/petitions/create/_submit_ui.html.erb
+++ b/app/views/petitions/create/_submit_ui.html.erb
@@ -8,7 +8,6 @@
   </div>
   <div class="generic_block" id="petition_summary_block">
     <h2 id="title_summary_field"><%= petition.title %></h2>
-    <p id="department_summary_field">Responsible department: <%= petition.department.name %></p>
     <div id="action_summary_field"><%= raw auto_link(simple_format(h(petition.action)), :html => { :target => '_blank' }) %></div>
     <div id="description_summary_field"><%= raw auto_link(simple_format(h(petition.description)), :html => { :target => '_blank' }) %></div>
   </div>

--- a/db/migrate/20150514140022_allow_null_departments_on_petitions.rb
+++ b/db/migrate/20150514140022_allow_null_departments_on_petitions.rb
@@ -1,0 +1,5 @@
+class AllowNullDepartmentsOnPetitions < ActiveRecord::Migration
+  def change
+    change_column_null :petitions, :department_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150511123210) do
+ActiveRecord::Schema.define(version: 20150514140022) do
 
   create_table "admin_users", force: :cascade do |t|
     t.string   "email",                limit: 255,                null: false
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20150511123210) do
     t.text     "response",                limit: 65535
     t.string   "state",                   limit: 10,    default: "pending", null: false
     t.datetime "open_at"
-    t.integer  "department_id",           limit: 4,                         null: false
+    t.integer  "department_id",           limit: 4
     t.integer  "creator_signature_id",    limit: 4,                         null: false
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -32,7 +32,6 @@ Scenario: Charlie creates our petition
   And I should be connected to the server via an ssl connection
   When I fill in "Title" with "The wombats of wimbledon rock."
   And I fill in "Action" with "Give half of Wimbledon rock to wombats!"
-  And I select "Department for International Development" from "Department"
   And I fill in "Description" with "The racial tensions between the wombles and the wombats are heating up. Racial attacks are a regular occurrence and the death count is already in 5 figures. The only resolution to this crisis is to give half of Wimbledon common to the Wombats and to recognise them as their own independent state."
   And I select "3 months" from "Time to collect signatures"
   And I press "Next"
@@ -61,7 +60,6 @@ Scenario: Charlie tries to submit an invalid petition
   When I press "Next"
   Then I should see "Title must be completed"
   And I should see "Action must be completed"
-  And I should see "Department must be completed"
   And I should see "Description must be completed"
 
   When I am allowed to make the petition title too long
@@ -75,7 +73,6 @@ Scenario: Charlie tries to submit an invalid petition
   And I should see "Action is too long."
 
   When I fill in "Title" with "The wombats of wimbledon rock."
-  And I select "Department for International Development" from "Department"
   And I fill in "Action" with "Give half of Wimbledon rock to wombats!"
   And I fill in "Description" with "The racial tensions between the wombles and the wombats are heating up.  Racial attacks are a regular occurrence and the death count is already in 5 figures.  The only resolution to this crisis is to give half of Wimbledon common to the Wombats and to recognise them as their own independent state."
   And I press "Next"
@@ -125,12 +122,8 @@ Scenario: Charlie tries to submit an invalid petition
 
 
 Scenario: Charlie looks up information about departments
-  Given I am on the new petition page
-  When I follow "Which department does what?"
-  Then I should be on the department information page
+  Given I am on the department information page
   And I should see "Cabinet Office"
   And I should see "Where cabinets do their paperwork"
   And I should see "Department for International Development"
   And I should see "A large portion of the UK population cannot intonate their words properly. This department is responsible for developing this."
-
-#The JS version for this scenario can't be run since Selenium doesn't seem to understand pages in new tabs.

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1008,10 +1008,6 @@ form fieldset#petition_submit_section #petition_summary_block #title_summary_fie
   font-size: 1.3em;
   margin-bottom: 25px;
 }
-form fieldset#petition_submit_section #petition_summary_block #department_summary_field {
-  margin-bottom: 25px;
-}
-
 form fieldset#petition_submit_section #petition_summary_block #description_summary_field {
   font-size: 1.0em;
 }

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -55,7 +55,6 @@ describe PetitionsController do
         :action => 'Limit temperature rise at two degrees',
         :description => 'Global warming is upon us',
         :duration => "12",
-        :department_id => department.id,
         :sponsor_emails => sponsor_emails,
         :creator_signature => creator_signature_attributes
       }
@@ -167,10 +166,10 @@ describe PetitionsController do
           expect(assigns[:departments]).to eq([department])
         end
 
-        it "has stage of 'petition' if there are errors on title, department or description" do
+        it "has stage of 'petition' if there are errors on title, action, or description" do
           do_post :petition => petition_attributes.merge(:title => '')
           expect(assigns[:stage_manager].stage).to eq 'petition'
-          do_post :petition => petition_attributes.merge(:department_id => nil)
+          do_post :petition => petition_attributes.merge(:action => '')
           expect(assigns[:stage_manager].stage).to eq 'petition'
           do_post :petition => petition_attributes.merge(:description => '')
           expect(assigns[:stage_manager].stage).to eq 'petition'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,7 +33,6 @@ FactoryGirl.define do
     sequence(:title) {|n| "Petition #{n}" }
     action "Petition action"
     description "Petition description"
-    association :department
     sponsor_emails { (1..sponsor_count).map { |i| "sponsor#{i}@example.com" } }
     creator_signature  { |cs| cs.association(:signature, creator_signature_attributes.merge(:state => Signature::VALIDATED_STATE)) }
   end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -8,7 +8,7 @@
 #  response                :text
 #  state                   :string(10)      default("pending"), not null
 #  open_at                 :datetime
-#  department_id           :integer(4)      not null
+#  department_id           :integer(4)
 #  creator_signature_id    :integer(4)      not null
 #  created_at              :datetime
 #  updated_at              :datetime
@@ -50,7 +50,6 @@ describe Petition do
     it { is_expected.to validate_presence_of(:action).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:description).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:duration).with_message(/must be completed/) }
-    it { is_expected.to validate_presence_of(:department).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:creator_signature).with_message(/must be completed/) }
 
     context "sponsor validations" do
@@ -623,7 +622,7 @@ describe Petition do
   describe "#update_sponsored_state" do
     context "with sufficient sponsor count" do
       let(:petition){ FactoryGirl.create(:validated_petition, sponsors_signed: true) }
-      
+
       it "sets state to sponsored" do
         expect{petition.update_sponsored_state}.to change{petition.state}
                                                     .from(Petition::VALIDATED_STATE)
@@ -639,7 +638,7 @@ describe Petition do
       end
     end
   end
-  
+
 
   describe "creating sponsors from sponsor emails in after create callback" do
     it 'persists sponsors to match the emails' do

--- a/spec/models/staged_petition_creator_spec.rb
+++ b/spec/models/staged_petition_creator_spec.rb
@@ -117,7 +117,6 @@ describe StagedPetitionCreator do
         :action => 'Limit temperature rise at two degrees',
         :description => 'Global warming is upon us',
         :duration => "12",
-        :department_id => department.id,
         :sponsor_emails => sponsor_emails,
         :creator_signature_attributes => creator_signature_params
       }


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/93907142

I haven't removed the department_id from petition, just the UI to let you create it.  I think once all the other department removal stories are in we can do a final sweep to actually remove the associations and the ``Department`` model entirely.