### PR TITLE
Remove chronic and timecop gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ group :test do
   gem 'factory_girl_rails'
   gem 'be_valid_asset', :require => false
   gem 'email_spec'
-  gem 'chronic'
-  gem 'timecop'
   gem 'launchy'
   gem 'rspec-collection_matchers'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    timecop (0.7.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     webmock (1.21.0)
@@ -289,7 +288,6 @@ DEPENDENCIES
   aws-sdk
   be_valid_asset
   capybara
-  chronic
   cucumber-rails
   database_cleaner
   delayed_job_active_record
@@ -320,7 +318,6 @@ DEPENDENCIES
   sunspot_rails
   sunspot_solr
   tabnav
-  timecop
   webmock
   whenever
   will_paginate

--- a/features/step_definitions/time_steps.rb
+++ b/features/step_definitions/time_steps.rb
@@ -1,9 +1,7 @@
 Given /^the(?: date is the| time is) "([^"]*)"$/ do |description|
-  time = Chronic.parse(description, :now => Time.now)
-  raise "Chronic could not parse #{description}" unless time
-  Timecop.travel time.utc
+  travel_to description.in_time_zone
 end
 
 After do
-  Timecop.return
+  travel_back
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -7,7 +7,3 @@ end
 Before do
   default_url_options[:protocol] = 'https'
 end
-
-After do
-  travel_back
-end

--- a/spec/lib/email_reminder_spec.rb
+++ b/spec/lib/email_reminder_spec.rb
@@ -58,10 +58,8 @@ describe EmailReminder do
     end
 
     it "updates the time so they aren't sent again" do
-      Timecop.freeze do
-        EmailReminder.special_resend_of_signature_email_validation('2011-09-02')
-        expect(petition.signatures.last.updated_at.change(usec: 0)).to eq(Time.current.change(usec: 0))
-      end
+      EmailReminder.special_resend_of_signature_email_validation('2011-09-02')
+      expect(petition.signatures.last.updated_at).to be_within(1.second).of(Time.current)
     end
 
     it "allows customisation of the last updated time" do
@@ -85,10 +83,8 @@ describe EmailReminder do
       end
 
       it "still updates the timestamp" do
-        Timecop.freeze do
-          EmailReminder.special_resend_of_signature_email_validation('2011-09-02')
-          expect(petition.signatures.last.updated_at.change(usec: 0)).to eq(Time.current.change(usec: 0))
-        end
+        EmailReminder.special_resend_of_signature_email_validation('2011-09-02')
+        expect(petition.signatures.last.updated_at).to be_within(1.second).of(Time.current)
       end
     end
   end


### PR DESCRIPTION
Our use of these two gems is very limited and can easily be handled using the built-in time helpers, String#in_time_zone and be_within matcher.