### PR TITLE
Update email regex logic in javascript files that handling feedback and signature forms

### DIFF
--- a/public/javascripts/form_controller.js
+++ b/public/javascripts/form_controller.js
@@ -350,6 +350,6 @@ E_PETS.FormController.validation_methods = {
 };
 
 E_PETS.FormController.validation_formats = {
-  email: /^([A-Za-z0-9_\.%\+\-\'])+\@([A-Za-z0-9\-\.])+\.([A-Za-z]{2,4})$/,
+  email: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
   postcode: /^(([A-Z]{1,2}[0-9][0-9A-Z]? ?[0-9][A-BD-HJLNP-UW-Z]{2})|(BFPO? ?(C\/O)? ?[0-9]{1,4}))$/i
 };

--- a/spec/javascripts/form_controller_spec.js
+++ b/spec/javascripts/form_controller_spec.js
@@ -44,6 +44,9 @@ describe('validation methods', function() {
     it ('matches a regular email address', function() {
       expect('foo@bar.com').toBeValidEmailAddress();
     });
+    it ('matches an email address with long tld', function() {
+      expect('foo@bar.averylongtldname').toBeValidEmailAddress();
+    });
     it ('rejects two @s', function() {
       expect('foo@bar@baz.com').not.toBeValidEmailAddress();
     });


### PR DESCRIPTION
This is to fix javascript forms that were still having old regex logic for email validation.