### PR TITLE
Remove system setting for GET_AN_MP_SIGNATURE_COUNT

### DIFF
--- a/db/seeds/system_settings.rb
+++ b/db/seeds/system_settings.rb
@@ -7,7 +7,3 @@
 SystemSetting.seed(SystemSetting::THRESHOLD_SIGNATURE_COUNT,
                    :description => "The threshold at which petitions are considered for debate in parliament",
                    :initial_value => "100000")
-
-SystemSetting.seed(SystemSetting::GET_AN_MP_SIGNATURE_COUNT,
-                   :description => "The threshold at which the creator is emailed to get an MP on board",
-                   :initial_value => "40000")


### PR DESCRIPTION
Removed this setting from system settings