### PR TITLE
Resend email to unvalidated signature

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -24,7 +24,7 @@ class SignaturesController < ApplicationController
     if @signature.perishable_token == params[:token]
       @signature.perishable_token = nil
       @signature.state = Signature::VALIDATED_STATE
-      @signature.save(:validate => false)
+      @signature.save(:validate => false)    #WHY SKIPPING VALIDATIONS??
 
       # if signature is that of the petition's creator, mark the petition as validated
       if @signature.petition.creator_signature == @signature

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -27,7 +27,7 @@ class SignaturesController < ApplicationController
     if @signature.perishable_token == params[:token]
       @signature.perishable_token = nil
       @signature.state = Signature::VALIDATED_STATE
-      @signature.save(:validate => false)    #WHY SKIPPING VALIDATIONS??
+      @signature.save(:validate => false)
 
       # if signature is that of the petition's creator, mark the petition as validated
       if @signature.petition.creator_signature == @signature

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -12,13 +12,13 @@ class SignaturesController < ApplicationController
     @signature = Signature.new(signature_params_for_create)
     @signature.email.strip!
     @signature.petition = @petition
-    @tmp = check_if_unvalidated_exists(@signature)
-    if @tmp
-      send_email_to_petition_signer(@tmp)
-    elsif (@signature.save)
-      send_email_to_petition_signer(@signature)
+
+    matching_signatures = Signature.pending.matching(@signature)
+    if matching_signatures.any?
+      handle_existing_signatures(matching_signatures, @petition)
+    else
+      handle_new_signature(@signature, @petition)
     end
-    respond_with @signature, :location => thank_you_petition_signature_path(@petition)
   end
 
   def verify
@@ -66,11 +66,13 @@ class SignaturesController < ApplicationController
              :postcode, :country, :uk_citizenship)
   end
 
-  def check_if_unvalidated_exists(signature)
-    matcher = Signature.where(:encrypted_email => signature.encrypted_email,
-                              :name => signature.name, 
-                              :petition_id => signature.petition_id,
-                              :state => 'pending')
-    matcher.first if matcher.any?
+  def handle_existing_signatures(signatures, petition)
+    signatures.each { |sig| send_email_to_petition_signer(sig) }
+    redirect_to thank_you_petition_signature_path(petition)
+  end
+
+  def handle_new_signature(signature, petition)
+    send_email_to_petition_signer(signature) if signature.save
+    respond_with signature, :location => thank_you_petition_signature_path(petition)
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -62,11 +62,15 @@ class Signature < ActiveRecord::Base
 
   # = Finders =
   scope :validated, -> { where(state: VALIDATED_STATE) }
+  scope :pending, -> { where(state: PENDING_STATE) }
   scope :notify_by_email, -> { where(notify_by_email: true) }
   scope :need_emailing, ->(job_datetime) {
     validated.notify_by_email.where('last_emailed_at is null or last_emailed_at < ?', job_datetime)
   }
   scope :in_days, ->(number_of_days) { validated.where("updated_at > ?", number_of_days.day.ago) }
+  scope :matching, ->(signature) { where(encrypted_email: signature.encrypted_email,
+                                         name: signature.name, 
+                                         petition_id: signature.petition_id) }
 
   # = Methods =
   attr_accessor :uk_citizenship

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -86,5 +86,4 @@ class Signature < ActiveRecord::Base
   def postal_district
     postcode.upcase[0..-4].match(/[A-Z]{1,2}[0-9]{1,2}[A-Z]?/).to_s
   end
-
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -38,19 +38,15 @@ class Signature < ActiveRecord::Base
     matcher = matcher.where("signatures.id != ?", signature.id) unless signature.new_record?
     existing_email_address_count = matcher.count
     next if existing_email_address_count == 0
-    # if 2 or more sigs already exist for this email
     if existing_email_address_count > 1
       signature.errors.add(:email, 'This email address is not allowed to sign this petition again')
       next
     end
-    #grab the signature
     existing_signature =  matcher.first
-    #if signature with this name already exists
     if (existing_signature.name.strip.downcase == signature.name.strip.downcase)
       signature.errors.add(:email, 'You cannot sign this petition again')
       next
     end
-    #checking the postcode for people living at same address
     if (existing_signature.postcode.gsub(/\s+/,'').downcase !=
         signature.postcode.gsub(/\s+/,'').downcase)
       signature.errors.add(:email, 'This email address is not allowed to sign this petition again')

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -38,15 +38,19 @@ class Signature < ActiveRecord::Base
     matcher = matcher.where("signatures.id != ?", signature.id) unless signature.new_record?
     existing_email_address_count = matcher.count
     next if existing_email_address_count == 0
