### PR TITLE
Force by_role scope to be ordered by id

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -52,7 +52,7 @@ class AdminUser < ActiveRecord::Base
 
   # = Finders =
   scope :by_name, -> { order(:last_name, :first_name) }
-  scope :by_role, ->(role) { where(role: role) }
+  scope :by_role, ->(role) { where(role: role).order(:id) }
 
   # = Methods =
 


### PR DESCRIPTION
When no ORDER BY clause is specified in SQL then there is no guarantee
of the order of the returned records. This was causing intermittent
failures in the email_reminder_spec.rb file because of the order of the
arguments passed to the AdminMailer.threshold_email_reminder method

This fixes those intermittent failures by forcing the by_role scope to
always return users ordered by id.