### PR TITLE
Manage sponsorship attempts after reaching limits of 20 sponsors

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -57,6 +57,10 @@ class PetitionsController < ApplicationController
     SignatureConfirmer.new(@petition, params[:confirmation_email], PetitionMailer, EMAIL_REGEX).confirm!
   end
 
+  def moderation_info
+    @petition = Petition.find(params[:id])
+  end
+
   protected
 
   def sanitise_state_param

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -91,7 +91,7 @@ class SignaturesController < ApplicationController
   end
 
   def send_sponsor_support_notification_email_to_petition_owner(petition, signature)
-    petition.notify_creator_about_sponsor_support(petition.sponsors.for(signature))
+    petition.notify_creator_about_sponsor_support(petition.sponsors.for(signature)) unless petition.in_moderation?
   end
 
   def find_existing_pending_signatures

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -10,7 +10,7 @@ class SponsorsController < ApplicationController
     elsif @petition.rejected? || @petition.closed?
       redirect_to petition_url(@petition)
     elsif @petition.open?
-      redirect_to sign_petition_signature_url(@petition)
+      redirect_to sign_petition_signatures_url(@petition)
     elsif @petition.has_maximum_sponsors?
       redirect_to moderation_info_petition_url(@petition)
     else

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -11,6 +11,8 @@ class SponsorsController < ApplicationController
       redirect_to petition_url(@petition)
     elsif @petition.open?
       redirect_to sign_petition_signature_url(@petition)
+    elsif @petition.has_maximum_sponsors?
+      redirect_to moderation_info_petition_url(@petition)
     else
       assign_stage
       @sponsor = @petition.sponsors.build

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -5,9 +5,17 @@ class SponsorsController < ApplicationController
   respond_to :html
 
   def show
-    assign_stage
-    @sponsor = @petition.sponsors.build
-    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, @petition, params[:stage], params[:move])
+    if @petition.hidden?
+      raise ActiveRecord::RecordNotFound
+    elsif @petition.rejected? || @petition.closed?
+      redirect_to petition_url(@petition)
+    elsif @petition.open?
+      redirect_to sign_petition_signature_url(@petition)
+    else
+      assign_stage
+      @sponsor = @petition.sponsors.build
+      @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, @petition, params[:stage], params[:move])
+    end
   end
 
   def update

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -224,7 +224,11 @@ class Petition < ActiveRecord::Base
   end
 
   def has_maximum_sponsors?
-    sponsors.count >= AppConfig.sponsor_count_max && (state == SPONSORED_STATE || state == VALIDATED_STATE)
+    sponsors.count >= AppConfig.sponsor_count_max && stop_collecting_sponsors_states
+  end
+
+  def stop_collecting_sponsors_states
+    state == SPONSORED_STATE || state == VALIDATED_STATE || state == PENDING_STATE
   end
 end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -222,5 +222,9 @@ class Petition < ActiveRecord::Base
   def update_sponsored_state
     update_attribute(:state, SPONSORED_STATE) if self.on_sponsor_moderation_threshold?
   end
+
+  def has_maximum_sponsors?
+    sponsors.count >= AppConfig.sponsor_count_max && (state == SPONSORED_STATE || state == VALIDATED_STATE)
+  end
 end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -132,6 +132,10 @@ class Petition < ActiveRecord::Base
     self.state == VALIDATED_STATE
   end
 
+  def in_moderation?
+    self.state == SPONSORED_STATE
+  end
+
   def open?
     self.state == OPEN_STATE
   end

--- a/app/views/petitions/moderation_info.html.erb
+++ b/app/views/petitions/moderation_info.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:page_title) { "#{@petition.title} - has been already sent to moderation - e-petitions" } %>
+<% content_for :title do %>
+  <div class="title_block">
+    <h2><%= @petition.creator_signature.name %>'s petition - "<%= @petition.title %>" already has its 5 sponsors and we're taking a look to make sure it meets the Petitions service terms and conditions.<h2>
+    <h2>The petition should be available for signing in a few days.</h2>
+  </div>
+<% end %>
+
+<%= link_to "Return to home page", home_path, :class => 'link_button large_link_button return_to_homepage_button' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     member do
       post 'resend_confirmation_email'
       get  'thank-you', :action => :thank_you, :as => :thank_you
+      get  'moderation-info', :action => :moderation_info, :as => :moderation_info
     end
     resources :sponsors, only: [:show, :update], param: :token do
       get 'thank-you', on: :member

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -20,6 +20,36 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     Then I am taken to a landing page
     And I should have fully signed the petition as a sponsor
 
