### PR TITLE
Add signature postcode setter method to strip white spaces

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -58,6 +58,10 @@ class Signature < ActiveRecord::Base
     super(value.to_s.downcase)
   end
 
+  def postcode=(value)
+    super(value.to_s.gsub(/\s+/, "").upcase)
+  end
+
   def creator?
     petition.creator_signature == self
   end
@@ -84,7 +88,7 @@ class Signature < ActiveRecord::Base
   end
 
   def postal_district
-    postcode.upcase[0..-4].match(/[A-Z]{1,2}[0-9]{1,2}[A-Z]?/).to_s
+    postcode.upcase[0..-4].match(/^[A-Z]{1,2}[0-9]{1,2}[A-Z]?/).to_s
   end
 
   def unsubscribe!

--- a/app/models/staged/validations/signer_details.rb
+++ b/app/models/staged/validations/signer_details.rb
@@ -13,7 +13,7 @@ module Staged
         validates :postcode,
           presence: { message: 'Postcode must be completed.' },
           format: {
-            with: /\A(([A-Z]{1,2}[0-9][0-9A-Z]? ?[0-9][A-BD-HJLNP-UW-Z]{2})|(BFPO? ?(C\/O)? ?[0-9]{1,4})|(GIR 0AA))\Z/i,
+            with: /\A(([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})|(BFPO?(C\/O)?[0-9]{1,4})|(GIR0AA))\Z/i,
             message: 'Postcode not recognised.'
           },
           if: ->(cd) { cd.country == 'United Kingdom' }

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -100,7 +100,7 @@ describe SponsorsController do
       {
         name: 'S. Ponsor',
         email: 's.ponsor@example.com',
-        postcode: 'SP1 1NR',
+        postcode: 'SP11NR',
         country: 'United Kingdom',
         uk_citizenship: '1',
         notify_by_email: '0'

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -20,12 +20,12 @@
 require 'rails_helper'
 
 describe Signature do
-  it "should have a valid factory" do
+  it "has a valid factory" do
     expect(FactoryGirl.build(:signature)).to be_valid
   end
 
   context "defaults" do
-    it "state should default to pending" do
+    it "has pending as default state" do
       s = Signature.new
       expect(s.state).to eq("pending")
     end
@@ -35,7 +35,7 @@ describe Signature do
       expect(s.perishable_token).not_to be_nil
     end
 
-    it "should set notify_by_email to truthy" do
+    it "sets notify_by_email to truthy" do
       s = Signature.new
       expect(s.notify_by_email).to be_truthy
     end
@@ -56,15 +56,15 @@ describe Signature do
     describe "#postcode=" do
       let(:signature) { FactoryGirl.build(:signature) }
 
-      it "should remove all whitespace" do
+      it "removes all whitespace" do
         signature.postcode = " N1  1TY  "
         expect(signature.postcode).to eq "N11TY"
       end
-      it "should upcase the postcode" do
+      it "upcases the postcode" do
         signature.postcode = "n11ty "
         expect(signature.postcode).to eq "N11TY"
       end
-      it "should remove whitespaces and upcase the postcode" do
+      it "removes whitespaces and upcase the postcode" do
         signature.postcode = "   N1  1ty "
         expect(signature.postcode).to eq "N11TY"
       end
@@ -72,7 +72,7 @@ describe Signature do
     describe "#email=" do
       let(:signature) { FactoryGirl.build(:signature) }
 
-      it "should downcase the email" do
+      it "downcases the email" do
         signature.email = "JOE@PUBLIC.COM"
         expect(signature.email).to eq "joe@public.com"
       end
@@ -85,12 +85,12 @@ describe Signature do
     it { is_expected.to validate_presence_of(:country).with_message(/must be completed/) }
     it { is_expected.to validate_length_of(:name).is_at_most(255) }
 
-    it "should validate format of email" do
+    it "validates format of email" do
       s = FactoryGirl.build(:signature, :email => 'joe@example.com')
       expect(s).to have_valid(:email)
     end
 
-    it "should not allow invalid email" do
+    it "does not allow invalid email" do
       s = FactoryGirl.build(:signature, :email => 'not an email')
       expect(s).not_to have_valid(:email)
     end
@@ -177,14 +177,14 @@ describe Signature do
       end
     end
 
-    it "should not allow blank or unknown state" do
+    it "does not allow blank or unknown state" do
       s = FactoryGirl.build(:signature, :state => '')
       expect(s).not_to have_valid(:state)
       s.state = 'unknown'
       expect(s).not_to have_valid(:state)
     end
 
-    it "should allow known states" do
+    it "allows known states" do
       s = FactoryGirl.build(:signature)
       %w(pending validated ).each do |state|
         s.state = state
@@ -249,13 +249,13 @@ describe Signature do
     end
 
     describe "uk_citizenship" do
-      it "should require acceptance of uk_citizenship for a new record" do
+      it "requires acceptance of uk_citizenship for a new record" do
         expect(FactoryGirl.build(:signature, :uk_citizenship => '1')).to be_valid
         expect(FactoryGirl.build(:signature, :uk_citizenship => '0')).not_to be_valid
         expect(FactoryGirl.build(:signature, :uk_citizenship => nil)).not_to be_valid
       end
 
-      it "should not require acceptance of uk_citizenship for old records" do
+      it "does not require acceptance of uk_citizenship for old records" do
         sig = FactoryGirl.create(:signature)
         sig.reload
         sig.uk_citizenship = '0'
@@ -275,7 +275,7 @@ describe Signature do
     let!(:signature5) { FactoryGirl.create(:signature, :email => "person5@example.com", :petition => petition, :state => Signature::VALIDATED_STATE, :notify_by_email => false, :last_emailed_at => two_days_ago) }
 
     context "validated" do
-      it "should return only validated signatures" do
+      it "returns only validated signatures" do
         signatures = Signature.validated
         expect(signatures.size).to eq(5)
         expect(signatures).to include(signature1, signature3, signature4, signature5, petition.creator_signature)
@@ -283,7 +283,7 @@ describe Signature do
     end
 
     context "pending" do
-      it "should return only pending signatures" do
+      it "returns only pending signatures" do
         signatures = Signature.pending
         expect(signatures.size).to eq(1)
         expect(signatures).to include(signature2)
@@ -291,7 +291,7 @@ describe Signature do
     end
 
     context "need emailing" do
-      it "should return only validated signatures who have opted in to receiving email updates" do
+      it "returns only validated signatures who have opted in to receiving email updates" do
         expect(Signature.need_emailing(Time.now)).to include(signature1, signature3, signature4, petition.creator_signature)
         expect(Signature.need_emailing(two_days_ago)).to include(signature1, signature3, petition.creator_signature)
         expect(Signature.need_emailing(week_ago)).to include(signature1, petition.creator_signature)
@@ -301,17 +301,17 @@ describe Signature do
     context "matching" do
       let!(:signature1) { FactoryGirl.create(:signature, name: "Joe Public", email: "person1@example.com", petition: petition, state: Signature::VALIDATED_STATE, last_emailed_at: nil) }
 
-      it "should return a signature matching in name, email and petition_id" do
+      it "returns a signature matching in name, email and petition_id" do
         signature = FactoryGirl.build(:signature, name: "Joe Public", email: "person1@example.com", petition: petition)
         expect(Signature.matching(signature)).to include(signature1)
       end
 
-      it "should not return a signature matching in name, email and different petition" do
+      it "does not return a signature matching in name, email and different petition" do
         signature = FactoryGirl.build(:signature, name: "Joe Public", email: "person1@example.com", petition_id: 2)
         expect(Signature.matching(signature)).to_not include(signature1)
       end
 
-      it "should not return a signature matching in email, petition and different name" do
+      it "does not return a signature matching in email, petition and different name" do
         signature = FactoryGirl.build(:signature, name: "Josey Public", email: "person1@example.com", petition: petition)
         expect(Signature.matching(signature)).to_not include(signature1)
       end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -52,6 +52,33 @@ describe Signature do
     end
   end
 
+  context "custom attribute setters" do
+    describe "#postcode=" do
+      let(:signature) { FactoryGirl.build(:signature) }
+
+      it "should remove all whitespace" do
+        signature.postcode = " N1  1TY  "
+        expect(signature.postcode).to eq "N11TY"
+      end
+      it "should upcase the postcode" do
+        signature.postcode = "n11ty "
+        expect(signature.postcode).to eq "N11TY"
+      end
+      it "should remove whitespaces and upcase the postcode" do
+        signature.postcode = "   N1  1ty "
+        expect(signature.postcode).to eq "N11TY"
+      end
+    end
+    describe "#email=" do
+      let(:signature) { FactoryGirl.build(:signature) }
+
+      it "should downcase the email" do
+        signature.email = "JOE@PUBLIC.COM"
+        expect(signature.email).to eq "joe@public.com"
+      end
+    end
+  end
+
   context "validations" do
     it { is_expected.to validate_presence_of(:name).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:email).with_message(/must be completed/) }
