### PR TITLE
Replay email address instead of confirming during create

### DIFF
--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -34,8 +34,8 @@ module PetitionHelper
       render('/petitions/create/your_details_ui', petition: stage_manager.stage_object, f: form)
     when 'sponsors'
       render('/petitions/create/sponsor_details_ui', petition: stage_manager.stage_object, f: form)
-    when 'submit'
-      render('/petitions/create/submit_ui', petition: stage_manager.stage_object, f: form)
+    when 'replay-petition'
+      render('/petitions/create/replay_petition_ui', petition: stage_manager.stage_object, f: form)
     end
   end
 end

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -20,6 +20,7 @@ module PetitionHelper
       concat render('/petitions/create/sponsor_details_hidden', petition: stage_manager.stage_object, f: form) unless stage_manager.stage == 'sponsors'
       if stage_manager.stage_object.creator_signature.present?
         concat render('/petitions/create/your_details_hidden', petition: stage_manager.stage_object, f: form) unless stage_manager.stage == 'creator'
+        concat render('/petitions/create/email_hidden', petition: stage_manager.stage_object, f: form) unless ['creator', 'replay-email'].include? stage_manager.stage
       end
     end
   end
@@ -36,6 +37,8 @@ module PetitionHelper
       render('/petitions/create/sponsor_details_ui', petition: stage_manager.stage_object, f: form)
     when 'replay-petition'
       render('/petitions/create/replay_petition_ui', petition: stage_manager.stage_object, f: form)
+    when 'replay-email'
+      render('/petitions/create/replay_email_ui', petition: stage_manager.stage_object, f: form)
     end
   end
 end

--- a/app/models/concerns/email_encrypter.rb
+++ b/app/models/concerns/email_encrypter.rb
@@ -11,12 +11,7 @@ module EmailEncrypter
                    marshaler: EmailDowncaser
 
     # = Validations =
-    validates_presence_of :email, message: "%{attribute} must be completed"
-
-    validates_format_of :email,
-                        with: EMAIL_REGEX,
-                        unless: 'email.blank?',
-                        message: "Email '%{value}' not recognised."
+    include Staged::Validations::Email
 
     # = Finders =
     scope :for_email, ->(email) { where(encrypted_email: encrypt_email(email)) }
@@ -29,11 +24,11 @@ module EmailEncrypter
     def encrypted_email
       super
     end
-    
+
     def encrypted_email=(value)
       super
     end
-    
+
     def encrypted_email?
       super
     end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -53,6 +53,6 @@ class Sponsor < ActiveRecord::Base
 
   private
   def default_signature_attribtues
-    {petition: petition, email: email, email_confirmation: email}
+    {petition: petition, email: email}
   end
 end

--- a/app/models/staged/base/creator_signature.rb
+++ b/app/models/staged/base/creator_signature.rb
@@ -8,7 +8,7 @@ module Staged
         @petition = petition
       end
       delegate :id, :to_param, :model_name, :to_key,
-               :name, :email, :email_confirmation, :uk_citizenship,
+               :name, :email, :uk_citizenship,
                :postcode, :country,
                to: :creator_signature
 

--- a/app/models/staged/creator.rb
+++ b/app/models/staged/creator.rb
@@ -5,6 +5,7 @@ module Staged
 
     class CreatorSignature < Staged::Base::CreatorSignature
       include Staged::Validations::SignerDetails
+      include Staged::Validations::Email
     end
   end
 end

--- a/app/models/staged/replay_email.rb
+++ b/app/models/staged/replay_email.rb
@@ -1,0 +1,10 @@
+module Staged
+  class ReplayEmail < Staged::Base::Petition
+    include ActiveModel::Model
+    include Staged::HasCreatorSignature
+
+    class CreatorSignature < Staged::Base::CreatorSignature
+      include Staged::Validations::Email
+    end
+  end
+end

--- a/app/models/staged/replay_petition.rb
+++ b/app/models/staged/replay_petition.rb
@@ -1,5 +1,5 @@
 module Staged
-  class Submit < Staged::Base::Petition
+  class ReplayPetition < Staged::Base::Petition
     include Staged::HasCreatorSignature
 
     class CreatorSignature < Staged::Base::CreatorSignature

--- a/app/models/staged/validations/email.rb
+++ b/app/models/staged/validations/email.rb
@@ -1,0 +1,17 @@
+module Staged
+  module Validations
+    module Email
+      extend ActiveSupport::Concern
+
+      included do
+        validates :email,
+          presence: { message: "Email must be completed" },
+          format: {
+            with: EMAIL_REGEX,
+            unless: -> (e) { e.email.blank? },
+            message: "Email '%{value}' not recognised."
+          }
+      end
+    end
+  end
+end

