### PR TITLE
Add field converters to import task

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -22,8 +22,14 @@ namespace :import do
       "honours"    => "E-petitions cannot include information about honours or appointments. Find information about nominations for honours at https://www.gov.uk/honours.",
     }
 
+    converters = [
+      ->(value) { value == 'NULL' ? nil : value },
+      ->(value) { value =~ /\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\z/ ? Time.strptime(value + ' UTC', '%Y-%m-%d %H:%M:%S %Z') : value },
+      ->(value) { value =~ /\A\d+\z/ ? Integer(value) : value }
+    ]
+
     Sunspot.batch do
-      CSV.foreach(file, headers: true) do |row|
+      CSV.foreach(file, headers: true, converters: converters) do |row|
         if ArchivedPetition::STATES.include?(row['state'])
           petition = ArchivedPetition.find_or_initialize_by(id: row['id'])
 


### PR DESCRIPTION
The CSV library can take an array of converters that convert the string from the csv field and if any of them return a non-string value then it uses that value. If it doesn't match any of them then it will use the original string value.

The converters are:

```
Null:    If a string matches "NULL" then convert it to nil
Integer: If a string is all digits then convert it to an integer
Time:    If a string matches the database timestamp format then convert it to a UTC time.
````