### PR TITLE
Removal of the LinkedIn sharing icon

### DIFF
--- a/app/views/petitions/show.html.erb
+++ b/app/views/petitions/show.html.erb
@@ -72,9 +72,6 @@
           <%= link_to image_tag("icons/twitter.png"), "http://twitter.com/share?text=#{URI.escape(title)}&url=#{URI.escape(petition_url(@petition))}", :class => "text_link_plain" %>
         </div>
         <div class='share'>
-          <%= link_to image_tag("icons/linkedin.png"), "http://www.linkedin.com/shareArticle?mini=true&url=#{URI.escape(petition_url(@petition))}&title=#{URI.escape(title)}&source=HM+Government+e-petitions", :class => "text_link_plain" %>
-        </div>
-        <div class='share'>
           <%= link_to image_tag("icons/facebook.png"), "http://www.facebook.com/sharer.php?t=#{URI.escape(title)}&u=#{URI.escape(petition_url(@petition))}", :class => "text_link_plain" %>
         </div>
       </dd>


### PR DESCRIPTION
This was never used and was removed, not sure why it has crept back, but let's bin it.  I have left the image in the icon folder, justincase it gets super useful again in the future.