--- a/app/models/staged/validations/signer_details.rb
+++ b/app/models/staged/validations/signer_details.rb
@@ -10,10 +10,7 @@ module Staged
 
         with_options on: :create do |creator|
           creator.validates :email,
-            presence: { message: 'Email must be completed.' },
-            confirmation: { message: 'Email should match confirmation.' }
-
-          creator.validates :email_confirmation, presence: { message: 'Email confirmation must be completed.' }
+            presence: { message: 'Email must be completed.' }
         end
 
         validates :country, presence: { message: 'Country must be completed.' }

--- a/app/models/staged/validations/signer_details.rb
+++ b/app/models/staged/validations/signer_details.rb
@@ -8,11 +8,6 @@ module Staged
           presence: { message: 'Name must be completed.' },
           length: { maximum: 255 }
 
-        with_options on: :create do |creator|
-          creator.validates :email,
-            presence: { message: 'Email must be completed.' }
-        end
-
         validates :country, presence: { message: 'Country must be completed.' }
 
         validates :postcode,

--- a/app/models/staged_petition_creator.rb
+++ b/app/models/staged_petition_creator.rb
@@ -55,7 +55,7 @@ class StagedPetitionCreator
 
   module Stages
     def self.names
-      ['petition', 'creator', 'sponsors', 'replay-petition', 'done']
+      ['petition', 'creator', 'sponsors', 'replay-petition', 'replay-email', 'done']
     end
 
     def self.for_name(name)
@@ -68,6 +68,8 @@ class StagedPetitionCreator
         Stages::Sponsors
       when 'replay-petition'
         Stages::ReplayPetition
+      when 'replay-email'
+        Stages::ReplayEmail
       when 'done'
         Stages::Done
       else
@@ -145,6 +147,16 @@ class StagedPetitionCreator
 
       def name; 'replay-petition'; end
       def go_back; Stages.for_name('sponsors').new(petition); end
+      def go_next; Stages.for_name('replay-email').new(petition); end
+    end
+
+    class ReplayEmail < Stages::Stage
+      def stage_object
+        @_stage_object ||= Staged::ReplayEmail.new(petition)
+      end
+
+      def name; 'replay-email'; end
+      def go_back; Stages.for_name('replay-petition').new(petition); end
       def go_next; Stages.for_name('done').new(petition); end
     end
 

--- a/app/models/staged_petition_creator.rb
+++ b/app/models/staged_petition_creator.rb
@@ -55,7 +55,7 @@ class StagedPetitionCreator
 
   module Stages
     def self.names
-      ['petition', 'creator', 'sponsors', 'submit','done']
+      ['petition', 'creator', 'sponsors', 'replay-petition', 'done']
     end
 
     def self.for_name(name)
@@ -66,8 +66,8 @@ class StagedPetitionCreator
         Stages::Creator
       when 'sponsors'
         Stages::Sponsors
-      when 'submit'
-        Stages::Submit
+      when 'replay-petition'
+        Stages::ReplayPetition
       when 'done'
         Stages::Done
       else
@@ -135,15 +135,15 @@ class StagedPetitionCreator
 
       def name; 'sponsors'; end
       def go_back; Stages.for_name('creator').new(petition); end
-      def go_next; Stages.for_name('submit').new(petition); end
+      def go_next; Stages.for_name('replay-petition').new(petition); end
     end
 
-    class Submit < Stages::Stage
+    class ReplayPetition < Stages::Stage
       def stage_object
-        @_stage_object ||= Staged::Submit.new(petition)
+        @_stage_object ||= Staged::ReplayPetition.new(petition)
       end
 
-      def name; 'submit'; end
+      def name; 'replay-petition'; end
       def go_back; Stages.for_name('sponsors').new(petition); end
       def go_next; Stages.for_name('done').new(petition); end
     end

--- a/app/views/petitions/create/_email_hidden.html.erb
+++ b/app/views/petitions/create/_email_hidden.html.erb
@@ -1,0 +1,3 @@
+<%= f.fields_for :creator_signature, petition.creator_signature do |csf| %>
+  <%= csf.hidden_field :email %>
+<% end %>