+  Scenario: Laura wants to sign the petition that is already published
+    Given the petition I want to sign is open
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And I am redirected to the petition sign page
+
+  Scenario: Laura wants to sign the petition that is in moderation state
+    Given the petition I want to sign is sponsored
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And the markup should be valid
+
+  Scenario: Laura wants to sign the petition that is closed
+    Given the petition I want to sign has been closed
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And I am redirected to the petition closed page
+
+  Scenario: Laura wants to sign the petition that is rejected
+    Given the petition I want to sign is rejected
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And I am redirected to the petition closed page
+
+  @allow-rescue
+  Scenario: Laura wants to sign the petition that is hidden from publishing
+    Given the petition I want to sign is hidden
+    When I visit the "sponsor this petition" url I was given
+    And I will see 404 error page
+
   Scenario: Laura gets her email address wrong and changes it while sponsoring
     When I visit the "sponsor this petition" url I was given
     And I fill in my details as a sponsor with email "sponsor@example.com"

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -50,6 +50,18 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     When I visit the "sponsor this petition" url I was given
     And I will see 404 error page
 
+  Scenario: Laura is the 21th sponsor that wants to sign the validated petition
+    Given the petition I want to sign has enough sponsors and is validated
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And I am redirected to the petition moderation info page
+
+  Scenario: Laura is the 21th sponsor that wants to sign the sponsored petition
+    Given the petition I want to sign has enough sponsors and is validated
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And I am redirected to the petition moderation info page
+
   Scenario: Laura gets her email address wrong and changes it while sponsoring
     When I visit the "sponsor this petition" url I was given
     And I fill in my details as a sponsor with email "sponsor@example.com"

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -57,7 +57,13 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     And I am redirected to the petition moderation info page
 
   Scenario: Laura is the 21th sponsor that wants to sign the sponsored petition
-    Given the petition I want to sign has enough sponsors and is validated
+    Given the petition I want to sign has enough sponsors and is sponsored
+    When I visit the "sponsor this petition" url I was given
+    Then I should be connected to the server via an ssl connection
+    And I am redirected to the petition moderation info page
+
+  Scenario: Laura is the 21th sponsor that wants to sign the pending petition
+    Given the petition I want to sign has enough sponsors and is pending
     When I visit the "sponsor this petition" url I was given
     Then I should be connected to the server via an ssl connection
     And I am redirected to the petition moderation info page

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -75,6 +75,14 @@ Then(/^I will see 404 error page$/) do
   expect(page.status_code).to eq 404
 end
 
+Given(/^the petition I want to sign has enough sponsors and is (validated|sponsored)?$/) do |state|
+  @sponsor_petition = FactoryGirl.create(:open_petition, state: state, sponsor_count: AppConfig.sponsor_count_max)
+end
+
+Then(/^I am redirected to the petition moderation info page$/) do
+  expect(current_path).to eq(moderation_info_petition_path(@sponsor_petition))
+end
+
 When(/^I visit the \"sponsor this petition\" url I was given$/) do
   visit petition_sponsor_path(@sponsor_petition, token: @sponsor_petition.sponsor_token)
 end

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -75,7 +75,7 @@ Then(/^I will see 404 error page$/) do
   expect(page.status_code).to eq 404
 end
 
-Given(/^the petition I want to sign has enough sponsors and is (validated|sponsored)?$/) do |state|
+Given(/^the petition I want to sign has enough sponsors and is (validated|sponsored|pending)?$/) do |state|
   @sponsor_petition = FactoryGirl.create(:open_petition, state: state, sponsor_count: AppConfig.sponsor_count_max)
 end
 

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -55,6 +55,26 @@ Given(/^I have enough support from sponsors for my e\-petition$/) do
   }
 end
 
