### PR TITLE
Remove redundant time format

### DIFF
--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,28 +1,25 @@
 module DateTimeHelper
-
   def short_date_format(date_time)
-    date_time.strftime("%e %B %Y") if date_time
+    date_time && date_time.strftime("%e %B %Y")
   end
 
   def date_time_format(date_time)
-    date_time.strftime("%d-%m-%Y %H:%M") if date_time
+    date_time && date_time.strftime("%d-%m-%Y %H:%M")
   end
 
   def date_format(date_time)
-    date_time.to_s(:dotted_short_date) if date_time
+    date_time && date_time.strftime("%d/%m/%Y")
   end
 
   def date_format_admin(date_time)
-    date_time.strftime("%d-%m-%Y") if date_time
+    date_time && date_time.strftime("%d-%m-%Y")
   end
 
   def local_date_time_format(date_time)
-    return unless date_time
-    date_time.in_time_zone.strftime("%d/%m/%Y %H:%M")
+    date_time && date_time.in_time_zone.strftime("%d/%m/%Y %H:%M")
   end
 
   def last_updated_at_time(date_time)
-    return unless date_time
-    date_time.in_time_zone.strftime("%H:%M %Z")
+    date_time && date_time.in_time_zone.strftime("%H:%M %Z")
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,0 @@
-Time::DATE_FORMATS[:dotted_short_date] = "%d/%m/%Y"


### PR DESCRIPTION
The dotted_short_date format has no dots and is only used in one place
so there's no point adding it to Time::FORMATS.