--- a/app/views/petitions/create/_replay_email_ui.html.erb
+++ b/app/views/petitions/create/_replay_email_ui.html.erb
@@ -1,0 +1,13 @@
+<fieldset>
+  <legend>Make sure this is right</legend>
+  <%= f.fields_for :creator_signature, petition.creator_signature do |csf| %>
+    <%= render 'signatures/email', f: csf, signature: csf.object %>
+  <% end %>
+
+  <p>If your email address is wrong, just change it above.</p>
+
+  <%= form_row :class => 'button_row' do %>
+    <%= f.button 'Back', :name => 'move', :value => 'back', :class => 'button backwards_action', :tabindex => increment %>
+    <%= f.button 'Submit', :name => 'move', :value => 'next', :class => 'button forward_action', :tabindex => increment %>
+  <% end %>
+</fieldset>

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -1,5 +1,5 @@
 <fieldset id="petition_submit_section">
-  <legend>Submit Petition</legend>
+  <legend>Review Petition</legend>
 
   <div class="strap_block">
     <p>Here's your chance to review your e-petition. Once you press 'submit', you can't go back.

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -21,6 +21,6 @@
 
   <%= form_row :class => 'button_row' do %>
     <%= f.button 'Back', :name => 'move', :value => 'back', :class => 'button backwards_action', :tabindex => increment %>
-    <%= f.button 'Submit', :name => 'move', :value => 'next', :class => 'button forward_action', :tabindex => increment %>
+    <%= f.button 'Next', :name => 'move', :value => 'next', :class => 'button forward_action', :tabindex => increment %>
   <% end %>
 </fieldset>

--- a/app/views/petitions/create/_your_details_hidden.html.erb
+++ b/app/views/petitions/create/_your_details_hidden.html.erb
@@ -1,6 +1,5 @@
 <%= f.fields_for :creator_signature, petition.creator_signature do |csf| %>
   <%= csf.hidden_field :name %>
-  <%= csf.hidden_field :email %>
   <%= csf.hidden_field :uk_citizenship %>
   <%= csf.hidden_field :postcode %>
   <%= csf.hidden_field :country %>

--- a/app/views/petitions/create/_your_details_hidden.html.erb
+++ b/app/views/petitions/create/_your_details_hidden.html.erb
@@ -1,7 +1,6 @@
 <%= f.fields_for :creator_signature, petition.creator_signature do |csf| %>
   <%= csf.hidden_field :name %>
   <%= csf.hidden_field :email %>
-  <%= csf.hidden_field :email_confirmation %>
   <%= csf.hidden_field :uk_citizenship %>
   <%= csf.hidden_field :postcode %>
   <%= csf.hidden_field :country %>

--- a/app/views/petitions/new.html.erb
+++ b/app/views/petitions/new.html.erb
@@ -11,7 +11,7 @@
       <li class="step_1 pagination_tab<%= ' active' if @stage_manager.stage == 'petition' %>"><span class="step_no">1</span>e-petition<br/>details</li>
       <li class="step_2 pagination_tab<%= ' active' if @stage_manager.stage == 'creator' %>"><span class="step_no">2</span>Your details</li>
       <li class="step_3 pagination_tab<%= ' active' if @stage_manager.stage == 'sponsors' %>"><span class="step_no">3</span>Sponsor emails</li>
-      <li class="step_4 pagination_tab<%= ' active' if @stage_manager.stage == 'submit' %>"><span class="step_no">4</span>Submit<br/>e-petition</li>
+      <li class="step_4 pagination_tab<%= ' active' if @stage_manager.stage == 'replay-petition' %>"><span class="step_no">4</span>Preview<br/>e-petition</li>
     </ul>
   </div>
 

--- a/app/views/petitions/new.html.erb
+++ b/app/views/petitions/new.html.erb
@@ -12,6 +12,7 @@
       <li class="step_2 pagination_tab<%= ' active' if @stage_manager.stage == 'creator' %>"><span class="step_no">2</span>Your details</li>
       <li class="step_3 pagination_tab<%= ' active' if @stage_manager.stage == 'sponsors' %>"><span class="step_no">3</span>Sponsor emails</li>
       <li class="step_4 pagination_tab<%= ' active' if @stage_manager.stage == 'replay-petition' %>"><span class="step_no">4</span>Preview<br/>e-petition</li>
+      <li class="step_5 pagination_tab<%= ' active' if @stage_manager.stage == 'replay-email' %>"><span class="step_no">5</span>Submit<br/>e-petition</li>
     </ul>
   </div>
 

--- a/app/views/signatures/_email.html.erb
+++ b/app/views/signatures/_email.html.erb
@@ -1,0 +1,5 @@
+<%= form_row :for => [signature, :email] do %>
+  <%= f.label :email %>
+  <%= f.text_field :email, :type => 'email', :tabindex => increment %>
+  <%= error_messages_for_field signature, :email %>
+<% end %>

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -14,13 +14,6 @@
     <%= f.label :email %>
     <%= f.text_field :email, :type => 'email', :tabindex => increment %>
     <%= error_messages_for_field signature, :email %>
