### PR TITLE
Deploy process improvements

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -184,7 +184,7 @@ class PackageBuilder
   end
 
   def latest_key
-    "#{environment}/latest.tar.gz"
+    "/latest.tar.gz"
   end
 
   def package_gems
@@ -226,11 +226,11 @@ class PackageBuilder
   end
 
   def release_bucket
-    'ubxd-epetitions-releases'
+    "ubxd-epetitions-#{environment}-releases"
   end
 
   def release_key
-    "#{environment}/#{release}.tar.gz"
+    "#{release}.tar.gz"
   end
 
   def remove_archive

--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -341,7 +341,11 @@ class PackageBuilder
     <<-SCRIPT.strip_heredoc
       #!/usr/bin/env bash
       chown -R deploy:deploy /home/deploy/epetitions/releases/#{release}
-      su - deploy -c 'mkdir /home/deploy/epetitions/releases/#{release}/tmp'
+
+      if [ ! -e /home/deploy/epetitions/releases/#{release}/tmp ]; then
+        su - deploy -c 'mkdir /home/deploy/epetitions/releases/#{release}/tmp'
+      fi
+
       su - deploy -c 'ln -nfs /home/deploy/epetitions/shared/log /home/deploy/epetitions/releases/#{release}/log'
       su - deploy -c 'ln -nfs /home/deploy/epetitions/shared/bundle /home/deploy/epetitions/releases/#{release}/vendor/bundle'
       su - deploy -c 'ln -s /home/deploy/epetitions/releases/#{release} /home/deploy/epetitions/current_#{release}'


### PR DESCRIPTION
Use per-environment buckets: So that we don't have to create cross-aws-account permission references, the release bucket name should vary, rather than just the directory.

If we install the same version of the code on a system twice, tmp would already exist. This would lead to an error making the directory.