### PR TITLE
Fix hrefs on favicon links

### DIFF
--- a/app/views/shared/_icons.html.erb
+++ b/app/views/shared/_icons.html.erb
@@ -1,27 +1,27 @@
 <!-- Desktop Browsers -->
-<link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
 
 <!-- Android: Chrome M39 and up-->
-<link rel="manifest" href="manifest.json">
+<link rel="manifest" href="/manifest.json">
 
 <!-- Android: Chrome M31 and up, ignored if manifest is present-->
 <meta name="mobile-web-app-capable" content="yes">
-<link rel="icon" sizes="192x192" href="images/android-icons/icon-192x192.png">
+<link rel="icon" sizes="192x192" href="/images/android-icons/icon-192x192.png">
 
 <!-- iOS -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-title" content="UK Parliament petitions">
 
-<link rel="apple-touch-icon" sizes="180x180" href="images/apple-icons/apple-touch-icon-180x180-precomposed.png">
-<link href="images/apple-icons/apple-touch-icon-152x152-precomposed.png" sizes="152x152" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-144x144-precomposed.png" sizes="144x144" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-120x120-precomposed.png" sizes="120x120" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-114x114-precomposed.png" sizes="114x114" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-76x76-precomposed.png" sizes="76x76" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-72x72-precomposed.png" sizes="72x72" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-60x60-precomposed.png" sizes="60x60" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-57x57-precomposed.png" sizes="57x57" rel="apple-touch-icon">
-<link href="images/apple-icons/apple-touch-icon-precomposed.png" rel="apple-touch-icon">
+<link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icons/apple-touch-icon-180x180-precomposed.png">
+<link href="/images/apple-icons/apple-touch-icon-152x152-precomposed.png" sizes="152x152" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-144x144-precomposed.png" sizes="144x144" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-120x120-precomposed.png" sizes="120x120" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-114x114-precomposed.png" sizes="114x114" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-76x76-precomposed.png" sizes="76x76" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-72x72-precomposed.png" sizes="72x72" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-60x60-precomposed.png" sizes="60x60" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-57x57-precomposed.png" sizes="57x57" rel="apple-touch-icon">
+<link href="/images/apple-icons/apple-touch-icon-precomposed.png" rel="apple-touch-icon">
 
 <!-- Windows 8 and IE 11 -->
 <meta name="msapplication-config" content="browserconfig.xml" />


### PR DESCRIPTION
The favicon links need to be root relative otherwise browsers will look
for them in the wrong place, e.g:

```
/archived/petitions/10001
```

will look for a favicon at:

```
/archived/petitions/favicon.ico
```

This will end up causing a database query looking for an archived petition
with an id of 'favicon' and try to render a .ico format template.