-    <%= error_messages_for_field signature, :email_confirmation %>
-  <% end %>
-
-  <%= form_row :for => [signature, :email_confirmation] do %>
-    <%= f.label :email_confirmation %>
-    <%= f.text_field :email_confirmation, :type => 'email', :tabindex => increment,
-                     :onpaste => "return false", :autocomplete => 'off' %>
   <% end %>
 <% end %>
 

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -10,11 +10,7 @@
 <% end %>
 
 <% if local_assigns.fetch(:with_email, true) %>
-  <%= form_row :for => [signature, :email] do %>
-    <%= f.label :email %>
-    <%= f.text_field :email, :type => 'email', :tabindex => increment %>
-    <%= error_messages_for_field signature, :email %>
-  <% end %>
+  <%= render 'signatures/email', f: f, signature: signature %>
 <% end %>
 
 <%= form_row :class => 'checkbox_row', :for => [signature, :uk_citizenship] do %>

--- a/app/views/signatures/new.html.erb
+++ b/app/views/signatures/new.html.erb
@@ -50,10 +50,6 @@ $().ready(function() {
     method: [E_PETS.FormController.validation_methods.validate_format, E_PETS.FormController.validation_formats.email],
     message: "Email not recognised."
   });
-  signature_form.validates('signature[email_confirmation]', {
-    method: [E_PETS.FormController.validation_methods.validate_confirmation, 'signature[email]'],
-    message: "Email must match confirmation."
-  });
   signature_form.validates('signature[uk_citizenship]', {
     method: E_PETS.FormController.validation_methods.validate_checked,
     message: "You must be a British citizen or normally live in the UK to create or sign e-petitions."

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -38,6 +38,7 @@ Scenario: Charlie creates our petition
   And I press "Next"
   And I fill in sponsor emails
   And I press "Next"
+  And I press "Next"
   Then the markup should be valid
   When I press "Submit"
   Then a petition should exist with title: "The wombats of wimbledon rock.", state: "pending"
@@ -102,6 +103,13 @@ Scenario: Charlie tries to submit an invalid petition
   And I press "Next"
   And I press "Next"
 
+  And I press "Next"
+  Then I should see a fieldset called "Make sure this is right"
+
+  When I fill in "Email" with ""
+  And I press "Submit"
+  Then I should see "Email must be completed"
+  When I fill in "Email" with "womboid@wimbledon.com"
   And I press "Submit"
 
   Then a petition should exist with title: "The wombats of wimbledon rock.", state: "pending"

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -91,12 +91,10 @@ Scenario: Charlie tries to submit an invalid petition
   And I fill in sponsor emails
 
   And I press "Next"
-  Then I should see a fieldset called "Submit Petition"
+  Then I should see a fieldset called "Review Petition"
 
-  #Seems there's an envjs bug here
-  # And I should see "The wombats of wimbledon rock."
-  # And I should see "Department for International Development"
-  # And I should see "The racial tensions between the wombles and the wombats are heating up.  Racial attacks are a regular occurrence and the death count is already in 5 figures.  The only resolution to this crisis is to give half of Wimbledon common to the Wombats and to recognise them as their own independent state."
+  And I should see "The wombats of wimbledon rock."
+  And I should see "The racial tensions between the wombles and the wombats are heating up.  Racial attacks are a regular occurrence and the death count is already in 5 figures.  The only resolution to this crisis is to give half of Wimbledon common to the Wombats and to recognise them as their own independent state."
 
   And I press "Back"
   And I press "Back"

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -83,10 +83,6 @@ Scenario: Charlie tries to submit an invalid petition
   And I should see "You must be a British citizen"
   And I should see "Postcode must be completed"
 
-  When I fill in my details with email "wimbledon@womble.com" and confirmation "uncleb@wimbledon.com"
-  And I press "Next"
-  And I should see "Email should match confirmation"
-
   When I fill in my details
 
   And I press "Next"

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -45,18 +45,9 @@ When /^I fill in my details$/ do
   steps %Q(
     When I fill in "Name" with "Womboid Wibbledon"
     And I fill in "Email" with "womboid@wimbledon.com"
-    And I fill in "Email confirmation" with "womboid@wimbledon.com"
     And I check "Yes, I am a British citizen or UK resident"
     And I fill in "Postcode" with "SW14 9RQ"
     And I select "United Kingdom" from "Country"
-  )
-end
-
-When /^I fill in my details with email "([^"]*)" and confirmation "([^"]*)"$/ do |email, email_confirmation|
-  step "I fill in my details"
-  steps %Q(
-    And I fill in "Email" with "#{email}"
-    And I fill in "Email confirmation" with "#{email_confirmation}"
   )
 end
 

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -66,7 +66,6 @@ end
 
 When(/^I fill in my details as a sponsor$/) do
   expect(page).to have_no_field 'signature[email]'
-  expect(page).to have_no_field 'signature[email_confirmation]'
   steps %Q(
     When I fill in "Name" with "Laura The Sponsor"
     And I check "Yes, I am a British citizen or UK resident"

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -39,13 +39,6 @@ Feature: Suzie signs a petition
     And I try to sign
     Then I should see an error
 
-  Scenario: Suzie cannot sign if she enters the email confirmation incorrectly
-    When I decide to sign the petition
-    And I fill in my details
-    And I fill in "Email confirmation" with "something@different.com"
-    And I try to sign
-    Then I should see an error
-
   Scenario: Suzie cannot sign if she has already signed
     And I have already signed the petition with an uppercase email
     When I decide to sign the petition

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -951,9 +951,19 @@ form.new_petition_form .form_pagination li.active .step_no {
 form.new_petition_form .form_pagination li.step_2 {
   position: absolute;
   top: 0px;
-  left: 300px;
+  left: 150px;
 }
 form.new_petition_form .form_pagination li.step_3 {
+  position: absolute;
+  top: 0px;
+  left: 300px;
+}
+form.new_petition_form .form_pagination li.step_4 {
+  position: absolute;
+  top: 0px;
+  left: 450px;
+}
+form.new_petition_form .form_pagination li.step_5 {
   position: absolute;
   top: 0px;
   right: -12px;
@@ -1663,19 +1673,28 @@ html[xmlns] .clearfix {
 
   form.new_petition_form .form_pagination li{
     font-size: 1.2em;
+    width: 50px;
   }
 
-  form.new_petition_form .form_pagination li .step_no{
-    width: 50px;
+  form.new_petition_form .form_pagination li .step_no {
+    width: 30px;
     padding: 10px 5px;
   }
 
-  form.new_petition_form .form_pagination li.step_2{
-    left: 110px;
+  form.new_petition_form .form_pagination li.step_2 {
+    left: 63px;
   }
 
-  form.new_petition_form .form_pagination li.step_3  {
-    right: 0px;
+  form.new_petition_form .form_pagination li.step_3 {
+    left: 126px;
+  }
+
+  form.new_petition_form .form_pagination li.step_4 {
+    left: 189px;
+  }
+
+  form.new_petition_form .form_pagination li.step_5 {
+    right: -10px;
   }
 
   form fieldset#petition_submit_section .row{

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -43,7 +43,6 @@ describe PetitionsController do
     let(:creator_signature_attributes) do
       {
         :name => 'John Mcenroe', :email => 'john@example.com',
-        :email_confirmation => 'john@example.com',
         :postcode => 'SE3 4LL', :country => 'United Kingdom',
         :uk_citizenship => '1'
       }
@@ -166,12 +165,10 @@ describe PetitionsController do
           expect(assigns[:stage_manager].stage).to eq 'petition'
         end
 
-        it "has stage of 'creator' if there are errors on name, email, email_confirmation, uk_citizenship, postcode or country" do
+        it "has stage of 'creator' if there are errors on name, email, uk_citizenship, postcode or country" do
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:name => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => ''))
-          expect(assigns[:stage_manager].stage).to eq 'creator'
-          do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => 'dave@example.com', :l_confirmation => 'laura@example.com'))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:uk_citizenship => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -168,7 +168,7 @@ describe PetitionsController do
         it "has stage of 'creator' if there are errors on name, email, uk_citizenship, postcode or country" do
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:name => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'
-          do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => ''))
+          do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => 'foo@'))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:uk_citizenship => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -58,7 +58,7 @@ describe PetitionsController do
     end
 
     def do_post(options = {})
-      post :create, {:stage => 'replay-petition', :move => 'next', :petition => petition_attributes}.merge(options)
+      post :create, {:stage => 'replay-email', :move => 'next', :petition => petition_attributes}.merge(options)
     end
 
     with_ssl do
@@ -165,10 +165,8 @@ describe PetitionsController do
           expect(assigns[:stage_manager].stage).to eq 'petition'
         end
 
-        it "has stage of 'creator' if there are errors on name, email, uk_citizenship, postcode or country" do
+        it "has stage of 'creator' if there are errors on name, uk_citizenship, postcode or country" do
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:name => ''))
-          expect(assigns[:stage_manager].stage).to eq 'creator'
-          do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:email => 'foo@'))
           expect(assigns[:stage_manager].stage).to eq 'creator'
           do_post :petition => petition_attributes.merge(:creator_signature => creator_signature_attributes.merge(:uk_citizenship => ''))
           expect(assigns[:stage_manager].stage).to eq 'creator'
