### PR TITLE
Add constituency info to signature signed page

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,6 +1,6 @@
 class SignaturesController < ApplicationController
   before_filter :retrieve_petition, :only => [:new, :create, :thank_you, :signed]
-  before_filter :retrieve_signature, :only => [:signed]
+  before_filter :retrieve_signature, :only => [:signed, :verify, :unsubscribe]
   include ActionView::Helpers::NumberHelper
 
   respond_to :html
@@ -21,7 +21,6 @@ class SignaturesController < ApplicationController
   end
 
   def verify
-    @signature = Signature.find(params[:id])
     @petition = @signature.petition
 
     if @signature.validate_from_token!(params[:token])
@@ -51,13 +50,12 @@ class SignaturesController < ApplicationController
   end
 
   def unsubscribe
-    signature = Signature.find(params[:id])
-    if signature.unsubscribe_token != params[:unsubscribe_token]
+    if @signature.unsubscribe_token != params[:unsubscribe_token]
       render 'signatures/unsubscribe/failed_to_unsubscribe'
-    elsif signature.unsubscribed?
+    elsif @signature.unsubscribed?
       render 'signatures/unsubscribe/already_unsubscribed'
     else
-      signature.unsubscribe!
+      @signature.unsubscribe!
       render 'signatures/unsubscribe/successfully_unsubscribed'
     end
   end

--- a/app/views/signatures/new.html.erb
+++ b/app/views/signatures/new.html.erb
@@ -6,6 +6,6 @@
   <h1 class="petition_title"><%= @petition.title %></h1>
 </div>
 
-<%= form_for @stage_manager.stage_object, :url => sign_petition_signature_path, :html => {:class => 'wizard_form new_petition_form'} do |f| %>
+<%= form_for @stage_manager.stage_object, :url => sign_petition_signatures_path, :html => {:class => 'wizard_form new_petition_form'} do |f| %>
   <%= render_signature_form @stage_manager, f %>
 <% end -%>

--- a/app/views/signatures/signed.html.erb
+++ b/app/views/signatures/signed.html.erb
@@ -9,4 +9,11 @@
   <p>Your signature has now been added to this e-petition.</p>
 
   <%= link_to "Click here to view the e-petition", petition_path(@petition), :class => 'link_button large_link_button return_to_homepage_button' %>
+
+  <% if @signature.constituency %>
+  <p>
+    Your constituency is <%= @signature.constituency.name %>
+  </p>
+  <% end %>
+  
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,10 +22,10 @@ Rails.application.routes.draw do
       get 'sponsored', on: :member
     end
 
-    resource :signature, :only => [:new] do
-      post 'new' => 'signatures#create', :as => :sign
+    resources :signatures, :only => [:new] do
+      post 'new' => 'signatures#create', :as => :sign, :on => :collection
       get 'thank-you', :action => :thank_you, :on => :collection, :as => :thank_you
-      get 'signed', :action => :signed, :on => :collection, :as => :signed
+      get 'signed', :action => :signed, :on => :member, :as => :signed
     end
   end
 

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -68,7 +68,7 @@ end
 When(/^I fill in my postcode with "(.*?)"$/) do |postcode|
   step %{I fill in "Postcode" with "#{postcode}"}
 
-  api_url = "http://data.parliament.uk/membersdataplatform/services/mnis/Constituencies"
+  api_url = ConstituencyApi::Client::URL
   body = "<Constituencies/>"
   if postcode == "N1 1TY"
     body = "<Constituencies>

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -13,6 +13,7 @@ Feature: Suzie signs a petition
     And the markup should be valid
     And I should be connected to the server via an ssl connection
     And I fill in my details with email "womboid@wimbledon.com"
+    And I fill in my postcode with "N1 1TY"
     And I try to sign
     Then I am asked to review my email address
     When I change my email address to "womboidian@wimbledon.com"
@@ -22,10 +23,24 @@ Feature: Suzie signs a petition
     And "womboidian@wimbledon.com" should receive 1 email
     When I confirm my email address
     Then I am taken to a landing page
+    And I should see my constituency "Islington South and Finsbury"	
     And I can click on a link to return to the petition
     And I should have signed the petition
 
-  @javascript
+  Scenario: Suzie signs a petition with invalid postcode SW14 9RQ
+    When I go to the new signature page for "Do something!"
+    And I fill in my details with email "womboid@wimbledon.com"
+    And I fill in my postcode with "SW14 9RQ"
+    And I try to sign
+    Then I am asked to review my email address
+    And I say I am happy with my email address
+    Then I have not yet signed the petition
+    And "womboid@wimbledon.com" should receive 1 email
+    When I confirm my email address
+    Then I am taken to a landing page
+    And I should not see the text "Your constituency is"
+
+    @javascript
   Scenario: Suzie signs a petition after validating her email (javascript run-through)
     When I decide to sign the petition
     And I fill in my details

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -5,6 +5,16 @@ describe SignaturesController do
     context "signature of user who is not the petition's creator" do
       let(:petition) { FactoryGirl.create(:petition) }
       let(:signature) { FactoryGirl.create(:pending_signature, :petition => petition) }
+      let(:api_url) { "http://data.parliament.uk/membersdataplatform/services/mnis/Constituencies" }
+      let(:fake_body) {
+        "<Constituencies>
+        <Constituency><Name>Cities of London and Westminster</Name></Constituency>
+       </Constituencies>"
+      }
+      
+      before do
+        stub_request(:get, "#{ api_url }/SW1A1AA/").to_return(status: 200, body: fake_body)
+      end
 
       it "should respond to /signatures/:id/verify/:token" do
         expect({:get => "/signatures/#{signature.id}/verify/#{signature.perishable_token}"}).
@@ -15,7 +25,7 @@ describe SignaturesController do
       it "should redirect to the petition signed page" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(assigns[:signature]).to eq(signature)
-        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{signature.petition_id}/signature/signed")
+        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{signature.petition_id}/signatures/#{signature.id}/signed")
       end
 
       it "should not set petition state to validated" do
@@ -219,7 +229,7 @@ describe SignaturesController do
 
       it "redirects to a thank you page" do
         do_post
-        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/signature/thank-you")
+        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/signatures/thank-you")
       end
     end
 
@@ -298,7 +308,7 @@ describe SignaturesController do
 
         it "sends to thank you page" do
           do_post
-          expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/signature/thank-you")
+          expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/signatures/thank-you")
         end
       end
 

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -5,7 +5,7 @@ describe SignaturesController do
     context "signature of user who is not the petition's creator" do
       let(:petition) { FactoryGirl.create(:petition) }
       let(:signature) { FactoryGirl.create(:pending_signature, :petition => petition) }
-      let(:api_url) { "http://data.parliament.uk/membersdataplatform/services/mnis/Constituencies" }
+      let(:api_url) { ConstituencyApi::Client::URL }
       let(:fake_body) {
         "<Constituencies>
         <Constituency><Name>Cities of London and Westminster</Name></Constituency>


### PR DESCRIPTION
For the constituency info to appear on the signed page, I had to enable member
routes for the signed signature to access the signature's postcode. Eager to hear
alternative/better approaches of how to achieve this!