@@ -170,22 +197,12 @@ describe Signature do
         expect(FactoryGirl.build(:signature, :postcode => 'SW1A 1AA')).to be_valid
         expect(FactoryGirl.build(:signature, :postcode => '')).not_to be_valid
       end
-
       it "does not require a postcode for non-UK addresses" do
         expect(FactoryGirl.build(:signature, :country => "United Kingdom", :postcode => '')).not_to be_valid
         expect(FactoryGirl.build(:signature, :country => "United States", :postcode => '')).to be_valid
       end
-
       it "checks the format of postcode" do
-        s = FactoryGirl.build(:signature, :postcode => 'SW1A 1AA')
-        expect(s).to have_valid(:postcode)
-      end
-      it "ignores lack of spaces in postcode" do
         s = FactoryGirl.build(:signature, :postcode => 'SW1A1AA')
-        expect(s).to have_valid(:postcode)
-      end
-      it "does not require upper case letters in postcode" do
-        s = FactoryGirl.build(:signature, :postcode => 'sw1a 1aa')
         expect(s).to have_valid(:postcode)
       end
       it "recognises special postcodes" do
@@ -193,7 +210,10 @@ describe Signature do
         expect(FactoryGirl.build(:signature, :postcode => 'XM4 5HQ')).to have_valid(:postcode)
         expect(FactoryGirl.build(:signature, :postcode => 'GIR 0AA')).to have_valid(:postcode)
       end