@@ -182,6 +180,22 @@ describe PetitionsController do
           petition_attributes[:sponsor_emails] = 'blah@'
           do_post
           expect(assigns[:stage_manager].stage).to eq 'sponsors'
+        end
+
+        it "has stage of 'replay-email' if there are errors on email and we came from 'replay-email' stage" do
+          new_creator_signature_attribtues = creator_signature_attributes.merge(:email => 'foo@')
+          new_petition_attributes = petition_attributes.merge(:creator_signature => new_creator_signature_attribtues)
+          do_post :stage => 'replay-email',
+                  :petition => new_petition_attributes
+          expect(assigns[:stage_manager].stage).to eq 'replay-email'
+        end
+
+        it "has stage of 'creator' if there are errors on email and we came from 'creator' stage" do
+          new_creator_signature_attribtues = creator_signature_attributes.merge(:email => 'foo@')
+          new_petition_attributes = petition_attributes.merge(:creator_signature => new_creator_signature_attribtues)
+          do_post :stage => 'creator',
+                  :petition => new_petition_attributes
+          expect(assigns[:stage_manager].stage).to eq 'creator'
         end
       end
     end

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -58,7 +58,7 @@ describe PetitionsController do
     end
 
     def do_post(options = {})
-      post :create, {:stage => 'submit', :move => 'next', :petition => petition_attributes}.merge(options)
+      post :create, {:stage => 'replay-petition', :move => 'next', :petition => petition_attributes}.merge(options)
     end
 
     with_ssl do

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -130,8 +130,15 @@ describe SignaturesController do
   describe "create" do
     let!(:petition) { FactoryGirl.create(:open_petition) }
 
