### PR TITLE
Re-flatten migrations

### DIFF
--- a/db/migrate/20150601153013_rename_encrypted_email_column.rb
+++ b/db/migrate/20150601153013_rename_encrypted_email_column.rb
@@ -1,5 +1,0 @@
-class RenameEncryptedEmailColumn < ActiveRecord::Migration
-  def change
-    rename_column :signatures, :encrypted_email, :email
-  end
-end

--- a/db/migrate/20150602200239_initial_schema.rb
+++ b/db/migrate/20150602200239_initial_schema.rb
@@ -90,11 +90,11 @@ class InitialSchema < ActiveRecord::Migration
       t.datetime :updated_at
       t.boolean  :notify_by_email, default: true
       t.datetime :last_emailed_at
-      t.string   :encrypted_email, limit: 255
+      t.string   :email, limit: 255
       t.string   :unsubscribe_token
     end
 
-    add_index :signatures, [:encrypted_email, :petition_id, :name], unique: true
+    add_index :signatures, [:email, :petition_id, :name], unique: true
     add_index :signatures, [:petition_id, :state, :name]
     add_index :signatures, [:petition_id, :state]
     add_index :signatures, [:petition_id]

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -528,8 +528,6 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 
 SET search_path TO "$user",public;
 
-INSERT INTO schema_migrations (version) VALUES ('20150601153013');
-
 INSERT INTO schema_migrations (version) VALUES ('20150602200239');
 
 INSERT INTO schema_migrations (version) VALUES ('20150603033108');


### PR DESCRIPTION
When #81 was merged it added a migration that was generated before the migrations were flattened in #90. This re-flattens the migrations so that a `rake db:migrate` will work with an empty database.