### PR TITLE
Removing duplicate crown copyright link from footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,10 +15,6 @@
         t.links_to help_path
       end
       n.add_tab do |t|
-        t.named 'Crown copyright'
-        t.links_to "http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"
-      end
-      n.add_tab do |t|
         t.named 'Feedback'
         t.links_to feedback_path
       end


### PR DESCRIPTION
Application of new design, now renders the previous crown copyright link redundant.