-    let(:signature_params) {{:name => 'John Mcenroe', :email => 'john@example.com', :email_confirmation => 'john@example.com',
-      :uk_citizenship => "1", :postcode => 'SE3 4LL', :country => 'UK'}}
+    let(:signature_params) do
+      {
+        :name => 'John Mcenroe',
+        :email => 'john@example.com',
+        :uk_citizenship => "1",
+        :postcode => 'SE3 4LL',
+        :country => 'UK'
+      }
+    end
 
     def do_post(options = {})
       post :create, :signature => signature_params.merge(options), :petition_id => petition.id

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -80,7 +80,6 @@ FactoryGirl.define do
   factory :signature do
     sequence(:name) {|n| "Jo Public #{n}" }
     sequence(:email) {|n| "jo#{n}@public.com" }
-    email_confirmation  {|sig| sig.email }
     postcode            "SW1A 1AA"
     country             "United Kingdom"
     uk_citizenship       '1'

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -84,25 +84,6 @@ describe Signature do
       expect(s).not_to have_valid(:email)
     end
 
-    describe "email confirmation" do
-      it "require email confirmation on create" do
-        s = FactoryGirl.build(:signature, :email => 'joe@example.com', :email_confirmation => nil)
-        s.valid?
-        expect(s.errors_on(:email_confirmation)).not_to be_blank
-      end
-
-      it "not require email confirmation on update" do
-        s = FactoryGirl.create(:signature)
-        expect(s.update_attributes(:email => 'john@hotmail.com', :email_confirmation => nil)).to be_truthy
-      end
-
-      it "require email and email confirmation to be the same" do
-        s = FactoryGirl.build(:signature, :email => 'john@hotmail.com', :email_confirmation => 'john2@hotmail.com')
-        s.valid?
-        expect(s.errors_on(:email_confirmation)).not_to be_blank
-      end
-    end
-
     describe "uniqueness of email" do
       before do
         FactoryGirl.create(:signature, :name => "Suzy Signer",

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -67,10 +67,6 @@ describe Sponsor do
         expect(subject.email).to eq sponsor.email
       end
 
-      it 'is has confirmation of the email address using the same one as the sponsor' do
-        expect(subject.email_confirmation).to eq sponsor.email
-      end
-
       it 'does not allow overriding the defaults' do
         attributes[:email] = 'a-brand-new-email@example.com'
         expect(subject.email).not_to eq 'a-brand-new-email@example.com'

--- a/spec/models/staged_petition_creator_spec.rb
+++ b/spec/models/staged_petition_creator_spec.rb
@@ -105,7 +105,6 @@ describe StagedPetitionCreator do
     let(:creator_signature_params) do
       {
         :name => 'John Mcenroe', :email => 'john@example.com',
-        :email_confirmation => 'john@example.com',
         :postcode => 'SE3 4LL', :country => 'United Kingdom',
         :uk_citizenship => '1'
       }
@@ -145,7 +144,7 @@ describe StagedPetitionCreator do
         end
 
         context 'around the "creator" UI' do
-          before { creator_signature_params.delete(:email_confirmation) }
+          before { creator_signature_params.delete(:email) }
 
           context 'before attempting to create the petition' do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'

--- a/spec/models/staged_petition_creator_spec.rb
+++ b/spec/models/staged_petition_creator_spec.rb
@@ -35,7 +35,7 @@ describe StagedPetitionCreator do
       end
     end
 
-    context 'when creator_signature attributes are present' do
+    context 'when creator_signature attributes are not present' do
       it 'does not cause a creator_signature to appear' do
         subject.create_petition
         expect(petition.creator_signature).to be_nil

--- a/spec/models/staged_petition_creator_spec.rb
+++ b/spec/models/staged_petition_creator_spec.rb
@@ -120,6 +120,28 @@ describe StagedPetitionCreator do
     end
 
     describe '#stage' do
+      context 'when there are no errors on the petition' do
+        context 'before attempting to create the petition' do
+          for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
+          for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
+          for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+          for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+          for_stage 'replay-email', next_is: 'done', back_is: 'replay-petition', not_moving_is: 'replay-email'
+          for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
+        end
+
+        context 'after attempting to create the petition' do
+          before { subject.create_petition }
+
+          for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
+          for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
+          for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+          for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+          for_stage 'replay-email', next_is: 'done', back_is: 'replay-petition', not_moving_is: 'replay-email'
+          for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
+        end
+      end
+
       context 'when there are errors on the petition' do
         context 'around the "petition" UI' do
           before { petition_params.delete(:title) }
@@ -128,7 +150,8 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'petition', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'replay-petition', next_is: 'done', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'done', back_is: 'replay-petition', not_moving_is: 'replay-email'
             for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
           end
 
@@ -138,19 +161,21 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'petition', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'replay-petition', next_is: 'petition', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'petition', back_is: 'replay-petition', not_moving_is: 'replay-email'
             for_stage 'done', next_is: 'petition', back_is: 'petition', not_moving_is: 'petition'
           end
         end
 
         context 'around the "creator" UI' do
-          before { creator_signature_params.delete(:email) }
+          before { creator_signature_params.delete(:postcode) }
 
           context 'before attempting to create the petition' do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'creator', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'replay-petition', next_is: 'done', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'done', back_is: 'replay-petition', not_moving_is: 'replay-email'
             for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
           end
 
@@ -160,7 +185,8 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'creator', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'replay-petition', next_is: 'creator', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'creator', back_is: 'replay-petition', not_moving_is: 'replay-email'
             for_stage 'done', next_is: 'creator', back_is: 'creator', not_moving_is: 'creator'
           end
         end
@@ -172,7 +198,8 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'sponsors', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'replay-petition', next_is: 'done', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'done', back_is: 'replay-petition', not_moving_is: 'replay-email'
             for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
           end
 
@@ -181,8 +208,40 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'sponsors', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'replay-petition', next_is: 'sponsors', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'sponsors', back_is: 'replay-petition', not_moving_is: 'replay-email'
             for_stage 'done', next_is: 'sponsors', back_is: 'sponsors', not_moving_is: 'sponsors'
+          end
+        end
+
+        context 'around the "replay email" UI' do
+          before { creator_signature_params.delete(:email) }
+
+          # NOTE: the creator stage also checks for errors on email, so
+          # we need to be aware that errors on the "replay email" UI will
+          # also trigger the creator stage.
+
+          context 'before attempting to create the petition' do
+            for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
+            for_stage 'creator', next_is: 'creator', back_is: 'petition', not_moving_is: 'creator'
+            for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'replay-email', back_is: 'replay-petition', not_moving_is: 'replay-email'
+            for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
+          end
+
+          context 'after attempting to create the petition' do
+            before { subject.create_petition }
+            for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
+            for_stage 'creator', next_is: 'creator', back_is: 'petition', not_moving_is: 'creator'
+            for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+            for_stage 'replay-petition', next_is: 'replay-email', back_is: 'sponsors', not_moving_is: 'replay-petition'
+            for_stage 'replay-email', next_is: 'replay-email', back_is: 'replay-petition', not_moving_is: 'replay-email'
+            # NOTE: ideally this would be 'replay-email', but we can't
+            # tell the difference between a 'creator' failure and a
+            # 'replay-email' failure if we started from 'done'.
+            # TODO: make it so we can?
+            for_stage 'done', next_is: 'creator', back_is: 'creator', not_moving_is: 'creator'
           end
         end
       end

--- a/spec/models/staged_petition_creator_spec.rb
+++ b/spec/models/staged_petition_creator_spec.rb
@@ -62,7 +62,7 @@ describe StagedPetitionCreator do
     end
 
     describe 'when the stage is not "done"' do
-      let(:stage) { 'submit' }
+      let(:stage) { 'replay-petition' }
 
       it 'returns false' do
         expect(subject.create_petition).to eq false
@@ -127,8 +127,8 @@ describe StagedPetitionCreator do
           context 'before attempting to create the petition' do
             for_stage 'petition', next_is: 'petition', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
-            for_stage 'sponsors', next_is: 'submit', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'submit', next_is: 'done', back_is: 'sponsors', not_moving_is: 'submit'
+            for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+            for_stage 'replay-petition', next_is: 'done', back_is: 'sponsors', not_moving_is: 'replay-petition'
             for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
           end
 
@@ -137,8 +137,8 @@ describe StagedPetitionCreator do
 
             for_stage 'petition', next_is: 'petition', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
-            for_stage 'sponsors', next_is: 'submit', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'submit', next_is: 'petition', back_is: 'sponsors', not_moving_is: 'submit'
+            for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+            for_stage 'replay-petition', next_is: 'petition', back_is: 'sponsors', not_moving_is: 'replay-petition'
             for_stage 'done', next_is: 'petition', back_is: 'petition', not_moving_is: 'petition'
           end
         end
@@ -149,8 +149,8 @@ describe StagedPetitionCreator do
           context 'before attempting to create the petition' do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'creator', back_is: 'petition', not_moving_is: 'creator'
-            for_stage 'sponsors', next_is: 'submit', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'submit', next_is: 'done', back_is: 'sponsors', not_moving_is: 'submit'
+            for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+            for_stage 'replay-petition', next_is: 'done', back_is: 'sponsors', not_moving_is: 'replay-petition'
             for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
           end
 
@@ -159,8 +159,8 @@ describe StagedPetitionCreator do
 
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'creator', back_is: 'petition', not_moving_is: 'creator'
-            for_stage 'sponsors', next_is: 'submit', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'submit', next_is: 'creator', back_is: 'sponsors', not_moving_is: 'submit'
+            for_stage 'sponsors', next_is: 'replay-petition', back_is: 'creator', not_moving_is: 'sponsors'
+            for_stage 'replay-petition', next_is: 'creator', back_is: 'sponsors', not_moving_is: 'replay-petition'
             for_stage 'done', next_is: 'creator', back_is: 'creator', not_moving_is: 'creator'
           end
         end
@@ -172,7 +172,7 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'sponsors', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'submit', next_is: 'done', back_is: 'sponsors', not_moving_is: 'submit'
+            for_stage 'replay-petition', next_is: 'done', back_is: 'sponsors', not_moving_is: 'replay-petition'
             for_stage 'done', next_is: 'done', back_is: 'done', not_moving_is: 'done'
           end
 
@@ -181,7 +181,7 @@ describe StagedPetitionCreator do
             for_stage 'petition', next_is: 'creator', back_is: 'petition', not_moving_is: 'petition'
             for_stage 'creator', next_is: 'sponsors', back_is: 'petition', not_moving_is: 'creator'
             for_stage 'sponsors', next_is: 'sponsors', back_is: 'creator', not_moving_is: 'sponsors'
-            for_stage 'submit', next_is: 'sponsors', back_is: 'sponsors', not_moving_is: 'submit'
+            for_stage 'replay-petition', next_is: 'sponsors', back_is: 'sponsors', not_moving_is: 'replay-petition'
             for_stage 'done', next_is: 'sponsors', back_is: 'sponsors', not_moving_is: 'sponsors'
           end
         end


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/94485374

1. Remove email_confirmation from creating and sigining a petition
2. Add a new step to the create process to replay the email address as the last step before submitting and allow the signer to make changes

Note: replaying the email while signing a petition will be dealt with in a future PR.