### PR TITLE
Redirect sponsors of already open petitions, to the view page

### DIFF
--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -7,10 +7,8 @@ class SponsorsController < ApplicationController
   def show
     if @petition.hidden?
       raise ActiveRecord::RecordNotFound
-    elsif @petition.rejected? || @petition.closed?
+    elsif @petition.rejected? || @petition.closed? || @petition.open?
       redirect_to petition_url(@petition)
-    elsif @petition.open?
-      redirect_to sign_petition_signatures_url(@petition)
     elsif @petition.has_maximum_sponsors?
       redirect_to moderation_info_petition_url(@petition)
     else

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -24,7 +24,7 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     Given the petition I want to sign is open
     When I visit the "sponsor this petition" url I was given
     Then I should be connected to the server via an ssl connection
-    And I am redirected to the petition sign page
+    And I am redirected to the petition view page
 
   Scenario: Laura wants to sign the petition that is in moderation state
     Given the petition I want to sign is sponsored

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -67,8 +67,8 @@ Then(/^I am redirected to the petition closed page$/) do
   expect(current_path).to eq(petition_path(@sponsor_petition))
 end
 
-Then(/^I am redirected to the petition sign page$/) do
-  expect(current_path).to eq(sign_petition_signatures_path(@sponsor_petition))
+Then(/^I am redirected to the petition view page$/) do
+  expect(current_path).to eq(petition_path(@sponsor_petition))
 end
 
 Then(/^I will see 404 error page$/) do

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -56,10 +56,10 @@ describe SponsorsController do
       expect(response).to redirect_to redirect_url
     end
 
-    it 'redirects to petition sign page if the petition is already published' do
+    it 'redirects to petition view page if the petition is already published' do
       published_petition = FactoryGirl.create(:open_petition)
       get :show, petition_id: published_petition, token: published_petition.sponsor_token
-      redirect_url = "https://petition.parliament.uk/petitions/#{published_petition.id}/signatures/new"
+      redirect_url = "https://petition.parliament.uk/petitions/#{published_petition.id}"
       expect(response).to redirect_to redirect_url
     end
 


### PR DESCRIPTION
This is for story > https://www.pivotaltracker.com/story/show/96533342

It's a follow up to the already delivered story, https://www.pivotaltracker.com/story/show/94792936 where we manage sponsorship attempts in various ways when we don't need / want any more.

The story should have been directing people to the petition view page not the petition sign page (I used the wrong name when I wrote the story....)

This PR remedies that....