### PR TITLE
Remove caching for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gem 'dotenv-rails', :require => 'dotenv/rails-now'
 gem 'rails', '4.2.1'
 
 # Legacy Rails feature gems - will no longer be supported in Rails 5.0
-gem 'actionpack-action_caching'
-gem 'actionpack-page_caching'
 gem 'responders'
 gem 'rails_autolink'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,10 +14,6 @@ GEM
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    actionpack-action_caching (1.1.1)
-      actionpack (>= 4.0.0, < 5.0)
-    actionpack-page_caching (1.0.2)
-      actionpack (>= 4.0.0, < 5)
     actionview (4.2.1)
       activesupport (= 4.2.1)
       builder (~> 3.1)
@@ -287,8 +283,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack-action_caching
-  actionpack-page_caching
   airbrake
   annotate
   attr_encrypted

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,19 +7,4 @@ class ApplicationController < ActionController::Base
     params[param] = params[param].to_i
     params[param] = 1 if params[param] < 1
   end
-
-  def self.caches_action_with_params(*actions)
-    options = actions.extract_options!
-    options[:cache_path] = Proc.new do |c|
-      p = {}
-      p[:page] = c.params[:page].to_i unless c.params[:page].blank?
-      p[:order] = c.params[:order] unless c.params[:order].blank?
-      p[:sort] = c.params[:sort] unless c.params[:sort].blank?
-      p[:state] = c.params[:state] unless c.params[:state].blank?
-      p
-    end
-    options[:expires_in] ||= DEFAULT_CACHE_EXPIRY
-    actions << options
-    self.caches_action(*actions)
-  end
 end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,9 +1,6 @@
 class PetitionsController < ApplicationController
   before_filter :sanitise_page_param
   before_filter :sanitise_state_param
-  caches_action_with_params :index
-
-  caches_page :show
 
   respond_to :html
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,4 @@
 class StaticPagesController < ApplicationController
-  caches_page :help
-  caches_action :home, :expires_in => 5.minutes
 
   def home
     @trending_petitions   = Petition.last_hour_trending


### PR DESCRIPTION
We will be re-visiting caching to use more modern techniques like
the Rails recommended way of using russian-doll view caching and
HTTP cache headers.