+    # if 2 or more sigs already exist for this email
     if existing_email_address_count > 1
       signature.errors.add(:email, 'This email address is not allowed to sign this petition again')
       next
     end
+    #grab the signature
     existing_signature =  matcher.first
+    #if signature with this name already exists
     if (existing_signature.name.strip.downcase == signature.name.strip.downcase)
       signature.errors.add(:email, 'You cannot sign this petition again')
       next
     end
+    #checking the postcode for people living at same address
     if (existing_signature.postcode.gsub(/\s+/,'').downcase !=
         signature.postcode.gsub(/\s+/,'').downcase)
       signature.errors.add(:email, 'This email address is not allowed to sign this petition again')

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -52,12 +52,23 @@ When /^I fill in my details$/ do
 end
 
 And "I have already signed the petition with an uppercase email" do
-  FactoryGirl.create(:signature, :petition => @petition, :email => "WOMBOID@WIMBLEDON.COM")
+  FactoryGirl.create(:signature, name: "Womboid Wibbledon", :petition => @petition,
+                     :email => "WOMBOID@WIMBLEDON.COM")
+end
+
+And "I have already signed the petition but not validated my email" do
+  FactoryGirl.create(:pending_signature, name: "Womboid Wibbledon", :petition => @petition,
+                     :email => "womboid@wimbledon.com")
 end
 
 Given /^Suzie has already signed the petition$/ do
   FactoryGirl.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
          :postcode => "SW14 9RQ", :name => "Womboid Wibbledon")
+end
+
+Given /^Eric has already signed the petition with Suzies email$/ do
+  FactoryGirl.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
+         :postcode => "SW14 9RQ", :name => "Eric Wibbledon")
 end
 
 Given /^I have signed the petition with a second name$/ do

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -39,14 +39,29 @@ Feature: Suzie signs a petition
     And I try to sign
     Then I should see an error
 
-  Scenario: Suzie cannot sign if she has already signed
-    And I have already signed the petition with an uppercase email
-    When I decide to sign the petition
+  Scenario: Suzie cannot sign if she has already signed and validated
+    When I have already signed the petition with an uppercase email
+    And I decide to sign the petition
     And I fill in my details
     And I try to sign
     Then I should see an error
+
+  Scenario: Suzie receives another email if she has already signed but not validated
+    When I have already signed the petition but not validated my email
+    And I decide to sign the petition
+    And I fill in my details
+    And I try to sign
+    Then "womboid@wimbledon.com" should receive 1 email
+
+  Scenario: Suzie receives an email if her email has been used to sign the petition already
+    When Eric has already signed the petition with Suzies email
+    And I decide to sign the petition
+    And I fill in my details
+    And I try to sign
+    Then "womboid@wimbledon.com" should receive 1 email
 
   Scenario: Suzie cannot sign if she does not provide her details
     When I decide to sign the petition
     And I try to sign
     Then I should see an error
+    

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -175,13 +175,13 @@ describe SignaturesController do
           expect(response).to redirect_to(thank_you_petition_signature_path(petition))
         end
       end
-      
+
       context "invalid input" do
         it "renders :new again for empty email" do
           do_post(:email => "")
           expect(response).to render_template(:new)
         end
-        
+
         it "should not create a new signature" do
           expect { do_post(:email => "") }.not_to change(Signature, :count)
         end
@@ -192,33 +192,29 @@ describe SignaturesController do
       ### good way to split up the contexts?
       ### how to make one assertion per test? email and redirect are currently linked?
       context "signature with same name/email/postcode" do
-        let(:custom_params) {{ name: 'Joe Blow', email: 'jb@example.com',
-                               email_confirmation: 'jb@example.com', postcode: 'SE3 4LL' }}
-        let(:unvalidated_signature) { FactoryGirl.build(:pending_signature, name: 'Joe Blow', email:'jb@example.com',
-                                                        email_confirmation:'jb@example.com', postcode: 'SE3 4LL',
-                                                        petition_id: petition.id) }
-        let(:validated_signature) { FactoryGirl.build(:validated_signature, name: 'Joe Blow', email:'jb@example.com',
-                                                      email_confirmation:'jb@example.com', postcode: 'SE3 4LL',
-                                                      petition_id: petition.id) }
-        
+        let(:custom_params) {{ name: 'Joe Blow', email: 'jb@example.com', postcode: 'SE3 4LL' }}
+
         context "unvalidated signature already exists" do
