### PR TITLE
Add /ping endpoint

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,5 @@
+class PingController < ApplicationController
+  def ping
+    render text: "PONG"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get '/' => 'static_pages#home', :as => :home
   get 'help' => 'static_pages#help', :as => 'help'
+  get 'ping' => 'ping#ping'
 
   get 'feedback' => 'feedback#index', :as => 'feedback'
   get 'feedback/thanks' => 'feedback#thanks', :as => 'thanks_feedback'

--- a/spec/controllers/ping_controller_spec.rb
+++ b/spec/controllers/ping_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe PingController do
+  describe "ping" do
+    it "should respond to the /ping path" do
+      expect({:get => "/ping"}).to route_to({:controller => "ping", :action => "ping"})
+    end
+
+    context "fetching ping" do
+      before { get :ping }
+
+      it "should return the correct body" do
+        expect(response.body).to eq("PONG")
+      end
+
+      it "should return with OK http status" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
To determine whether a server is up and running, we need an endpoint URL that
load balancers can poll periodically.

I consider this separate from a healthcheck endpoint. The healthcheck endpoint
gives us information about whether any of the dependent services are up and
running or not, and is a more in-depth check. The healthcheck can be useful for
diagnosing system problems / monitoring.

There are arguments for-and-against doing an exhaustive check on the load
balancer, but let me give one specific example:

Let's say that the app can send email as part of it's functionality. However,
99% of app usage by the public doesn't use that feature - it's only a small part
of the functionality.

If the mail server goes down, we want the app to remain up and running, even
though some portion of functionality is temporarily unavailable.

What we *don't want* is for the load balancer and autoscaling to consider all
servers to be unavailable if the mail server is down, and immediately start
rotating machines out of service and replacing them. That would take down the
whole website until the mail server comes back online.

So, I propose having two endpoints:

- *ping* - which is whether the web server is up or not. This is what
  the load balancer uses to determine if things are up and running
- *healthcheck* - a more detailed set of tests that can be used
  to determine if some portion of functionality is unavailable.
  That could be something closer to https://github.com/alphagov/e-petitions/pull/76/files

I've done the ping endpoint at the rails level, rather than at the Rack level
because we want the rails app to be functioning before we consider it 'in
rotation' for the load balancer. This does mean we probably have one external
dependency as part of the app state - the availability of the database.