### PR TITLE
Pre-creation searching petitions results limited to 3 ones

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -40,7 +40,6 @@ class PetitionsController < ApplicationController
   def check_results
     search_params = params
     search_params[:q] = search_params[:search]
-    search_params[:per_page] = 10
     @petition_search = PetitionSearch.new(search_params)
   end
 

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -9,15 +9,13 @@
 <%= render "pre_creation_search_form" %>
 
 <div class="petition_index_view">
-  <%= render 'search/result_tabs' %>
-  <div class="petition_list">
-    <% if @petition_search.present? -%>
-      <div class="title_pagination_row"></div>
-      <%= render 'search/results_table', :petition_search => @petition_search %>
+  <div class="petition_pre_create_results">
+    <% if @petition_search.limited_results_for_create_petition_search.present? %>
+      <%= render 'search/results_for_pre_create_petition', petition_search: @petition_search %>
       <% creation_prefix = "If there are no existing e-petitions on the same subject, click the 'Create e-petition' button to continue." -%>
-    <% else -%>
+    <% else %>
       <p class="no_petitions_warning">We didn't find any existing e-petitions that match your subject, click the 'Create e-petition' button to continue.</p>
-    <% end -%>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/search/_results_for_pre_create_petition.html.erb
+++ b/app/views/search/_results_for_pre_create_petition.html.erb
@@ -1,0 +1,12 @@
+<% petition_search.limited_results_for_create_petition_search.each do |petition| %>
+  <ul>
+    <li>
+      <%= link_to petition.title, petition_path(petition), class: 'link_prompt text_link' %>
+    </li>
+    <% if petition.state != Petition::REJECTED_STATE -%>
+      <li><%= number_with_delimiter(petition.signature_count) %> signatures</li>
+    <% end %>
+    <li><%= petition.closed? ? "closed" : petition.state %></li>
+    <li><%= petition.action %></li>
+  </ul>
+<% end %>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1193,6 +1193,15 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#96258e', end
   margin: 60px 60px 40px;
 }
 
+.petition_pre_create_results {
+  font-size: 1.5em;
+  margin: 60px 60px 40px;
+}
+
+.petition_pre_create_results ul {
+    padding-top: 30px
+}
+
 /* How it works page */
 .how_it_works {
   text-align: center;


### PR DESCRIPTION
So I've updated this PR as we're actually removing the petition state tabs for that particular search (thanks @otlaitil for look-out) and generally provide one view results. I've tried to follow what we're currently having in a design, meaning removing table, adding petition description, but not being very exact with styling as we're saying goodbye to the current css

PT: https://www.pivotaltracker.com/story/show/93884116