### PR TITLE
Add cookie information message

### DIFF
--- a/app/assets/stylesheets/petitions/_header.scss
+++ b/app/assets/stylesheets/petitions/_header.scss
@@ -38,3 +38,19 @@
     color: $white;
   }
 }
+
+#global-cookie-message {
+  width: 100%;
+  background-color: $light-blue-25;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  p {
+    @extend %site-width-container;
+    @include core-16;
+    margin-top: 0;
+    margin-bottom: 0;
+    a {
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,18 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  before_action :set_seen_cookie_message, if: :show_cookie_message?
+  helper_method :show_cookie_message?
+
   protected
+
+  def set_seen_cookie_message
+    cookies[:seen_cookie_message] = { value: 'yes', expires: 1.year.from_now }
+  end
+
+  def show_cookie_message?
+    @show_cookie_message ||= cookies[:seen_cookie_message] != 'yes'
+  end
 
   def sanitise_page_param(param = :page)
     params[param] = params[param].to_i

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,12 @@
     <%= render 'layouts/analytics' %>
   </head>
   <body>
+    <% if show_cookie_message? %>
+      <div id="global-cookie-message">
+        <p>We use cookies to make this service simpler. <a href="/help#cookies">Find out more about cookies</a></p>
+      </div>
+    <% end %>
+
     <%= render "shared/header" %>
 
     <main id="content">

--- a/features/joe_sees_cookie_message.feature
+++ b/features/joe_sees_cookie_message.feature
@@ -1,0 +1,19 @@
+Feature: Joe sees cookie message
+  In order to be informed about privacy issues
+  As Joe, a member of the general public
+  I want to see a message about cookie usage
+
+  Scenario: On the first visit
+    Given I am on the home page
+    Then I should see the cookie message
+
+  Scenario: On subsequent visits
+    Given I am on the home page
+    And I go to the home page
+    Then I should not see the cookie message
+
+  Scenario: On revisiting after a year
+    Given I am on the home page
+    And I wait for 1 year
+    And I go to the home page
+    Then I should see the cookie message

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,3 +1,15 @@
+Then(/^I should see the cookie message$/) do
+  expect(page).to have_text('We use cookies to make this service simpler')
+end
+
+Then(/^I should not see the cookie message$/) do
+  expect(page).not_to have_text('We use cookies to make this service simpler')
+end
+
+Then(/^I wait for (\d+) ((?:day|week|month|year|)s?)$/) do |duration, period|
+  travel(duration.to_i.send(period) + 1.second)
+end
+
 Then /^the response status should be (\d+)$/ do |code|
   expect(page.driver.response.status.to_i).to eq code
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -7,3 +7,7 @@ end
 Before do
   default_url_options[:protocol] = 'https'
 end
+
+After do
+  travel_back
+end


### PR DESCRIPTION
When a user visits a site for the first time show them a message about cookies and link to the cookies section on the help page. On any subsequent page views the cookie message is hidden by the presence of a cookie called `seen_cookie_message` being set to `yes`.

This follows the pattern establised on GOV.UK and in the [govuk_template gem][1] but the implementation is slightly different in that we're not using JavaScript to determine whether to show the message or not and we're also setting the expiry date on the cookie that stores whether the user has seen the message or not to 1 year and not the standard 28 days.

We may need to revisit this when we look at performance and caching.

[https://www.pivotaltracker.com/story/show/95857040][2]

[1]: https://github.com/alphagov/govuk_template
[2]: https://www.pivotaltracker.com/story/show/95857040