-          before { unvalidated_signature.save }
-          
+          before do
+            FactoryGirl.create(:pending_signature, name: 'Joe Blow', email:'jb@example.com',
+                               postcode: 'SE3 4LL', petition_id: petition.id)
+          end
+
           it "same name/email/postcode does not change count of signatures" do
             expect{ do_post(custom_params) }.to_not change(Signature, :count)
           end
-          
+
           it "same email/postcode changes count of signatures" do
             expect{ do_post(custom_params.merge( { name: 'Susan Blow' })) }.to change(Signature, :count).by(1)
           end
-          
+
           it "sends email to signer" do
             ActionMailer::Base.deliveries.clear
             do_post(custom_params)
             email = ActionMailer::Base.deliveries.last
             expect(email.to).to eq(["jb@example.com"])
           end
-          
+
           it "sends to thank you page" do
             do_post(custom_params)
             expect(response).to redirect_to(thank_you_petition_signature_path(petition))
@@ -226,8 +222,11 @@ describe SignaturesController do
         end
 
         context "validated signature already exists" do
-          before { validated_signature.save }
-          
+          before do
+            FactoryGirl.create(:validated_signature, name: 'Joe Blow', email:'jb@example.com',
+                               postcode: 'SE3 4LL', petition_id: petition.id)
+          end
+
           it "sends to :new for same name/email/postcode" do
             do_post(custom_params)
             expect(response).to render_template(:new)

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -194,7 +194,7 @@ describe SignaturesController do
       context "signature with same name/email/postcode" do
         let(:custom_params) {{ name: 'Joe Blow', email: 'jb@example.com',
                                email_confirmation: 'jb@example.com', postcode: 'SE3 4LL' }}
-        let(:unvalidated_signature) { FactoryGirl.build(:signature, name: 'Joe Blow', email:'jb@example.com',
+        let(:unvalidated_signature) { FactoryGirl.build(:pending_signature, name: 'Joe Blow', email:'jb@example.com',
                                                         email_confirmation:'jb@example.com', postcode: 'SE3 4LL',
                                                         petition_id: petition.id) }
         let(:validated_signature) { FactoryGirl.build(:validated_signature, name: 'Joe Blow', email:'jb@example.com',
@@ -202,9 +202,7 @@ describe SignaturesController do
                                                       petition_id: petition.id) }
         
         context "unvalidated signature already exists" do
-          before do
-            unvalidated_signature.save
-          end
+          before { unvalidated_signature.save }
           
           it "same name/email/postcode does not change count of signatures" do
             expect{ do_post(custom_params) }.to_not change(Signature, :count)
@@ -228,10 +226,7 @@ describe SignaturesController do
         end
 
         context "validated signature already exists" do
-
-          before do
-            validated_signature.save
-          end
+          before { validated_signature.save }
           
           it "sends to :new for same name/email/postcode" do
             do_post(custom_params)

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -278,11 +278,38 @@ describe Signature do
       end
     end
 
+    context "pending" do
+      it "should return only pending signatures" do
+        signatures = Signature.pending
+        expect(signatures.size).to eq(1)
+        expect(signatures).to include(signature2)
+      end
+    end
+    
     context "need emailing" do
       it "should return only validated signatures who have opted in to receiving email updates" do
         expect(Signature.need_emailing(Time.now)).to include(signature1, signature3, signature4, petition.creator_signature)
         expect(Signature.need_emailing(two_days_ago)).to include(signature1, signature3, petition.creator_signature)
         expect(Signature.need_emailing(week_ago)).to include(signature1, petition.creator_signature)
+      end
+    end
+
+    context "matching" do
+      let!(:signature1) { FactoryGirl.create(:signature, name: "Joe Public", email: "person1@example.com", petition: petition, state: Signature::VALIDATED_STATE, last_emailed_at: nil) }
+      
+      it "should return a signature matching in name, email and petition_id" do
+        signature = FactoryGirl.build(:signature, name: "Joe Public", email: "person1@example.com", petition: petition)
+        expect(Signature.matching(signature)).to include(signature1)
+      end
+
+      it "should not return a signature matching in name, email and different petition" do
+        signature = FactoryGirl.build(:signature, name: "Joe Public", email: "person1@example.com", petition_id: 2)
+        expect(Signature.matching(signature)).to_not include(signature1)
+      end
+
+      it "should not return a signature matching in email, petition and different name" do
+        signature = FactoryGirl.build(:signature, name: "Josey Public", email: "person1@example.com", petition: petition)
+        expect(Signature.matching(signature)).to_not include(signature1)
       end
     end
 


### PR DESCRIPTION
Have edited the create method in the signature controller to check if any matching signatures (with the form details) already exist and if yes, resend the email.

Otto helped me massively with the refactor but would still love to get some feedback. Thanks!