-
+      it "does not allow prefix of postcode only" do
+        s = FactoryGirl.build(:signature, :postcode => 'N1')
+        expect(s).not_to have_valid(:postcode)
+      end
       it "does not allow unrecognised postcodes" do
         s = FactoryGirl.build(:signature, :postcode => '90210')
         expect(s).not_to have_valid(:postcode)
@@ -405,7 +425,7 @@ describe Signature do
     let(:constituency2) { ConstituencyApi::Constituency.new(name: "Lambeth") }
 
     it "returns a constituency object from the API return array" do
-      allow(ConstituencyApi::Client).to receive(:constituencies).with('N1 1TY').and_return([constituency1])
+      allow(ConstituencyApi::Client).to receive(:constituencies).with('N11TY').and_return([constituency1])
       signature = FactoryGirl.build(:signature, postcode: 'N1 1TY')
       expect(signature.constituency).to eq(constituency1)
     end
@@ -417,7 +437,7 @@ describe Signature do
     end
 
     it "returns nil for invalid postcode" do
-      allow(ConstituencyApi::Client).to receive(:constituencies).with('SW14 9RQ').and_return([])
+      allow(ConstituencyApi::Client).to receive(:constituencies).with('SW149RQ').and_return([])
       signature = FactoryGirl.build(:signature, postcode: 'SW14 9RQ')
       expect(signature.constituency).to be_nil
     end
@@ -429,3 +449,4 @@ describe Signature do
     end
   end
 end
+


### PR DESCRIPTION
Allows for user input of postcodes with arbitrary white spaces. The signature 
attribute setter will strip all white spaces and upcase the postcode. As before 
at validation the string will checked against the postcode regex.
Have also removed some postcode tests there were testing different 
postcode formats, which is not needed anymore since the attr setter tests 
ensure that the postcode is squished and upcased.

Addresses https://www.pivotaltracker.com/story/show/95968600