### PR TITLE
Adding a cookies page

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  caches_page :accessibility, :how_it_works, :terms_and_conditions, :privacy_policy
+  caches_page :accessibility, :how_it_works, :terms_and_conditions, :cookies, :privacy_policy
   caches_action :home, :expires_in => 5.minutes
 
   def home

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,10 @@
               t.links_to accessibility_path
             end            
             n.add_tab do |t|
+              t.named 'Cookies'
+              t.links_to cookies_path
+            end
+            n.add_tab do |t|
               t.named 'Privacy'
               t.links_to privacy_policy_path
             end

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,0 +1,91 @@
+<% content_for(:page_title) { "Cookies" } %>
+<div class="title_block">
+  <h1>Cookies</h1>
+</div>
+
+<div class="generic_text_block">
+
+  <p>This website puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.</p>
+
+  <p>Cookies are used to:</p>
+
+  <ul>
+    <li>measure how you use the petitions service so it can be updated and improved based on your needs</li>
+    <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+  </ul>
+
+  <p>These cookies aren’t used to identify you personally.</p>
+
+  <p>Find out more about <a rel="external" href="http://www.aboutcookies.org/">how to manage cookies.</a></p>  
+
+  <h2>Google Analytics cookies</h2>
+
+  <p>We use Google Analytics to collect information about how you use the service. This information helps us to improve the service.</p>
+  <p>The Google analytics cookie collects and stores information about:</p>
+
+  <ul>
+      <li>the pages you visit - how long you spend on each page</li>
+      <li>how you got to the service</li>
+      <li>what you click on while you’re using the service</li>
+  </ul>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>_utma</td>
+        <td>This lets us know if you’ve visited before, so we can count how many of our visitors are new to the petitions service or to a certain page</td>            
+        <td>2 years</td>
+      </tr>
+      <tr>
+        <td>_utmb</td>
+        <td>This works with _utmc to calculate the average length of time you spend on the petitions service</td>
+        <td>30 minutes</td>
+      </tr>
+      <tr>
+        <td>_utmc</td>
+        <td>This works with _utmb to calculate when you close your browser</td>
+        <td>When you close your browser</td>
+      </tr>
+      <tr>
+        <td>_utmt</td>
+        <td>This tells us about events as you use the service</td>
+        <td>10 minutes</td>
+      </tr>
+      <tr>
+        <td>_utmz</td>
+        <td>This tells us how you reached the petitions service (like from another website or a search engine)</td>
+        <td>6 months</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>Google isn’t allowed to use or share our analytics data with anyone, but you can opt out of Google Analytics cookies.</p>
+
+  <h2>Session cookies</h2>
+  <p>We store a session cookie on your computer to help keep your information secure while you use the service.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>_epets_session</td>
+        <td>This keeps your information secure while you use the petitions service</td>
+        <td>When you close your browser</td>
+      </tr>
+    </tbody>
+  </table>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'accessibility' => 'static_pages#accessibility', :as => 'accessibility'
   get 'how-it-works' => 'static_pages#how_it_works', :as => 'how_it_works'
   get 'terms-and-conditions' => 'static_pages#terms_and_conditions', :as => 'terms_and_conditions'
+  get 'cookies' => 'static_pages#cookies', :as => 'cookies'
   get 'privacy-policy' => 'static_pages#privacy_policy', :as => 'privacy_policy'
 
   get 'feedback' => 'feedback#index', :as => 'feedback'

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -20,6 +20,9 @@ module NavigationHelpers
     when /^the terms and conditions page$/
       terms_and_conditions_path
 
+    when /^the cookies page$/
+      cookies_path
+
     when /^the privacy policy page$/
       privacy_policy_path
 

--- a/features/user_sees_static_stuff.feature
+++ b/features/user_sees_static_stuff.feature
@@ -1,6 +1,6 @@
 Feature: User views static pages
   In order to let users know about the site
-  I can navigate to how E-petitions works, terms and conditions, privacy and accessibility pages
+  I can navigate to how E-petitions works, terms and conditions, cookies, privacy and accessibility pages
 
   Scenario: I navigate to the home page
     When I go to the home page
@@ -23,6 +23,13 @@ Feature: User views static pages
     And I should see "Terms and conditions - e-petitions" in the browser page title
     And the markup should be valid
 
+  Scenario: I navigate to Cookies
+    When I go to the home page
+    And I follow "Cookies"
+    Then I should be on the cookies page
+    And I should see "Cookies" in the browser page title
+    And the markup should be valid
+    
   Scenario: I navigate to Privacy
     When I go to the home page
     And I follow "Privacy"

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -28,4 +28,10 @@ describe StaticPagesController do
       expect(privacy_policy_path).to eq "/privacy-policy"
     end
   end
+  describe "cookies" do
+    it "should respond to /cookies" do
+      expect({:get => "/cookies"}).to route_to({:controller => "static_pages", :action => "cookies"})
+      expect(cookies_path).to eq "/cookies"
+    end
+  end  
 end


### PR DESCRIPTION
As per: https://www.pivotaltracker.com/story/show/95040606

This PR adds the new cookie page with *probably* correct content, then adds it into all the usual places routes and adds a couple of tests.