### PR TITLE
Fix 404 for revalidating signature email

### DIFF
--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -87,3 +87,12 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     And I say I am happy with my email address
     Then I should see an error
     And I should not have signed the petition as a sponsor
+
+  Scenario: Laura sees notice that she has already signed when she validates more than once
+    When I have sponsored a petition
+    When I confirm my email address
+    Then I am taken to a landing page
+    And I should have fully signed the petition as a sponsor
+    When I confirm my email address
+    Then I am taken to a landing page
+    And I should see that I have already signed the petition

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -93,7 +93,7 @@ When(/^I fill in my details as a sponsor(?: with email "(.*?)")?$/) do |email_ad
     When I fill in "Name" with "Laura The Sponsor"
     And I fill in "Email" with "#{email_address}"
     And I check "Yes, I am a British citizen or UK resident"
-    And I fill in "Postcode" with "AB10 1AA"
+    And I fill in my postcode with "AB10 1AA"
     And I select "United Kingdom" from "Location"
   )
 end
@@ -148,3 +148,18 @@ Then(/^(I|they|".*?") should be emailed a link for gathering support from sponso
     Then they should see /\/petitions\/\\d+\/sponsors\/[A-Za-z0-9]+/ in the email body
   }
 end
+
+When(/^I have sponsored a petition$/) do
+  steps %Q{
+    When I visit the "sponsor this petition" url I was given
+    And I should be connected to the server via an ssl connection
+    When I fill in my details as a sponsor
+    And I try to sign
+    Then I should not have signed the petition as a sponsor
+    And I am asked to review my email address
+    When I say I am happy with my email address
+    Then I should have a pending signature on the petition as a sponsor
+    And I should receive an email explaining the petition I am sponsoring
+}
+end
+

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -27,7 +27,7 @@ describe SignaturesController do
       it "should redirect to the petition signed page" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(assigns[:signature]).to eq(signature)
-        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{signature.petition_id}/signatures/#{signature.id}/signed")
+        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{signature.petition_id}/signatures/#{signature.perishable_token}/signed")
       end
 
       it "should not set petition state to validated" do
@@ -109,6 +109,23 @@ describe SignaturesController do
           get :verify, :id => signature.id, :token => "#{signature.perishable_token}a"
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
+    end
+  end
+
+  describe "signed" do
+    let(:petition) { FactoryGirl.create(:petition) }
+    let(:signature) { FactoryGirl.create(:pending_signature, :petition => petition) }
+    
+    it "redirects to the signature verify page if unvalidated" do
+      get :signed, :petition_id => petition.id, :id => signature.perishable_token
+      expect(assigns[:signature]).to eq(signature)
+      expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.id}/verify/#{signature.perishable_token}")
+    end
+
+    it "raises exception if token not found" do
+      expect do
+        get :signed, :petition_id => petition.id, :id => "#{signature.perishable_token}a"
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -18,30 +18,30 @@ describe SignaturesController do
         stub_request(:get, "#{ api_url }/SW1A1AA/").to_return(status: 200, body: fake_body)
       end
 
-      it "should respond to /signatures/:id/verify/:token" do
+      it "responds to /signatures/:id/verify/:token" do
         expect({:get => "/signatures/#{signature.id}/verify/#{signature.perishable_token}"}).
           to route_to({:controller => "signatures", :action => "verify", :id => signature.id.to_s, :token => signature.perishable_token})
         expect(verify_signature_path(signature, signature.perishable_token)).to eq("/signatures/#{signature.id}/verify/#{signature.perishable_token}")
       end
 
-      it "should redirect to the petition signed page" do
+      it "redirects to the petition signed page" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(assigns[:signature]).to eq(signature)
         expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{signature.petition_id}/signatures/#{signature.perishable_token}/signed")
       end
 
-      it "should not set petition state to validated" do
+      it "does not set petition state to validated" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(petition.reload.state).to eq(Petition::PENDING_STATE)
       end
 
-      it "should raise exception if id not found" do
+      it "raises exception if id not found" do
         expect do
           get :verify, :id => signature.id + 1, :token => signature.perishable_token
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "should raise exception if token not found" do
+      it "raises exception if token not found" do
         expect do
           get :verify, :id => signature.id, :token => "#{signature.perishable_token}a"
         end.to raise_error(ActiveRecord::RecordNotFound)
@@ -53,23 +53,23 @@ describe SignaturesController do
       let(:sponsor) { FactoryGirl.create(:sponsor, petition: petition) }
       let(:signature) { sponsor.create_signature(FactoryGirl.attributes_for(:pending_signature, petition: petition)) }
 
-      it "should redirect to the petition sponsored page" do
+      it "redirects to the petition sponsored page" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(assigns[:signature]).to eq(signature)
         expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/sponsors/#{petition.sponsor_token}/sponsored")
       end
 
-      it "should set petition state to validated" do
+      it "sets petition state to validated" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(petition.reload.state).to eq(Petition::VALIDATED_STATE)
       end
 
-      it "should set state to validated" do
+      it "sets state to validated" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(signature.reload.state).to eq(Signature::VALIDATED_STATE)
       end
 
-      it "should set petition creator signature state to validated" do
+      it "sets petition creator signature state to validated" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(petition.creator_signature.reload.state).to eq(Signature::VALIDATED_STATE)
       end
@@ -98,13 +98,13 @@ describe SignaturesController do
         get :verify, :id => signature.id, :token => signature.perishable_token
       end
 
-      it "should raise exception if id not found" do
+      it "raises exception if id not found" do
         expect do
           get :verify, :id => signature.id + 1, :token => signature.perishable_token
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "should raise exception if token not found" do
+      it "raises exception if token not found" do
         expect do
           get :verify, :id => signature.id, :token => "#{signature.perishable_token}a"
         end.to raise_error(ActiveRecord::RecordNotFound)
@@ -262,7 +262,7 @@ describe SignaturesController do
         expect(response).to render_template(:new)
       end
 
-      it "should not create a new signature" do
+      it "does not create a new signature" do
         signature_params[:email] = ''
         expect { do_post }.not_to change(Signature, :count)
       end


### PR DESCRIPTION
The previous retrieve_petition method that was called before the signed controller method was scoped to only OPEN and REJECTED petitions, so would not find any other petition.