### PR TITLE
Avoid short-circuiting ``valid?`` in Staged models

### DIFF
--- a/app/models/staged/petition_creator/has_creator_signature.rb
+++ b/app/models/staged/petition_creator/has_creator_signature.rb
@@ -4,13 +4,13 @@ module Staged
       extend ActiveSupport::Concern
 
       included do
-        def valid?
-          super && creator_signature_valid?
-        end
+        validate :creator_signature_valid?
 
         def creator_signature
           @_creator_signature ||= self.class::CreatorSignature.new(petition)
         end
+
+        private
 
         def creator_signature_valid?
           if creator_signature.valid?

--- a/app/models/staged/petition_creator/sponsors.rb
+++ b/app/models/staged/petition_creator/sponsors.rb
@@ -9,9 +9,7 @@ module Staged
         :create
       end
 
-      def valid?
-        super && sponsors_valid?
-      end
+      validate :sponsors_valid?
 
       private
 


### PR DESCRIPTION
In the classes where we have overridden ``valid?`` to also validate a child object (the ``HasCreatorSignature`` mixin and ``Sponsors`` model) we were doing:

    def valid?
      super && some_other_method_that_calls_valid_on_a_child_object
    end

The problem here is that if ``super`` returned false we short-circuit the expression and don't run the other method and so don't validate the child object.  Instead we use ``validate`` to call the other method as part of the standard validation process.

In practice it wasn't a problem as I neither of the affected classes had any validations on the "parent" so ``super`` would never fail.  However it's not a good pattern to leave lying around.