### PR TITLE
Fix require of Rails spec helper

### DIFF
--- a/spec/models/rejection_reason_spec.rb
+++ b/spec/models/rejection_reason_spec.rb
@@ -1,7 +1,6 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'rails_helper'
 
 describe RejectionReason do
-
   describe "#options_for_select" do
     it "should load the reasons and codes from the rejection reasons file" do
       expect(RejectionReason.options_for_select.size).to eq(6)


### PR DESCRIPTION
There's no need to do a relative require as the load paths are setup correctly.