### PR TITLE
Add error catching for Faraday errors

### DIFF
--- a/app/lib/constituency_api.rb
+++ b/app/lib/constituency_api.rb
@@ -7,13 +7,12 @@ module ConstituencyApi
   class Client
     include Faraday
     URL = 'http://data.parliament.uk/membersdataplatform/services/mnis/Constituencies'
-    TIMEOUT = 10
+    TIMEOUT = 5
     
     def self.constituencies(postcode)
       response = call_api(postcode)
       parse_constituencies(response)
     end
-    
     
     def self.parse_constituencies(response)
       return [] unless response["Constituencies"]
@@ -33,8 +32,10 @@ module ConstituencyApi
                                        "request #{URL}/#{postcode_param(postcode)}/")
       end
       Hash.from_xml(response.body)
-    rescue Faraday::TimeoutError
+    rescue Faraday::Error::TimeoutError
       raise ConstituencyApiError.new("Timeout after #{TIMEOUT} seconds")
+    rescue Faraday::Error => e
+      raise ConstituencyApiError.new("Network error - #{e}")
     end
     
     def self.postcode_param(postcode)

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -13,13 +13,8 @@
   </div>
   <div class="generic_block">
     <p>Your petition will be open for <%= AppConfig.petition_duration %> months after it is reviewed by Parliament.</p>
-    <% if petition.creator_signature.constituency %>
-    <p>
-      Your constituency is <%= petition.creator_signature.constituency.name %>
-    </p>
-    <% end %>
   </div>
-  
+
   <div class="row">
     <p>By creating this petition, you agree to the <%= link_to 'Terms & Conditions', help_path(anchor: 'terms-and-conditions') %></p>
   </div>

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -26,9 +26,8 @@ Scenario: Charlie creates our petition
   Given I start a new petition
   And I fill in the petition details
   And I press "Next"
-  And I fill in my details with postcode "N1 1TY"
+  And I fill in my details
   And I press "Next"
-  Then I should see my constituency "Islington South and Finsbury"
   When I press "Next"
   Then the markup should be valid
   When I press "Submit"

--- a/spec/lib/constituency_api_spec.rb
+++ b/spec/lib/constituency_api_spec.rb
@@ -59,6 +59,16 @@ describe ConstituencyApi do
       stub_request(:any, /.*data.parliament.uk.*/).to_timeout
       expect{ api.constituencies("N1").count }.to raise_error(ConstituencyApi::ConstituencyApiError)
     end
+
+    it "handles connection failed errors" do
+      stub_request(:any, /.*data.parliament.uk.*/).to_raise(Faraday::Error::ConnectionFailed)
+      expect{ api.constituencies("N1").count }.to raise_error(ConstituencyApi::ConstituencyApiError)
+    end
+    
+    it "handles resource not found errors" do
+      stub_request(:any, /.*data.parliament.uk.*/).to_raise(Faraday::Error::ResourceNotFound)
+      expect{ api.constituencies("N1").count }.to raise_error(ConstituencyApi::ConstituencyApiError)
+    end
     
     it "handles unexpected response" do
       stub_request(:get, "#{ api_url }/N1/").to_return(status: 500, body: fake_body)


### PR DESCRIPTION
Added error catching for other Faraday errors other than timeout. Reduced timeout to 5 seconds.
Also removed the constituency info from the petition creation replay stage.