### PR TITLE
Add petition action in all the places

### DIFF
--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -17,7 +17,11 @@
 </div>
 
 <div class="row">
+  <label>Petition action:</label>
+  <p class="text_block"><%= raw auto_link(h(@petition.action), :html => { :target => '_blank' }) %></p>
+</div>
+
+<div class="row">
   <label>Petition description:</label>
   <p class="text_block"><%= raw auto_link(h(@petition.description), :html => { :target => '_blank' }) %></p>
 </div>
-

--- a/app/views/petitions/show.html.erb
+++ b/app/views/petitions/show.html.erb
@@ -12,7 +12,8 @@
 <div class="petition_view">
   <div class="content">
     <h1><%= @petition.title %></h1>
-    <p class='description'><%= raw auto_link(simple_format(h(@petition.description)), :html => { :target => '_blank' }) %></p>
+    <div class='action'><%= raw auto_link(simple_format(h(@petition.action)), :html => { :target => '_blank' }) %></div>
+    <div class='description'><%= raw auto_link(simple_format(h(@petition.description)), :html => { :target => '_blank' }) %></div>
 
     <% if @petition.rejected? -%>
       <div class="petition_rejected">

--- a/app/views/sponsor_mailer/new_sponsor_email.html.erb
+++ b/app/views/sponsor_mailer/new_sponsor_email.html.erb
@@ -6,8 +6,8 @@ If you're happy to support this petition, please follow the link below to
 provide a few details additional details.
 </p>
 <%=
-  url = petition_sponsor_url(@sponsor.petition, token: @sponsor.perishable_token, :secure => true)
-  link_to url, url
+  link_to nil, petition_sponsor_url(@sponsor.petition, token: @sponsor.perishable_token, :protocol => 'https')
 %>
 <p><%= @sponsor.petition.title  %></p>
+<p><%= @sponsor.petition.action  %></p>
 <p><%= @sponsor.petition.description  %></p>

--- a/app/views/sponsor_mailer/new_sponsor_email.text.erb
+++ b/app/views/sponsor_mailer/new_sponsor_email.text.erb
@@ -7,9 +7,11 @@ If you're happy to support this petition, please follow the link below to
 provide a few details additional details.
 
 <%=
-  petition_sponsor_url(@sponsor.petition, token: @sponsor.perishable_token, :secure => true)
+  petition_sponsor_url(@sponsor.petition, token: @sponsor.perishable_token, :protocol => 'https')
 %>
 
 <%= @sponsor.petition.title  %>
+
+<%= @sponsor.petition.action  %>
 
 <%= @sponsor.petition.description  %>

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -4,11 +4,12 @@ Feature: Moderator respond to petition
   I want to respond to a petition, accepting, rejecting or re-assigning it
 
   Scenario: Accessing the petitions page
-    Given a sponsored petition exists with title: "More money for charities"
+    Given a sponsored petition "More money for charities"
     And I am logged in as a sysadmin
     When I go to the admin moderate petitions page for "More money for charities"
     Then I should be connected to the server via an ssl connection
     And the markup should be valid
+    And I should see the petition details
 
   Scenario: Moderator publishes petition
     Given I am logged in as a moderator

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -93,6 +93,7 @@ end
 
 Then /^I should see the petition details$/ do
   expect(page).to have_content(@petition.title)
+  expect(page).to have_content(@petition.action)
   expect(page).to have_content(@petition.description)
 end
 

--- a/spec/mailers/sponsor_mailer_spec.rb
+++ b/spec/mailers/sponsor_mailer_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe SponsorMailer do
+  let :creator do
+    FactoryGirl.create(:validated_signature, name: "Barry Butler", email: "bazbutler@gmail.com")
+  end
+
+  let :petition do
+    FactoryGirl.create(:pending_petition,
+      creator_signature: creator,
+      title: "Allow organic vegetable vans to use red diesel",
+      action: "Add vans to permitted users of red diesel",
+      description: "To promote organic vegetables"
+    )
+  end
+
+  let :sponsor do
+    FactoryGirl.create(:sponsor, email: "allyadams@outlook.com", petition: petition)
+  end
+
+  subject :mail do
+    described_class.new_sponsor_email(sponsor)
+  end
+
+  describe "#new_sponsor_email" do
+    it "has the correct subject" do
+      expect(mail.subject).to eq("Parliament petitions - Barry Butler would like your support")
+    end
+
+    it "sends it to the sponsor" do
+      expect(mail.to).to eq(%w[allyadams@outlook.com])
+    end
+
+    it "sends a copy to the creator" do
+      expect(mail.cc).to eq(%w[bazbutler@gmail.com])
+    end
+
+    it "includes the creator's name in the body" do
+      expect(mail.body.encoded).to match(%r[Barry Butler])
+    end
+
+    it "includes the petition sponsor url" do
+      expect(mail.body.encoded).to match(%r[https://www.example.com/petitions/#{petition.id}/sponsors/#{sponsor.perishable_token}])
+    end
+
+    it "includes the petition title" do
+      expect(mail.body.encoded).to match(%r[Allow organic vegetable vans to use red diesel])
+    end
+
+    it "includes the petition action" do
+      expect(mail.body.encoded).to match(%r[Add vans to permitted users of red diesel])
+    end
+
+    it "includes the petition subject" do
+      expect(mail.body.encoded).to match(%r[To promote organic vegetables])
+    end
+  end
+end


### PR DESCRIPTION
This adds the petition action to the admin petition details partial, the
public petition page and the new sponsor email templates.

https://www.pivotaltracker.com/story/show/95039588