### PR TITLE
Don't display validated petitions as trending

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -75,6 +75,7 @@ class Petition < ActiveRecord::Base
   scope :moderated, -> { where(state: MODERATED_STATES) }
   scope :trending, ->(number_of_days) {
                       joins(:signatures).
+                      where("petitions.state" => "open").
                       where("signatures.state" => "validated").
                       where("signatures.updated_at > ?", number_of_days.day.ago).
                       order("count('signatures.id') DESC").
@@ -83,6 +84,7 @@ class Petition < ActiveRecord::Base
   scope :last_hour_trending, -> {
                               joins(:signatures).
                               select("petitions.*, count('signatures.id') as signatures_in_last_hour").
+                              where("petitions.state" => "open").
                               where("signatures.state" => "validated").
                               where("signatures.updated_at > ?", 1.hour.ago).
                               order("signatures_in_last_hour DESC").

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -198,6 +198,13 @@ describe Petition do
 
         expect(Petition.last_hour_trending.to_a.size).to eq(3)
       end
+
+      it "excludes petitions that are not open" do
+        petition = FactoryGirl.create(:validated_petition)
+        20.times{ FactoryGirl.create(:validated_signature, :petition => petition) }
+
+        expect(Petition.last_hour_trending.to_a).not_to include(petition)
+      end
     end
 
     describe "trending" do
@@ -230,6 +237,15 @@ describe Petition do
       context "finding trending petitions for the last 7 days" do
         it "includes the petition with older signatures" do
           expect(Petition.trending(7).map(&:title).include?(@petition_with_old_signatures.title)).to be_truthy
+        end
+      end
+
+      context "when there are validated petitions" do
+        it "excludes petitions that are not open" do
+          petition = FactoryGirl.create(:validated_petition)
+          20.times{ FactoryGirl.create(:validated_signature, :petition => petition) }
+
+          expect(Petition.trending(1).to_a).not_to include(petition)
         end
       end
     end


### PR DESCRIPTION
If a petition has been signed by the sponsors but not yet moderated then
it shouldn't appear in the trending petitions list and report.

https://www.pivotaltracker.com/story/show/95404898