### PR TITLE
Add sharing buttons for Email and Whatsapp

### DIFF
--- a/app/assets/stylesheets/petitions/views/shared/_share-petition.scss
+++ b/app/assets/stylesheets/petitions/views/shared/_share-petition.scss
@@ -22,5 +22,6 @@
   }
   .icon {
     margin-right: 5px;
+    width: 19px;
   }
 }

--- a/app/views/shared/_share_petition.html.erb
+++ b/app/views/shared/_share_petition.html.erb
@@ -3,25 +3,25 @@
 <ul class="petition-share">
   <li>
     <%= link_to "http://www.facebook.com/sharer.php?t=#{URI.escape(title)}&u=#{URI.escape(petition_url(petition))}" do %>
-      <span class="icon icon-share-facebook"></span>
+      <span class="icon icon-share-facebook" aria-hidden="true"></span>
       Facebook
     <% end %>
   </li>
   <li>
     <%= link_to "mailto:?subject=#{URI.escape(title)}&body=#{URI.escape(petition_url(petition))}" do %>
-      <span class="icon icon-share-email"></span>
+      <span class="icon icon-share-email" aria-hidden="true"></span>
       Email
     <% end %>
   </li>
   <li>
     <%= link_to "http://twitter.com/share?text=#{URI.escape(title)}&url=#{URI.escape(petition_url(petition))}" do %>
-      <span class="icon icon-share-twitter"></span>
+      <span class="icon icon-share-twitter" aria-hidden="true"></span>
       Twitter
     <% end %>
   </li>
   <li>
     <%= link_to "whatsapp://send?text=#{URI.escape(title + "\n" + petition_url(petition))}" do %>
-      <span class="icon icon-share-whatsapp"></span>
+      <span class="icon icon-share-whatsapp" aria-hidden="true"></span>
       Whatsapp
     <% end %>
   </li>

--- a/app/views/shared/_share_petition.html.erb
+++ b/app/views/shared/_share_petition.html.erb
@@ -8,9 +8,21 @@
     <% end %>
   </li>
   <li>
+    <%= link_to "mailto:?subject=#{URI.escape(title)}&body=#{URI.escape(petition_url(petition))}" do %>
+      <span class="icon icon-share-email"></span>
+      Email
+    <% end %>
+  </li>
+  <li>
     <%= link_to "http://twitter.com/share?text=#{URI.escape(title)}&url=#{URI.escape(petition_url(petition))}" do %>
       <span class="icon icon-share-twitter"></span>
       Twitter
+    <% end %>
+  </li>
+  <li>
+    <%= link_to "whatsapp://send?text=#{URI.escape(title + "\n" + petition_url(petition))}" do %>
+      <span class="icon icon-share-whatsapp"></span>
+      Whatsapp
     <% end %>
   </li>
 </ul>

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -223,3 +223,26 @@ Then(/^the e\-petition creator signature should be validated$/) do
   @sponsor_petition.reload
   expect(@sponsor_petition.creator_signature.state).to eq Signature::VALIDATED_STATE
 end
+
+Then(/^I can share it via (.+)$/) do |service|
+  case service
+  when 'Email'
+    within(:css, '.petition-share') do
+      expect(page).to have_link('Email', %r[\Amailto:?subject=#{URI.escape(@petition.title)}&body=#{URI.escape(petition_url(@petition))}\z])
+    end
+  when 'Facebook'
+    within(:css, '.petition-share') do
+      expect(page).to have_link('Facebook', %r[\Ahttp://www.facebook.com/sharer.php?t=#{URI.escape(title)}&u=#{URI.escape(petition_url(@petition))}\z])
+    end
+  when 'Twitter'
+    within(:css, '.petition-share') do
+      expect(page).to have_link('Twitter', %r[\Ahttp://twitter.com/share?text=#{URI.escape(title)}&url=#{URI.escape(petition_url(@petition))}\z])
+    end
+  when 'Whatsapp'
+    within(:css, '.petition-share') do
+      expect(page).to have_link('Whatsapp', %r[\Awhatsapp://send?text=#{URI.escape(title + "\n" + petition_url(@petition))}\z])
+    end
+  else
+    raise ArgumentError, "Unknown sharing service: #{service.inspect}"
+  end
+end

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -10,6 +10,10 @@ Feature: Suzie views a petition
     And I should see "Spend more money on Defence - e-petitions" in the browser page title
     And I should see the vote count, closed and open dates
     And I should not see "This e-petition is now closed"
+    And I can share it via Email
+    And I can share it via Facebook
+    And I can share it via Twitter
+    And I can share it via Whatsapp
 
   Scenario: Suzie views a petition containing urls, email addresses and html tags
     Given an open petition exists with title: "Defence review", description: "<i>We<i> like http://www.google.com and bambi@gmail.com"
@@ -35,7 +39,7 @@ Feature: Suzie views a petition
     When I view the petition
     Then I should see the petition details
     And I cannot sign the petition
-    
+
   Scenario: Suzie sees a 'closed' message when viewing a closed petition
     Given a petition "Spend more money on Defence" has been closed
     When I view the petition


### PR DESCRIPTION
Adds the additional sharing buttons for Email and Whatsapp. Icon width was set to 19px so that the labels line up.

https://www.pivotaltracker.com/story/show/95724426