+Given /^the petition I want to sign is (validated|sponsored|open|hidden|rejected)?$/ do |state|
+  @sponsor_petition = FactoryGirl.create(:open_petition, state: state, :rejection_code => "irrelevant")
+end
+
+Given /^the petition I want to sign has been closed$/ do
+  @sponsor_petition = FactoryGirl.create(:open_petition, closed_at: 1.day.ago)
+end
+
+Then(/^I am redirected to the petition closed page$/) do
+  expect(current_path).to eq(petition_path(@sponsor_petition))
+end
+
+Then(/^I am redirected to the petition sign page$/) do
+  expect(current_path).to eq(sign_petition_signature_path(@sponsor_petition))
+end
+
+Then(/^I will see 404 error page$/) do
+  expect(page.status_code).to eq 404
+end
+
 When(/^I visit the \"sponsor this petition\" url I was given$/) do
   visit petition_sponsor_path(@sponsor_petition, token: @sponsor_petition.sponsor_token)
 end

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -68,7 +68,7 @@ Then(/^I am redirected to the petition closed page$/) do
 end
 
 Then(/^I am redirected to the petition sign page$/) do
-  expect(current_path).to eq(sign_petition_signature_path(@sponsor_petition))
+  expect(current_path).to eq(sign_petition_signatures_path(@sponsor_petition))
 end
 
 Then(/^I will see 404 error page$/) do

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -86,6 +86,15 @@ describe SignaturesController do
         end
       end
 
+      it 'doesn\'t send email notification to the petition creator if the petition is already in moderation' do
+        petition_in_moderation = FactoryGirl.create(:petition, state: 'sponsored')
+        sponsor = FactoryGirl.create(:sponsor, petition: petition_in_moderation)
+        signature = sponsor.create_signature(FactoryGirl.attributes_for(:pending_signature, petition: petition_in_moderation))
+        assert_no_performed_jobs do
+          get :verify, :id => signature.id, :token => signature.perishable_token
+        end
+      end
+
       it 'updates petition sponsored state' do
         allow(Signature).to receive(:find).with(signature.to_param).and_return signature
         allow(signature).to receive(:petition).and_return petition

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -84,6 +84,13 @@ describe SponsorsController do
         redirect_url = "https://petition.parliament.uk/petitions/#{validated_petition.id}/moderation-info"
         expect(response).to redirect_to redirect_url
       end
+
+      it 'redirects to petition moderation info page when petition is in pending state' do
+        pending_petition = FactoryGirl.create(:pending_petition, sponsor_count: AppConfig.sponsor_count_max)
+        get :show, petition_id: pending_petition, token: pending_petition.sponsor_token
+        redirect_url = "https://petition.parliament.uk/petitions/#{pending_petition.id}/moderation-info"
+        expect(response).to redirect_to redirect_url
+      end
     end
   end
 

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -41,6 +41,34 @@ describe SponsorsController do
       expect(assigns[:stage_manager].signature).to be_present
       expect(assigns[:stage_manager].signature.petition).to eq petition
     end
+
+    it 'redirects to petition page when the petition is closed' do
+      closed_petition = FactoryGirl.create(:closed_petition)
+      get :show, petition_id: closed_petition, token: closed_petition.sponsor_token
+      redirect_url = "https://petition.parliament.uk/petitions/#{closed_petition.id}"
+      expect(response).to redirect_to redirect_url
+    end
+
+    it 'redirects to petition page when the petition is rejected' do
+      rejected_petition = FactoryGirl.create(:rejected_petition)
+      get :show, petition_id: rejected_petition, token: rejected_petition.sponsor_token
+      redirect_url = "https://petition.parliament.uk/petitions/#{rejected_petition.id}"
+      expect(response).to redirect_to redirect_url
+    end
+
+    it 'redirects to petition sign page if the petition is already published' do
+      published_petition = FactoryGirl.create(:open_petition)
+      get :show, petition_id: published_petition, token: published_petition.sponsor_token
+      redirect_url = "https://petition.parliament.uk/petitions/#{published_petition.id}/signature/new"
+      expect(response).to redirect_to redirect_url
+    end
+
+    it 'redirects to 404 if the petition is hidden' do
+      hidden_petition = FactoryGirl.create(:hidden_petition)
+      expect {
+        get :show, petition_id: hidden_petition, token: hidden_petition.sponsor_token
+      }.to raise_error ActiveRecord::RecordNotFound
+    end
   end
 
   context 'PATCH update' do

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -69,6 +69,22 @@ describe SponsorsController do
         get :show, petition_id: hidden_petition, token: hidden_petition.sponsor_token
       }.to raise_error ActiveRecord::RecordNotFound
     end
+
+    context 'petition has reached maximum amount of sponsors' do
+      it 'redirects to petition moderation info page when petition is in sponsored state' do
+        sponsored_petition = FactoryGirl.create(:sponsored_petition, sponsor_count: AppConfig.sponsor_count_max)
+        get :show, petition_id: sponsored_petition, token: sponsored_petition.sponsor_token
+        redirect_url = "https://petition.parliament.uk/petitions/#{sponsored_petition.id}/moderation-info"
+        expect(response).to redirect_to redirect_url
+      end
+
+      it 'redirects to petition moderation info page when petition is in validated state' do
+        validated_petition = FactoryGirl.create(:validated_petition, sponsor_count: AppConfig.sponsor_count_max)
+        get :show, petition_id: validated_petition, token: validated_petition.sponsor_token
+        redirect_url = "https://petition.parliament.uk/petitions/#{validated_petition.id}/moderation-info"
+        expect(response).to redirect_to redirect_url
+      end
+    end
   end
 
   context 'PATCH update' do

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -59,7 +59,7 @@ describe SponsorsController do
     it 'redirects to petition sign page if the petition is already published' do
       published_petition = FactoryGirl.create(:open_petition)
       get :show, petition_id: published_petition, token: published_petition.sponsor_token
-      redirect_url = "https://petition.parliament.uk/petitions/#{published_petition.id}/signature/new"
+      redirect_url = "https://petition.parliament.uk/petitions/#{published_petition.id}/signatures/new"
       expect(response).to redirect_to redirect_url
     end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -618,5 +618,27 @@ describe Petition do
       expect(petition.id).to be >= 100000
     end
   end
+
+  describe '#has_maximum_sponsors?' do
+    it 'is true when sponsored petition has reached maximum amount of sponsors' do
+      sponsored_petition = FactoryGirl.create(:sponsored_petition, sponsor_count: AppConfig.sponsor_count_max)
+      expect(sponsored_petition.has_maximum_sponsors?).to be_truthy
+    end
+
+    it 'is true when validated petition has reached maximum amount of sponsors' do
+      sponsored_petition = FactoryGirl.create(:validated_petition, sponsor_count: AppConfig.sponsor_count_max)
+      expect(sponsored_petition.has_maximum_sponsors?).to be_truthy
+    end
+
+    it 'is false when sponsored petition has not reached maximum amount of sponsors' do
+      sponsored_petition = FactoryGirl.create(:sponsored_petition, sponsor_count: AppConfig.sponsor_count_max - 1)
+      expect(sponsored_petition.has_maximum_sponsors?).to be_falsey
+    end
+
+    it 'is false when validated petition has not reached maximum amount of sponsors' do
+      sponsored_petition = FactoryGirl.create(:validated_petition, sponsor_count: AppConfig.sponsor_count_max - 1)
+      expect(sponsored_petition.has_maximum_sponsors?).to be_falsey
+    end
+  end
 end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -630,6 +630,11 @@ describe Petition do
       expect(sponsored_petition.has_maximum_sponsors?).to be_truthy
     end
 
+    it 'is true when pending petition has reached maximum amount of sponsors' do
+      sponsored_petition = FactoryGirl.create(:pending_petition, sponsor_count: AppConfig.sponsor_count_max)
+      expect(sponsored_petition.has_maximum_sponsors?).to be_truthy
+    end
+
     it 'is false when sponsored petition has not reached maximum amount of sponsors' do
       sponsored_petition = FactoryGirl.create(:sponsored_petition, sponsor_count: AppConfig.sponsor_count_max - 1)
       expect(sponsored_petition.has_maximum_sponsors?).to be_falsey
@@ -637,6 +642,11 @@ describe Petition do
 
     it 'is false when validated petition has not reached maximum amount of sponsors' do
       sponsored_petition = FactoryGirl.create(:validated_petition, sponsor_count: AppConfig.sponsor_count_max - 1)
+      expect(sponsored_petition.has_maximum_sponsors?).to be_falsey
+    end
+
+    it 'is false when validated petition has not reached maximum amount of sponsors' do
+      sponsored_petition = FactoryGirl.create(:pending_petition, sponsor_count: AppConfig.sponsor_count_max - 1)
       expect(sponsored_petition.has_maximum_sponsors?).to be_falsey
     end
   end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -392,6 +392,12 @@ describe Petition do
     end
   end
 
+  describe "#in_moderation?" do
+    it "is in moderation when the state is sponsored" do
+      expect(FactoryGirl.build(:petition, :state => Petition::SPONSORED_STATE).in_moderation?).to be_truthy
+    end
+  end
+
   describe "rejection_reason" do
     it "should give rejection reason from json file" do
       petition = FactoryGirl.build(:rejected_petition, :rejection_code => 'duplicate')


### PR DESCRIPTION
different scenarios described here:
PT: https://www.pivotaltracker.com/n/projects/307301/stories/94792936

Added one commit to fix signature route after rebasing

Added new commit after updating ACs - we want also stop collecting sponsors on petitions that are still pending (no one has validated its email)