### PR TITLE
Popular in your constituency

### DIFF
--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -11,6 +11,7 @@ class LocalPetitionsController < ApplicationController
         constituencies = ConstituencyApi::Client.constituencies(sanitized_postcode)
         if constituencies.any?
           @constituency = constituencies.first
+          @petitions = Petition.popular_in_constituency(@constituency.id, 3)
         else
           render 'constituency_lookup_failed'
         end

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -1,2 +1,6 @@
 class LocalPetitionsController < ApplicationController
+  respond_to :html
+
+  def index
+  end
 end

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -1,6 +1,29 @@
+require 'postcode_sanitizer'
+
 class LocalPetitionsController < ApplicationController
   respond_to :html
 
   def index
+    if sanitized_postcode.blank?
+      render 'no_postcode_provided'
+    else
+      begin
+        constituencies = ConstituencyApi::Client.constituencies(sanitized_postcode)
+        if constituencies.any?
+          @constituency = constituencies.first
+        else
+          render 'constituency_lookup_failed'
+        end
+      rescue ConstituencyApi::Error => e
+        Rails.logger.error("Failed to fetch constituency - #{e}")
+        render 'constituency_lookup_failed'
+      end
+    end
+  end
+
+  private
+
+  def sanitized_postcode
+    PostcodeSanitizer.call(params[:postcode])
   end
 end

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -1,0 +1,2 @@
+class LocalPetitionsController < ApplicationController
+end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -31,6 +31,7 @@ class PetitionsController < ApplicationController
     assign_stage
     @stage_manager = Staged::PetitionCreator.manager(petition_params_for_create, request, params[:stage], params[:move])
     if @stage_manager.create_petition
+      @stage_manager.petition.creator_signature.store_constituency_id
       send_email_to_gather_sponsors(@stage_manager.petition)
       redirect_to thank_you_petition_url(@stage_manager.petition)
     else

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -109,6 +109,7 @@ class SignaturesController < ApplicationController
     assign_stage
     @stage_manager = Staged::PetitionSigner.manage(signature_params_for_create, petition, params[:stage], params[:move])
     if @stage_manager.create_signature
+      @stage_manager.signature.store_constituency_id
       send_email_to_petition_signer(@stage_manager.signature)
       respond_with @stage_manager.stage_object, :location => thank_you_petition_signatures_url(petition)
     else

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -26,6 +26,7 @@ class SponsorsController < ApplicationController
     @stage_manager = Staged::PetitionSigner.manage(signature_params_for_create, @petition, params[:stage], params[:move])
     if @stage_manager.create_signature
       @signature = @stage_manager.signature
+      @signature.store_constituency_id
       @sponsor = @petition.sponsors.create(signature: @signature)
       send_email_to_sponsor(@sponsor)
       redirect_to thank_you_petition_sponsor_url(@petition, token: @petition.sponsor_token)

--- a/app/lib/constituency_api.rb
+++ b/app/lib/constituency_api.rb
@@ -2,14 +2,14 @@ module ConstituencyApi
   class Error < RuntimeError; end
 
   class Constituency
-    attr_reader :name, :mp
+    attr_reader :id, :name, :mp
 
-    def initialize(name, mp = nil)
-      @name, @mp = name, mp
+    def initialize(id, name, mp = nil)
+      @id, @name, @mp = id, name, mp
     end
 
     def ==(other)
-      other.is_a?(self.class) && name == other.name && mp == other.mp
+      other.is_a?(self.class) && id == other.id && name == other.name && mp == other.mp
     end
     alias_method :eql?, :==
   end
@@ -45,7 +45,7 @@ module ConstituencyApi
     def self.parse_constituencies(response)
       return [] unless response["Constituencies"]
       constituencies = response["Constituencies"]["Constituency"]
-      Array.wrap(constituencies).map { |c| Constituency.new(c["Name"], last_mp(c)) }
+      Array.wrap(constituencies).map { |c| Constituency.new(c["Constituency_Id"], c["Name"], last_mp(c)) }
     end
 
     def self.call_api(postcode)

--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -10,6 +10,11 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
     find_or_create_by(petition: petition, constituency_id: constituency_id)
   end
 
+  def self.record_new_signature_for(signature)
+    return if signature.nil? || signature.petition.nil? || signature.constituency_id.blank? || !signature.validated?
+    self.for(signature.petition, signature.constituency_id).record_new_signature
+  end
+
   def record_new_signature(at = Time.current)
     signature_count_field = self.class.connection.quote_column_name('signature_count')
     changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"

--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -6,6 +6,14 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
   validates :petition_id, uniqueness: { scope: [:constituency_id] }
   validates :signature_count, presence: true
 
+  scope :ordered, -> {
+    order("#{table_name}.signature_count DESC")
+  }
+  scope :with_signatures_for, ->(constituency_id) {
+    where("#{table_name}.signature_count > 0").
+    where(table_name => { constituency_id: constituency_id})
+  }
+
   def self.for(petition, constituency_id)
     find_or_create_by(petition: petition, constituency_id: constituency_id)
   end

--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -5,4 +5,15 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
   validates :constituency_id, presence: true, length: { maximum: 255 }
   validates :petition_id, uniqueness: { scope: [:constituency_id] }
   validates :signature_count, presence: true
+
+  def self.for(petition, constituency_id)
+    find_or_create_by(petition: petition, constituency_id: constituency_id)
+  end
+
+  def record_new_signature(at = Time.current)
+    signature_count_field = self.class.connection.quote_column_name('signature_count')
+    changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
+    self.class.where(id: id).update_all([changes, updated_at: at])
+    reload
+  end
 end

--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -1,0 +1,8 @@
+class ConstituencyPetitionJournal < ActiveRecord::Base
+  belongs_to :petition
+
+  validates :petition, presence: true
+  validates :constituency_id, presence: true, length: { maximum: 255 }
+  validates :petition_id, uniqueness: { scope: [:constituency_id] }
+  validates :signature_count, presence: true
+end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -85,5 +85,10 @@ class Signature < ActiveRecord::Base
   def set_constituency_id
     self.constituency_id = constituency.try(:id)
   end
+
+  def store_constituency_id
+    set_constituency_id
+    save if constituency_id_changed?
+  end
 end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -81,5 +81,9 @@ class Signature < ActiveRecord::Base
     Rails.logger.error("Failed to fetch constituency - #{e}")
     nil
   end
+
+  def set_constituency_id
+    self.constituency_id = constituency.try(:id)
+  end
 end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -1,3 +1,5 @@
+require 'postcode_sanitizer'
+
 class Signature < ActiveRecord::Base
 
   include PerishableTokenGenerator
@@ -41,7 +43,7 @@ class Signature < ActiveRecord::Base
   end
 
   def postcode=(value)
-    super(value.to_s.gsub(/\s+/, "").upcase)
+    super(PostcodeSanitizer.call(value))
   end
 
   def creator?

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -67,8 +67,13 @@ class Signature < ActiveRecord::Base
   end
 
   def validate!
-    self.update_columns(state: Signature::VALIDATED_STATE)
-    self.touch
+    if pending?
+      self.update_columns(
+        state: VALIDATED_STATE,
+        updated_at: Time.current
+      )
+      ConstituencyPetitionJournal.record_new_signature_for(self)
+    end
   end
 
   def unsubscribe!

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -18,6 +18,7 @@ class Signature < ActiveRecord::Base
   include Staged::Validations::SignerDetails
   include Staged::Validations::MultipleSigners
   validates_inclusion_of :state, :in => STATES, :message => "'%{value}' not recognised"
+  validates :constituency_id, length: { maximum: 255 }
 
   # = Finders =
   scope :validated, -> { where(state: VALIDATED_STATE) }

--- a/app/views/local_petitions/_search.html.erb
+++ b/app/views/local_petitions/_search.html.erb
@@ -1,0 +1,7 @@
+<%= form_tag local_petitions_path, method: 'get' do %>
+  <div class="form-group">
+    <%= label_tag 'postcode', 'UK postcode', class: 'form-label' %>
+    <%= search_field_tag 'postcode', local_assigns[:postcode], class: 'form-control' %>
+  </div>
+  <%= submit_tag 'Search', class: 'button' %>
+<% end %>

--- a/app/views/local_petitions/constituency_lookup_failed.html.erb
+++ b/app/views/local_petitions/constituency_lookup_failed.html.erb
@@ -1,0 +1,4 @@
+<h1 class="page-title">Sorry!</h1>
+<p>We could not find your constituency from the postcode you provided: <q><%= params[:postcode] %></q>.</p>
+<p>It's possible that the API we use is down, or that your postcode wasn't recognised.  Why not try again?</p>
+<%= render 'local_petitions/search', postcode: params[:postcode] %>

--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -1,6 +1,10 @@
 <% content_for(:page_title) { "Petitions in #{@constituency.name}" } %>
 <h1 class="page-title">Petitions in <%= @constituency.name %></h1>
 
+<% if @constituency.mp %>
+  <p>Your MP is <%= link_to @constituency.mp.name, @constituency.mp.url %></p>
+<% end %>
+
 <div class="section-panel local-petitions">
   <% if @petitions.any? %>
     <ol>

--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -1,0 +1,3 @@
+<% content_for(:page_title) { "Petitions in #{@constituency.name}" } %>
+<h1 class="page-title">Petitions in <%= @constituency.name %></h1>
+

--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -1,3 +1,16 @@
 <% content_for(:page_title) { "Petitions in #{@constituency.name}" } %>
 <h1 class="page-title">Petitions in <%= @constituency.name %></h1>
 
+<div class="section-panel local-petitions">
+  <ol>
+    <% @petitions.each do |petition| %>
+      <li class="petition-item petition-<%= petition.state %>">
+        <%= link_to petition.title, petition_path(petition) %>
+        <p>
+          <%= signature_count(:in_your_constituency, petition.constituency_signature_count) %>
+          (<%= signature_count(:in_total, petition.signature_count) %>)
+        </p>
+      </li>
+    <% end -%>
+  </ol>
+</div>

--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -2,15 +2,19 @@
 <h1 class="page-title">Petitions in <%= @constituency.name %></h1>
 
 <div class="section-panel local-petitions">
-  <ol>
-    <% @petitions.each do |petition| %>
-      <li class="petition-item petition-<%= petition.state %>">
-        <%= link_to petition.title, petition_path(petition) %>
-        <p>
-          <%= signature_count(:in_your_constituency, petition.constituency_signature_count) %>
-          (<%= signature_count(:in_total, petition.signature_count) %>)
-        </p>
-      </li>
-    <% end -%>
-  </ol>
+  <% if @petitions.any? %>
+    <ol>
+      <% @petitions.each do |petition| %>
+        <li class="petition-item petition-<%= petition.state %>">
+          <%= link_to petition.title, petition_path(petition) %>
+          <p>
+            <%= signature_count(:in_your_constituency, petition.constituency_signature_count) %>
+            (<%= signature_count(:in_total, petition.signature_count) %>)
+          </p>
+        </li>
+      <% end -%>
+    </ol>
+  <% else %>
+    <p>No petitions are popular in your constituency.</p>
+  <% end %>
 </div>

--- a/app/views/local_petitions/no_postcode_provided.html.erb
+++ b/app/views/local_petitions/no_postcode_provided.html.erb
@@ -1,0 +1,3 @@
+<h1 class="page-title">Local to you</h1>
+<p>Find petitions about local issues</p>
+<%= render 'local_petitions/search' %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -16,13 +16,25 @@
   <%= link_to 'View all e-petitions', petitions_path, :class => 'view-all' %>
 </div>
 
+<section class="section-panel local-to-you">
+  <h2>Local to you</h2>
+  <p>Find petitions about local issues</p>
+  <form method="get" action="/petitions/local">
+    <div class="form-group">
+      <label for="postcode" class="form-label">UK postcode</label>
+      <input type="text" name="postcode" id="postcode" class="form-control" />
+    </div>
+    <input type="submit" value="Search" class="button" />
+  </form>
+</section>
+
 <section class="section-panel">
   <h2>Start a new petition</h2>
   <p>Anyone can start a petition as long as they are a British citizen or UK resident</p>
   <%= link_to "Start a new petition", check_petitions_path, :class => 'button' %>
 </section>
 
-<form method="get" action="/search">
+<form method="get" action="/search" class="search-form">
   <div class="form-group">
     <label for="search" class="form-label">Search for an e-petition to sign</label>
     <input type='text' name="q" id="search" class="form-control" />

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -19,13 +19,7 @@
 <section class="section-panel local-to-you">
   <h2>Local to you</h2>
   <p>Find petitions about local issues</p>
-  <%= form_tag local_petitions_path, method: 'get' do %>
-    <div class="form-group">
-      <%= label_tag 'postcode', 'UK postcode', class: 'form-label' %>
-      <%= search_field_tag 'postcode', nil, class: 'form-control' %>
-    </div>
-    <%= submit_tag 'Search', class: 'button' %>
-  <% end %>
+  <%= render 'local_petitions/search' %>
 </section>
 
 <section class="section-panel">

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -19,13 +19,13 @@
 <section class="section-panel local-to-you">
   <h2>Local to you</h2>
   <p>Find petitions about local issues</p>
-  <form method="get" action="/petitions/local">
+  <%= form_tag local_petitions_path, method: 'get' do %>
     <div class="form-group">
-      <label for="postcode" class="form-label">UK postcode</label>
-      <input type="text" name="postcode" id="postcode" class="form-control" />
+      <%= label_tag 'postcode', 'UK postcode', class: 'form-label' %>
+      <%= search_field_tag 'postcode', nil, class: 'form-control' %>
     </div>
-    <input type="submit" value="Search" class="button" />
-  </form>
+    <%= submit_tag 'Search', class: 'button' %>
+  <% end %>
 </section>
 
 <section class="section-panel">

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -21,6 +21,14 @@ en-GB:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> signature in the last hour"
           other: "<span class=\"count\">%{formatted_count}</span> signatures in the last hour"
+      in_your_constituency:
+        html:
+          one: "%{formatted_count} signature from your constituency"
+          other: "%{formatted_count} signatures from your constituency"
+      in_total:
+        html:
+          one: "%{formatted_count} signature total"
+          other: "%{formatted_count} signatures total"
 
     rejection_reasons:
       titles:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     collection do
       get 'check'
       get 'check_results'
+      get 'local' => 'local_petitions#index'
     end
 
     member do

--- a/db/migrate/20150609111042_add_constituency_id_to_signatures.rb
+++ b/db/migrate/20150609111042_add_constituency_id_to_signatures.rb
@@ -1,0 +1,5 @@
+class AddConstituencyIdToSignatures < ActiveRecord::Migration
+  def change
+    add_column :signatures, :constituency_id, :string
+  end
+end

--- a/db/migrate/20150610091149_create_constituency_petition_journals.rb
+++ b/db/migrate/20150610091149_create_constituency_petition_journals.rb
@@ -1,0 +1,13 @@
+class CreateConstituencyPetitionJournals < ActiveRecord::Migration
+  def change
+    create_table :constituency_petition_journals do |t|
+      t.string :constituency_id, null: false
+      t.references :petition, null: false
+      t.integer :signature_count, default: 0, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :constituency_petition_journals, [:petition_id, :constituency_id], unique: true, name: 'idx_constituency_petition_journal_uniqueness'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -224,7 +224,8 @@ CREATE TABLE signatures (
     notify_by_email boolean DEFAULT true,
     last_emailed_at timestamp without time zone,
     email character varying(255),
-    unsubscribe_token character varying
+    unsubscribe_token character varying,
+    constituency_id character varying
 );
 
 
@@ -584,4 +585,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150603033108');
 INSERT INTO schema_migrations (version) VALUES ('20150603112821');
 
 INSERT INTO schema_migrations (version) VALUES ('20150605100049');
+
+INSERT INTO schema_migrations (version) VALUES ('20150609111042');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -113,6 +113,39 @@ ALTER SEQUENCE archived_petitions_id_seq OWNED BY archived_petitions.id;
 
 
 --
+-- Name: constituency_petition_journals; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE constituency_petition_journals (
+    id integer NOT NULL,
+    constituency_id character varying NOT NULL,
+    petition_id integer NOT NULL,
+    signature_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: constituency_petition_journals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE constituency_petition_journals_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: constituency_petition_journals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE constituency_petition_journals_id_seq OWNED BY constituency_petition_journals.id;
+
+
+--
 -- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -331,6 +364,13 @@ ALTER TABLE ONLY archived_petitions ALTER COLUMN id SET DEFAULT nextval('archive
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY constituency_petition_journals ALTER COLUMN id SET DEFAULT nextval('constituency_petition_journals_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY delayed_jobs ALTER COLUMN id SET DEFAULT nextval('delayed_jobs_id_seq'::regclass);
 
 
@@ -379,6 +419,14 @@ ALTER TABLE ONLY archived_petitions
 
 
 --
+-- Name: constituency_petition_journals_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY constituency_petition_journals
+    ADD CONSTRAINT constituency_petition_journals_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -416,6 +464,13 @@ ALTER TABLE ONLY sponsors
 
 ALTER TABLE ONLY system_settings
     ADD CONSTRAINT system_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: idx_constituency_petition_journal_uniqueness; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX idx_constituency_petition_journal_uniqueness ON constituency_petition_journals USING btree (petition_id, constituency_id);
 
 
 --
@@ -587,4 +642,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150603112821');
 INSERT INTO schema_migrations (version) VALUES ('20150605100049');
 
 INSERT INTO schema_migrations (version) VALUES ('20150609111042');
+
+INSERT INTO schema_migrations (version) VALUES ('20150610091149');
 

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -10,11 +10,11 @@ Feature: Freya searches petitions by constituency
     And an open petition "Restore vintage diggers" with some signatures
     And an open petition "Build more quirky theme parks" with some signatures
     And a closed petition "What about other primates?" with some signatures
-    And constituents in "Rochester and Strood" support "Restore vintage diggers"
-    And constituents in "South Dorset" support "Save the monkeys"
-    And constituents in "South Dorset" support "Build more quirky theme parks"
-    And constituents in "Rochester and Strood" support "Build more quirky theme parks"
-    And constituents in "South Dorset" support "What about other primates?"
+    And a constituent in "Rochester and Strood" supports "Restore vintage diggers"
+    And few constituents in "South Dorset" support "Save the monkeys"
+    And some constituents in "South Dorset" support "Build more quirky theme parks"
+    And many constituents in "Rochester and Strood" support "Build more quirky theme parks"
+    And a constituent in "South Dorset" supports "What about other primates?"
 
   Scenario: Searching for local petitions
     Given I am on the home page
@@ -26,6 +26,7 @@ Feature: Freya searches petitions by constituency
     And I should see that my fellow constituents support "Build more quirky theme parks"
     But I should not see that my fellow constituents support "What about other primates?"
     And I should not see that my fellow constituents support "Restore vintage diggers"
+    And the petitions I see should be ordered by my fellow constituents level of support
 
   Scenario: Searching for local petitions when the api is down
     Given the constituency api is down

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -1,0 +1,35 @@
+Feature: Freya searches petitions by constituency
+  In order to see what petitions are relevant to other people in my constituency
+  As Freya, a member of the general public
+  I want to use my postcode to find my constituency and see petitions with signatures from people who also live in it
+
+  Background:
+    Given a constituency "South Dorset" is found by postcode "BH20 6HH"
+    And a constituency "Rochester and Strood" is found by postcode "ME2 2NU"
+    And an open petition "Save the monkeys" with some signatures
+    And an open petition "Restore vintage diggers" with some signatures
+    And an open petition "Build more quirky theme parks" with some signatures
+    And a closed petition "What about other primates?" with some signatures
+    And constituents in "Rochester and Strood" support "Restore vintage diggers"
+    And constituents in "South Dorset" support "Save the monkeys"
+    And constituents in "South Dorset" support "Build more quirky theme parks"
+    And constituents in "Rochester and Strood" support "Build more quirky theme parks"
+    And constituents in "South Dorset" support "What about other primates?"
+
+  Scenario: Searching for local petitions
+    Given I am on the home page
+    When I search for petitions local to me in "BH20 6HH"
+    Then I should be on the local petitions results page
+    And the markup should be valid
+    And I should see "Petitions in South Dorset" in the browser page title
+    And I should see that my fellow constituents support "Save the monkeys"
+    And I should see that my fellow constituents support "Build more quirky theme parks"
+    But I should not see that my fellow constituents support "What about other primates?"
+    And I should not see that my fellow constituents support "Restore vintage diggers"
+
+  Scenario: Searching for local petitions when the api is down
+    Given the constituency api is down
+    And I am on the home page
+    When I search for petitions local to me in "BH20 6HH"
+    Then the markup should be valid
+    But I should see an explanation that my constituency couldn't be found

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -4,7 +4,7 @@ Feature: Freya searches petitions by constituency
   I want to use my postcode to find my constituency and see petitions with signatures from people who also live in it
 
   Background:
-    Given a constituency "South Dorset" is found by postcode "BH20 6HH"
+    Given a constituency "South Dorset" with MP "Emma Pee MP" is found by postcode "BH20 6HH"
     And a constituency "Rochester and Strood" is found by postcode "ME2 2NU"
     And an open petition "Save the monkeys" with some signatures
     And an open petition "Restore vintage diggers" with some signatures
@@ -22,6 +22,7 @@ Feature: Freya searches petitions by constituency
     Then I should be on the local petitions results page
     And the markup should be valid
     And I should see "Petitions in South Dorset" in the browser page title
+    And I should see a link to the MP for my constituency
     And I should see that my fellow constituents support "Save the monkeys"
     And I should see that my fellow constituents support "Build more quirky theme parks"
     But I should not see that my fellow constituents support "What about other primates?"

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -45,7 +45,10 @@ end
 
 When(/^I search for petitions local to me in "(.*?)"$/) do |postcode|
   @my_constituency = @constituencies.fetch(postcode)
-  step %{I fill in "UK postcode" with "#{postcode}"}
+  within :css, '.local-to-you' do
+    fill_in "UK postcode", with: postcode
+    click_on "Search"
+  end
 end
 
 Then(/^I should see that my fellow constituents support "(.*?)"$/) do |petition_title|

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -22,7 +22,7 @@ Given(/^constituents in "(.*?)" support "(.*?)"$/) do |constituency, petition_ti
   petition = Petition.find_by!(title: petition_title)
   constituency = @constituencies.fetch(constituency)
   10.times do
-    FactoryGirl.create(:validated_signature, petition: petition, constituency_id: constituency.id)
+    FactoryGirl.create(:pending_signature, petition: petition, constituency_id: constituency.id).validate!
   end
 end
 

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -9,24 +9,7 @@ Given(/^a constituency "(.*?)" is found by postcode "(.*?)"$/) do |constituency_
 
   for_postcode = @constituencies[postcode]
   if for_postcode.nil?
-    body = <<-RESPONSE.strip_heredoc
-      <Constituencies>
-        <Constituency>
-          <Constituency_Id>#{constituency.id}</Constituency_Id>
-          <Name>#{constituency.name}</Name>
-          <RepresentingMembers>
-            <RepresentingMember>
-              <Member_Id>0001</Member_Id>
-              <Member>A. N. Other MP</Member>
-              <StartDate>2015-05-07T00:00:00</StartDate>
-              <EndDate xsi:nil="true"
-                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
-            </RepresentingMember>
-          </RepresentingMembers>
-        </Constituency>
-      </Constituencies>
-      RESPONSE
-    stub_request(:get, "#{ ConstituencyApi::Client::URL }/#{postcode.gsub(/\s+/, '')}/").to_return(status: 200, body: body)
+    stub_constituency(postcode, constituency.id, constituency.name)
     @constituencies[postcode] = constituency
   elsif for_postcode == constituency
     # noop
@@ -70,7 +53,7 @@ Then(/^I should not see that my fellow constituents support "(.*?)"$/) do |petit
 end
 
 Given(/^the constituency api is down$/) do
-  stub_request(:get, %r[#{ Regexp.escape(ConstituencyApi::Client::URL) }/*]).to_return(status: 500, body: "Daisy, Daisy / Give me your answer, do. / I'm half crazy / all for the love of you.")
+  stub_broken_api
 end
 
 Then(/^I should see an explanation that my constituency couldn't be found$/) do

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -1,0 +1,76 @@
+Given(/^a constituency "(.*?)" is found by postcode "(.*?)"$/) do |constituency_name, postcode|
+  @constituencies ||= {}
+
+  constituency = @constituencies[constituency_name]
+  if constituency.nil?
+    constituency = ConstituencyApi::Constituency.new(FactoryGirl.generate(:constituency_id), constituency_name)
+    @constituencies[constituency.name] = constituency
+  end
+
+  for_postcode = @constituencies[postcode]
+  if for_postcode.nil?
+    body = <<-RESPONSE.strip_heredoc
+      <Constituencies>
+        <Constituency>
+          <Constituency_Id>#{constituency.id}</Constituency_Id>
+          <Name>#{constituency.name}</Name>
+          <RepresentingMembers>
+            <RepresentingMember>
+              <Member_Id>0001</Member_Id>
+              <Member>A. N. Other MP</Member>
+              <StartDate>2015-05-07T00:00:00</StartDate>
+              <EndDate xsi:nil="true"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+            </RepresentingMember>
+          </RepresentingMembers>
+        </Constituency>
+      </Constituencies>
+      RESPONSE
+    stub_request(:get, "#{ ConstituencyApi::Client::URL }/#{postcode.gsub(/\s+/, '')}/").to_return(status: 200, body: body)
+    @constituencies[postcode] = constituency
+  elsif for_postcode == constituency
+    # noop
+  else
+    raise "Postcode #{postcode} registered for constituency #{for_postcode.name} already, can't reassign to #{constituency.name}"
+  end
+end
+
+Given(/^constituents in "(.*?)" support "(.*?)"$/) do |constituency, petition_title|
+  petition = Petition.find_by!(title: petition_title)
+  constituency = @constituencies.fetch(constituency)
+  10.times do
+    FactoryGirl.create(:validated_signature, petition: petition, constituency_id: constituency.id)
+  end
+end
+
+When(/^I search for petitions local to me in "(.*?)"$/) do |postcode|
+  @my_constituency = @constituencies.fetch(postcode)
+  step %{I fill in "UK postcode" with "#{postcode}"}
+end
+
+Then(/^I should see that my fellow constituents support "(.*?)"$/) do |petition_title|
+  petition = Petition.find_by!(title: petition_title)
+  all_signature_count = petition.signatures.validated.count
+  local_signature_count = petition.signatures.validated.where(constituency_id: @my_constituency.id).count
+  within :css, '.local-petitions ol' do
+    within ".//li[a[.='#{petition_title}']]" do
+      expect(page).to have_text("#{local_signature_count} signatures from your constituency")
+      expect(page).to have_text("#{all_signature_count} signatures total")
+    end
+  end
+end
+
+Then(/^I should not see that my fellow constituents support "(.*?)"$/) do |petition_title|
+  within :css, '.local-petitions ol' do |list|
+    expect(list).not_to have_selector(".//li[a[.='#{petition_title}']]")
+  end
+end
+
+Given(/^the constituency api is down$/) do
+  stub_request(:get, %r[#{ Regexp.escape(ConstituencyApi::Client::URL) }/*]).to_return(status: 500, body: "Daisy, Daisy / Give me your answer, do. / I'm half crazy / all for the love of you.")
+end
+
+Then(/^I should see an explanation that my constituency couldn't be found$/) do
+  expect(page).not_to have_selector(:css, '.local-petitions ol')
+  expect(page).to have_content('We could not find your constituency from the postcode you provided')
+end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -279,3 +279,16 @@ end
 Then /^I expand "([^"]*)"/ do |text|
   page.find("//details/summary[contains(., '#{text}')]").click
 end
+
+Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |state, title|
+  petition_closed_at = state == 'closed' ? 1.day.ago : 1.day.from_now
+  petition_state = state == 'closed' ? 'open' : state
+  petition_args = {
+    title: title,
+    open_at: 3.months.ago,
+    closed_at: petition_closed_at,
+    state: petition_state
+  }
+  petition = FactoryGirl.create(:open_petition, petition_args)
+  5.times { FactoryGirl.create(:validated_signature, petition: petition) }
+end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -291,4 +291,5 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |
   }
   petition = FactoryGirl.create(:open_petition, petition_args)
   5.times { FactoryGirl.create(:validated_signature, petition: petition) }
+  Petition.update_all_signature_counts
 end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -9,8 +9,10 @@ end
 
 When /^I search for "([^"]*)"$/ do |query|
   visit home_path
-  fill_in :search, :with => query
-  click_link_or_button "Search"
+  within :css, '.search-form' do
+    fill_in :search, :with => query
+    click_on "Search"
+  end
 end
 
 Then /^I should not be able to search via free text$/ do

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -149,7 +149,7 @@ When /^I try to sign the petition with the same email address, a different name,
   step "I decide to sign the petition"
   step "I fill in my details"
   step %{I fill in "Name" with "Sam Wibbledon"}
-  step %{I fill in "Postcode" with "W1A 1AA"}
+  step %{I fill in my postcode with "W1A 1AA"}
   step "I try to sign"
 end
 

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -67,13 +67,11 @@ end
 When(/^I fill in my postcode with "(.*?)"$/) do |postcode|
   step %{I fill in "Postcode" with "#{postcode}"}
 
-  api_url = ConstituencyApi::Client::URL
-  if postcode == "N1 1TY"
-    body = IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "N11TY.xml"))
+  if postcode == 'N1 1TY'
+    stub_constituency_from_file(postcode, Rails.root.join("spec", "fixtures", "constituency_api", "N11TY.xml"))
   else
-    body = IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "no_results.xml"))
+    stub_no_constituencies(postcode)
   end
-  stub_request(:get, "#{ api_url }/#{postcode.gsub(/\s+/, '')}/").to_return(status: 200, body: body)
 end
 
 When /^I fill in my details and sign a petition$/ do

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -20,7 +20,7 @@ When(/^a sponsor supports my e\-petition$/) do
     And I fill in "Name" with "Anonymous Sponsor"
     And I fill in "Email" with "#{sponsor_email}"
     And I check "Yes, I am a British citizen or UK resident"
-    And I fill in "Postcode" with "SW1A 1AA"
+    And I fill in my postcode with "SW1A 1AA"
     And I select "United Kingdom" from "Location"
     And I try to sign
     And I say I am happy with my email address
@@ -93,7 +93,7 @@ When(/^I fill in my details as a sponsor(?: with email "(.*?)")?$/) do |email_ad
     When I fill in "Name" with "Laura The Sponsor"
     And I fill in "Email" with "#{email_address}"
     And I check "Yes, I am a British citizen or UK resident"
-    And I fill in "Postcode" with "AB10 1AA"
+    And I fill in my postcode with "AB10 1AA"
     And I select "United Kingdom" from "Location"
   )
 end

--- a/features/support/constituency_api.rb
+++ b/features/support/constituency_api.rb
@@ -1,0 +1,3 @@
+require Rails.root.join 'spec/support/constituency_api_helpers'
+
+World(ConstituencyApiHelpers::NetworkLevel)

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -41,6 +41,9 @@ module NavigationHelpers
     when /^the Admin (.*)$/i
       admin_path($1)
 
+    when /^the local petitions results page$/
+      local_petitions_path
+
     else
       begin
         page_name =~ /^the (.*) page$/

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -18,9 +18,7 @@ Feature: Suzy Singer searches by free text
     And all petitions have had their signatures counted
 
   Scenario: Search for open petitions
-    When I go to the home page
-    And I fill in "search" with "Wombles"
-    And I press "Search"
+    When I search for "Wombles"
     Then I should be on the search results page
     And I should see "Search results - e-petitions" in the browser page title
     And I should see /For "Wombles"/
@@ -34,26 +32,20 @@ Feature: Suzy Singer searches by free text
     And the markup should be valid
 
   Scenario: See search counts
-    When I go to the home page
-    And I fill in "search" with "Wombles"
-    And I press "Search"
+    When I search for "Wombles"
     Then I should see an "open" petition count of 4
     Then I should see a "closed" petition count of 1
     Then I should see a "rejected" petition count of 1
 
   Scenario: Search for open petitions using multiple search terms
-    When I go to the home page
-    And I fill in "search" with "overthrow the"
-    And I press "Search"
-    But I should see the following search results:
-      | Overthrow the Wombles | 1 signatures          |
+    When I search for "overthrow the"
+    Then I should see the following search results:
+      | Overthrow the Wombles | 1 signatures |
 
   Scenario: Search for special lucene characters to ensure they are escaped correctly
-    When I go to the home page
-    And I fill in "search" with "+ -|| ! && Common () { } [ ] ^ ~ * ? : \\"
-    And I press "Search"
+    When I search for "+ -|| ! && Common () { } [ ] ^ ~ * ? : \\"
     Then I should see the following search results:
-      | Common People | 1 signatures          |
+      | Common People | 1 signatures |
 
   Scenario: Search for rejected petitions
     When I go to the search page

--- a/lib/postcode_sanitizer.rb
+++ b/lib/postcode_sanitizer.rb
@@ -1,0 +1,5 @@
+module PostcodeSanitizer
+  def self.call(postcode)
+    postcode.to_s.gsub(/\s+/, "").upcase
+  end
+end

--- a/spec/controllers/local_petitions_controller_spec.rb
+++ b/spec/controllers/local_petitions_controller_spec.rb
@@ -22,6 +22,17 @@ describe LocalPetitionsController, type: :controller do
           expect(constituency).to eq ConstituencyApi::Constituency.new(constituency_id, constituency_name, mp)
         end
 
+        it 'exposes the 3 most popular petitions in the constituency' do
+          petitions = double
+          expect(Petition).to receive(:popular_in_constituency).with(constituency_id, 3).and_return petitions
+
+          get :index, params
+
+          petitions = assigns(:petitions)
+          expect(petitions).to be_present
+          expect(petitions).to eq petitions
+        end
+
         it 'responds successfully and renders the index template' do
           get :index, params
           expect(response).to be_success

--- a/spec/controllers/local_petitions_controller_spec.rb
+++ b/spec/controllers/local_petitions_controller_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+describe LocalPetitionsController, type: :controller do
+  describe 'GET :index' do
+    context 'when a postcode is supplied' do
+      let(:postcode) { 'SW1A 1aa' }
+      let(:params) { { postcode: postcode } }
+
+      context 'that can be found on the API' do
+        let(:api_url) { ConstituencyApi::Client::URL }
+        let(:constituency_id) { FactoryGirl.generate(:constituency_id) }
+        let(:constituency_name) { 'Cities of London and Westminster' }
+        let(:mp) { ConstituencyApi::Mp.new('4321', 'Emma Pee MP', 3.years.ago.to_date) }
+        let(:api_response) do
+          <<-RESPONSE.strip_heredoc
+            <Constituencies>
+              <Constituency>
+                <Constituency_Id>#{ constituency_id }</Constituency_Id>
+                <Name>#{ constituency_name }</Name>
+                <RepresentingMembers>
+                  <RepresentingMember>
+                    <Member_Id>#{mp.id}</Member_Id>
+                    <Member>#{mp.name}</Member>
+                    <StartDate>#{mp.start_date}</StartDate>
+                    <EndDate xsi:nil="true"
+                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                  </RepresentingMember>
+                </RepresentingMembers>
+              </Constituency>
+            </Constituencies>
+          RESPONSE
+        end
+
+        before do
+          stub_request(:get, "#{ api_url }/#{PostcodeSanitizer.call(postcode)}/").to_return(status: 200, body: api_response)
+        end
+
+        it 'exposes a constituency object for the postcode' do
+          get :index, params
+          constituency = assigns(:constituency)
+          expect(constituency).to be_present
+          expect(constituency).to eq ConstituencyApi::Constituency.new(constituency_id, constituency_name, mp)
+        end
+
+        it 'responds successfully and renders the index template' do
+          get :index, params
+          expect(response).to be_success
+          expect(response).to render_template 'local_petitions/index'
+        end
+      end
+
+      shared_examples_for 'a local petitions controller that failed to lookup a constituency' do
+        it 'exposes no constituency object' do
+          get :index, params
+          constituency = assigns(:constituency)
+          expect(constituency).to be_nil
+        end
+
+        it 'responds successfully and renders the error template' do
+          get :index, params
+          expect(response).to be_success
+          expect(response).to render_template 'local_petitions/constituency_lookup_failed'
+        end
+      end
+
+      context 'that cannot be found on the API' do
+        let(:api_url) { ConstituencyApi::Client::URL }
+        let(:api_response) do
+          <<-RESPONSE.strip_heredoc
+            <Constituencies/>
+          RESPONSE
+        end
+
+        before do
+          stub_request(:get, "#{ api_url }/#{PostcodeSanitizer.call(postcode)}/").to_return(status: 200, body: api_response)
+        end
+
+        it_behaves_like 'a local petitions controller that failed to lookup a constituency'
+      end
+
+      context 'but the API is down' do
+        let(:api_url) { ConstituencyApi::Client::URL }
+        before do
+          stub_request(:get, "#{ api_url }/#{PostcodeSanitizer.call(postcode)}/").to_return(status: 500)
+        end
+
+        it_behaves_like 'a local petitions controller that failed to lookup a constituency'
+      end
+    end
+
+    shared_examples_for 'a local petitions controller that does not try to lookup a constituency' do
+      it 'does not communicate with the API' do
+        expect(ConstituencyApi::Client).not_to receive(:constituencies)
+        get :index, params
+      end
+
+      it 'responds successfully and renders the blank postcode template' do
+        get :index, params
+        expect(response).to be_success
+        expect(response).to render_template 'local_petitions/no_postcode_provided'
+      end
+    end
+
+    context 'when no postcode is supplied' do
+      let(:params) { {} }
+
+      it_behaves_like 'a local petitions controller that does not try to lookup a constituency'
+    end
+
+    context 'when a blank postcode is supplied' do
+      let(:params) { {postcode: ' '} }
+
+      it_behaves_like 'a local petitions controller that does not try to lookup a constituency'
+    end
+  end
+end

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -2,21 +2,14 @@ require 'rails_helper'
 
 describe SignaturesController do
   include ActiveJob::TestHelper
+  include ConstituencyApiHelpers::NetworkLevel
 
   describe "verify" do
     context "signature of user who is not the petition's creator" do
       let(:petition) { FactoryGirl.create(:petition) }
       let(:signature) { FactoryGirl.create(:pending_signature, :petition => petition) }
-      let(:api_url) { ConstituencyApi::Client::URL }
-      let(:fake_body) {
-        "<Constituencies>
-        <Constituency><Name>Cities of London and Westminster</Name></Constituency>
-       </Constituencies>"
-      }
 
-      before do
-        stub_request(:get, "#{ api_url }/SW1A1AA/").to_return(status: 200, body: fake_body)
-      end
+      before { stub_constituency('SW1A 1AA', '1234', 'Cities of London and Westminster') }
 
       it "should respond to /signatures/:id/verify/:token" do
         expect({:get => "/signatures/#{signature.id}/verify/#{signature.perishable_token}"}).

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -95,6 +95,8 @@ describe SponsorsController do
   end
 
   context 'PATCH update' do
+    include ConstituencyApiHelpers::ApiLevel
+
     let(:petition) { FactoryGirl.create(:petition) }
     let(:signature_params) {
       {
@@ -107,6 +109,8 @@ describe SponsorsController do
       }
     }
 
+    let(:constituency) { ConstituencyApi::Constituency.new('54321', 'Sponsor-upon-petition')}
+
     def do_patch(options = {})
       params = {
         petition_id: petition,
@@ -115,6 +119,7 @@ describe SponsorsController do
         stage: 'replay-email',
         move: 'next'
       }.merge(options)
+      stub_constituency(params[:signature][:postcode], constituency)
       patch :update, params
     end
 
@@ -183,6 +188,11 @@ describe SponsorsController do
         do_patch
         expect(signature).to be_pending
         expect(signature.perishable_token).not_to be_nil
+      end
+
+      it "sets the constituency_id on the creator signature, based on the postcode" do
+        do_patch
+        expect(signature.constituency_id).to eq constituency.id
       end
 
       it 'redirects to the thank you page' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -141,4 +141,6 @@ FactoryGirl.define do
   factory :system_setting do
     sequence(:key)  {|n| "key#{n}"}
   end
+
+  sequence(:constituency_id) { |n| (1234 + n).to_s }
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -143,4 +143,5 @@ FactoryGirl.define do
   end
 
   sequence(:constituency_id) { |n| (1234 + n).to_s }
+  sequence(:mp_id) { |n| (4321 + n).to_s }
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -144,4 +144,10 @@ FactoryGirl.define do
 
   sequence(:constituency_id) { |n| (1234 + n).to_s }
   sequence(:mp_id) { |n| (4321 + n).to_s }
+
+
+  factory :constituency_petition_journal do
+    constituency_id { generate(:constituency_id) }
+    association :petition
+  end
 end

--- a/spec/fixtures/constituency_api/no_mps.xml
+++ b/spec/fixtures/constituency_api/no_mps.xml
@@ -1,0 +1,8 @@
+<Constituencies>
+  <Constituency>
+    <Constituency_Id>3550</Constituency_Id>
+    <Name>Islington South and Finsbury</Name>
+    <ONSCode>E14000764</ONSCode>
+    <RepresentingMembers/>
+  </Constituency>
+</Constituencies>

--- a/spec/lib/constituency_api_spec.rb
+++ b/spec/lib/constituency_api_spec.rb
@@ -8,10 +8,10 @@ describe ConstituencyApi::Mp do
       expect(mp.start_date).to eq Date.new(2015, 5, 7)
     end
   end
-  
+
   describe "#url" do
     let(:mp) { ConstituencyApi::Mp.new("1536", "Emily Thornberry MP", Date.new(2015, 5, 7)) }
-    
+
     it "returns the URL for the mp" do
       expect(mp.url).to eq "#{ConstituencyApi::Mp::URL}/emily-thornberry-mp/1536"
     end
@@ -29,13 +29,13 @@ describe ConstituencyApi do
     let(:mp_keir) { ConstituencyApi::Mp.new("4514", "Keir Starmer MP", Date.new(2015, 5, 7)) }
     let(:mp_jeremy) { ConstituencyApi::Mp.new("185", "Jeremy Corbyn MP", Date.new(2015, 5, 7)) }
 
-    let(:constituencies_islington) { [ConstituencyApi::Constituency.new("Islington South and Finsbury", mp_emily)] }
-    let(:constituencies_n1) { [ConstituencyApi::Constituency.new("Hackney North and Stoke Newington", mp_diane),
-                               ConstituencyApi::Constituency.new("Hackney South and Shoreditch", mp_meg),
-                               ConstituencyApi::Constituency.new("Holborn and St Pancras", mp_keir),
-                               ConstituencyApi::Constituency.new("Islington North", mp_jeremy),
-                               ConstituencyApi::Constituency.new("Islington South and Finsbury", mp_emily)] }
-    let(:constituencies_holborn) { [ConstituencyApi::Constituency.new("Holborn and St Pancras", mp_keir)] }
+    let(:constituencies_islington) { [ConstituencyApi::Constituency.new('3550', "Islington South and Finsbury", mp_emily)] }
+    let(:constituencies_n1) { [ConstituencyApi::Constituency.new('3506', "Hackney North and Stoke Newington", mp_diane),
+                               ConstituencyApi::Constituency.new('3507', "Hackney South and Shoreditch", mp_meg),
+                               ConstituencyApi::Constituency.new('3536', "Holborn and St Pancras", mp_keir),
+                               ConstituencyApi::Constituency.new('3549', "Islington North", mp_jeremy),
+                               ConstituencyApi::Constituency.new('3550', "Islington South and Finsbury", mp_emily)] }
+    let(:constituencies_holborn) { [ConstituencyApi::Constituency.new('3536', "Holborn and St Pancras", mp_keir)] }
 
     let(:empty_body) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "no_results.xml")) }
     let(:fake_body) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "N11TY.xml")) }

--- a/spec/lib/constituency_api_spec.rb
+++ b/spec/lib/constituency_api_spec.rb
@@ -58,7 +58,7 @@ describe ConstituencyApi do
     end
 
     it "returns Constituency array for valid postcode with lowercase" do
-      stub_request(:get, "#{ api_url }/n11ty/").to_return(status: 200, body: fake_body)
+      stub_request(:get, "#{ api_url }/N11TY/").to_return(status: 200, body: fake_body)
       expect(api.constituencies("n11ty")).to match_array constituencies_islington
     end
 

--- a/spec/lib/constituency_api_spec.rb
+++ b/spec/lib/constituency_api_spec.rb
@@ -36,11 +36,13 @@ describe ConstituencyApi do
                                ConstituencyApi::Constituency.new('3549', "Islington North", mp_jeremy),
                                ConstituencyApi::Constituency.new('3550', "Islington South and Finsbury", mp_emily)] }
     let(:constituencies_holborn) { [ConstituencyApi::Constituency.new('3536', "Holborn and St Pancras", mp_keir)] }
+    let(:constituencies_islington_no_mp) { [ConstituencyApi::Constituency.new('3550', "Islington South and Finsbury", nil)] }
 
     let(:empty_body) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "no_results.xml")) }
     let(:fake_body) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "N11TY.xml")) }
     let(:fake_body_multiple) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "N1.xml")) }
     let(:fake_body_multiple_mps) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "N1C4QP.xml")) }
+    let(:fake_body_no_mps) { IO.read(Rails.root.join("spec", "fixtures", "constituency_api", "no_mps.xml")) }
 
     it "returns an empty Constituency array for invalid postcode" do
       stub_request(:get, "#{ api_url }/SW149RQ/").to_return(status: 200, body: empty_body)
@@ -70,6 +72,11 @@ describe ConstituencyApi do
     it "returns Constituency array with the last MP where the MP has changed since the last term" do
       stub_request(:get, "#{ api_url }/N1/").to_return(status: 200, body: fake_body_multiple_mps)
       expect(api.constituencies("N1")).to match_array constituencies_holborn
+    end
+
+    it 'handles a constituency without an MP' do
+      stub_request(:get, "#{ api_url }/N11TY/").to_return(status: 200, body: fake_body_no_mps)
+      expect(api.constituencies("N1 1TY")).to eq constituencies_islington_no_mp
     end
 
     it "handles timeout errors" do

--- a/spec/lib/postcode_sanitizer_spec.rb
+++ b/spec/lib/postcode_sanitizer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'postcode_sanitizer'
+
+describe PostcodeSanitizer do
+  describe '.call' do
+    it "removes all whitespace" do
+      postcode = " N1  1TY  "
+      expect(described_class.call(postcode)).to eq "N11TY"
+    end
+    it "upcases the postcode" do
+      postcode = "n11ty "
+      expect(described_class.call(postcode)).to eq "N11TY"
+    end
+    it "removes whitespaces and upcase the postcode" do
+      postcode = "   N1  1ty "
+      expect(described_class.call(postcode)).to eq "N11TY"
+    end
+  end
+end

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ConstituencyPetitionJournal, type: :model do
+  it "has a valid factory" do
+    expect(FactoryGirl.build(:constituency_petition_journal)).to be_valid
+  end
+
+  context "defaults" do
+    subject { described_class.new }
+    it "has 0 for initial signature_count" do
+      expect(subject.signature_count).to eq 0
+    end
+  end
+
+  context "validations" do
+    subject { FactoryGirl.build(:constituency_petition_journal) }
+
+    it { is_expected.to validate_presence_of(:constituency_id) }
+    it { is_expected.to validate_length_of(:constituency_id).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:petition) }
+    it { is_expected.to validate_uniqueness_of(:petition_id).scoped_to(:constituency_id) }
+    it { is_expected.to validate_presence_of(:signature_count) }
+  end
+end

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -21,4 +21,73 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     it { is_expected.to validate_uniqueness_of(:petition_id).scoped_to(:constituency_id) }
     it { is_expected.to validate_presence_of(:signature_count) }
   end
+
+  context '.for' do
+    let(:petition) { FactoryGirl.create(:petition) }
+    let(:constituency_id) { FactoryGirl.generate(:constituency_id) }
+
+    context 'when there is a journal for the requested petition and constituency' do
+      let!(:existing_record) { FactoryGirl.create(:constituency_petition_journal, petition: petition, constituency_id: constituency_id, signature_count: 30) }
+
+      it 'doesn\'t create a new record' do
+        expect {
+          described_class.for(petition, constituency_id)
+        }.not_to change(described_class, :count)
+      end
+
+      it 'fetches the instance from the DB' do
+        fetched = described_class.for(petition, constituency_id)
+        expect(fetched).to eq existing_record
+      end
+    end
+
+    context 'when there is no journal for the requested petition and constituency' do
+      it 'creates a new instance in the DB' do
+        expect {
+          described_class.for(petition, constituency_id)
+        }.to change(described_class, :count).by(1)
+      end
+
+      it 'returns the newly created instance' do
+        fetched = described_class.for(petition, constituency_id)
+        expect(fetched).to be_a described_class
+        expect(fetched).to be_persisted
+      end
+
+      it 'sets the petition of the new instance to the supplied petition' do
+        fetched = described_class.for(petition, constituency_id)
+        expect(fetched.petition).to eq petition
+      end
+
+      it 'sets the constituency_id of the new instance to the supplied petition' do
+        fetched = described_class.for(petition, constituency_id)
+        expect(fetched.constituency_id).to eq constituency_id
+      end
+
+      it 'has 0 for a signature count' do
+        fetched = described_class.for(petition, constituency_id)
+        expect(fetched.signature_count).to eq 0
+      end
+    end
+  end
+
+  context '#record_new_signature' do
+    let(:petition) { FactoryGirl.create(:petition) }
+    let(:constituency_id) { FactoryGirl.generate(:constituency_id) }
+
+    subject { described_class.for(petition, constituency_id) }
+
+    it 'increments signature_count by 1' do
+      expect {
+        subject.record_new_signature
+      }.to change(subject, :signature_count).by(1)
+    end
+
+    it 'persists the change' do
+      old_signature_count = subject.signature_count
+      subject.record_new_signature
+      subject.reload
+      expect(subject.signature_count).not_to eq old_signature_count
+    end
+  end
 end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -265,6 +265,66 @@ describe Petition do
     end
   end
 
+  describe '.popular_in_constituency' do
+    let!(:petition_1) { FactoryGirl.create(:open_petition, signature_count: 10) }
+    let!(:petition_2) { FactoryGirl.create(:open_petition, signature_count: 20) }
+    let!(:petition_3) { FactoryGirl.create(:open_petition, signature_count: 30) }
+    let!(:petition_4) { FactoryGirl.create(:open_petition, signature_count: 40) }
+
+    let!(:constituency_1) { FactoryGirl.generate(:constituency_id) }
+    let!(:constituency_2) { FactoryGirl.generate(:constituency_id) }
+
+    let!(:petition_1_journal_1) { FactoryGirl.create(:constituency_petition_journal, petition: petition_1, constituency_id: constituency_1, signature_count: 6) }
+    let!(:petition_1_journal_2) { FactoryGirl.create(:constituency_petition_journal, petition: petition_1, constituency_id: constituency_2, signature_count: 4) }
+    let!(:petition_2_journal_2) { FactoryGirl.create(:constituency_petition_journal, petition: petition_2, constituency_id: constituency_2, signature_count: 20) }
+    let!(:petition_3_journal_1) { FactoryGirl.create(:constituency_petition_journal, petition: petition_3, constituency_id: constituency_1, signature_count: 30) }
+    let!(:petition_4_journal_1) { FactoryGirl.create(:constituency_petition_journal, petition: petition_4, constituency_id: constituency_1, signature_count: 0) }
+    let!(:petition_4_journal_2) { FactoryGirl.create(:constituency_petition_journal, petition: petition_4, constituency_id: constituency_2, signature_count: 40) }
+
+    it 'excludes petitions that have no journal for the supplied constituency_id' do
+      popular = Petition.popular_in_constituency(constituency_1, 4)
+      expect(popular).not_to include(petition_2)
+    end
+
+    it 'excludes petitions that have a journal with 0 votes for the supplied constituency_id' do
+      popular = Petition.popular_in_constituency(constituency_1, 4)
+      expect(popular).not_to include(petition_4)
+    end
+
+    it 'excludes closed petitions with signatures from the supplied constituency_id' do
+      petition_1.update_column(:closed_at, 3.days.ago)
+      popular = Petition.popular_in_constituency(constituency_1, 4)
+      expect(popular).not_to include(petition_1)
+    end
+
+    it 'excludes rejected petitions with signatures from the supplied constituency_id' do
+      petition_1.update_column(:state, Petition::REJECTED_STATE)
+      popular = Petition.popular_in_constituency(constituency_1, 4)
+      expect(popular).not_to include(petition_1)
+    end
+
+    it 'excludes hidden petitions with signatures from the supplied constituency_id' do
+      petition_1.update_column(:state, Petition::HIDDEN_STATE)
+      popular = Petition.popular_in_constituency(constituency_1, 4)
+      expect(popular).not_to include(petition_1)
+    end
+
+    it 'includes open petitions with signatures from the supplied constituency_id ordered by the count of signatures' do
+      popular = Petition.popular_in_constituency(constituency_1, 2)
+      expect(popular).to eq [petition_3, petition_1]
+    end
+
+    it 'adds the constituency_signature_count attribute to the retrieved petitions' do
+      most_popular = Petition.popular_in_constituency(constituency_1, 1).first
+      expect(most_popular).to respond_to :constituency_signature_count
+      expect(most_popular.constituency_signature_count).to eq 30
+    end
+
+    it 'returns an array, not a scope' do
+      expect(Petition.popular_in_constituency(constituency_1, 1)).to be_an Array
+    end
+  end
+
   describe "signature count" do
     before :each do
       @petition = FactoryGirl.create(:open_petition)

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -435,5 +435,23 @@ describe Signature do
       expect(signature.constituency_id).to eq '1235'
     end
   end
+
+  describe 'store_constituency_id' do
+    let(:signature) { FactoryGirl.build(:signature, postcode: 'SW1 1AA')}
+
+    it 'saves the instance and sets the constituency id' do
+      stub_constituency('SW1 1AA', '12345', 'North Idshire')
+      signature.store_constituency_id
+      expect(signature.constituency_id).to eq '12345'
+      expect(signature).to be_persisted
+    end
+
+    it 'does not save the instance if it did not set a constituency id' do
+      stub_no_constituencies('SW1 1AA')
+      signature.store_constituency_id
+      expect(signature.constituency_id).to be_nil
+      expect(signature).not_to be_persisted
+    end
+  end
 end
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -66,6 +66,7 @@ describe Signature do
     it { is_expected.to validate_presence_of(:email).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:country).with_message(/must be completed/) }
     it { is_expected.to validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:constituency_id).is_at_most(255) }
 
     it "validates format of email" do
       s = FactoryGirl.build(:signature, :email => 'joe@example.com')

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -373,6 +373,17 @@ describe Signature do
       subject.validate!
       expect(subject.updated_at).to eq now
     end
+
+    it 'tells the relevant constituency petition journal to record a new signature' do
+      expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(subject)
+      subject.validate!
+    end
+
+    it 'does not talk to the constituency petition journal if the signature is not pending' do
+      expect(ConstituencyPetitionJournal).not_to receive(:record_new_signature_for)
+      subject.state = Signature::VALIDATED_STATE
+      subject.validate!
+    end
   end
 
   include ConstituencyApiHelpers::ApiLevel

--- a/spec/routing/local_petitions_spec.rb
+++ b/spec/routing/local_petitions_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "routes for local petitions", type: :routing do
+  it "routes GET /petitions/local to local_petitions#index" do
+    expect(get("/petitions/local")).to route_to("local_petitions#index")
+  end
+end

--- a/spec/support/constituency_api_helpers.rb
+++ b/spec/support/constituency_api_helpers.rb
@@ -1,6 +1,38 @@
 require 'postcode_sanitizer'
 
 module ConstituencyApiHelpers
+  module ApiLevel
+    def stub_constituency(postcode, *constituency_params)
+      constituency =
+        if constituency_params.first.is_a? ConstituencyApi::Constituency
+          constituency_params.first
+        else
+          ConstituencyApi::Constituency.new(*constituency_params)
+        end
+      allow(ConstituencyApi::Client).to receive(:constituencies).
+                                        with(PostcodeSanitizer.call(postcode)).
+                                        and_return([constituency])
+    end
+
+    def stub_constituencies(partial_postcode, *constituencies)
+      allow(ConstituencyApi::Client).to receive(:constituencies).
+                                        with(PostcodeSanitizer.call(partial_postcode)).
+                                        and_return(constituencies)
+
+    end
+
+    def stub_no_constituencies(postcode)
+      allow(ConstituencyApi::Client).to receive(:constituencies).
+                                        with(PostcodeSanitizer.call(postcode)).
+                                        and_return([])
+    end
+
+    def stub_broken_api
+      allow(ConstituencyApi::Client).to receive(:constituencies).
+                                        and_raise(ConstituencyApi::Error)
+    end
+  end
+
   module NetworkLevel
     def api_url
       ConstituencyApi::Client::URL

--- a/spec/support/constituency_api_helpers.rb
+++ b/spec/support/constituency_api_helpers.rb
@@ -1,0 +1,43 @@
+require 'postcode_sanitizer'
+
+module ConstituencyApiHelpers
+  module NetworkLevel
+    def api_url
+      ConstituencyApi::Client::URL
+    end
+
+    def stub_constituency_from_file(postcode, filename)
+      stub_request(:get, "#{ api_url }/#{PostcodeSanitizer.call(postcode)}/").to_return(status: 200, body: IO.read(filename))
+    end
+
+    def stub_constituency(postcode, constituency_id, constituency_name, mp_id: '0001', mp_name: 'A. N. Other MP', mp_start_date: '2015-05-07T00:00:00')
+      api_response = <<-RESPONSE.strip_heredoc
+          <Constituencies>
+            <Constituency>
+              <Constituency_Id>#{ constituency_id }</Constituency_Id>
+              <Name>#{ constituency_name }</Name>
+              <RepresentingMembers>
+                <RepresentingMember>
+                  <Member_Id>#{ mp_id }</Member_Id>
+                  <Member>#{ mp_name }</Member>
+                  <StartDate>#{ mp_start_date }</StartDate>
+                  <EndDate xsi:nil="true"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                </RepresentingMember>
+              </RepresentingMembers>
+            </Constituency>
+          </Constituencies>
+        RESPONSE
+
+      stub_request(:get, "#{ api_url }/#{PostcodeSanitizer.call(postcode)}/").to_return(status: 200, body: api_response)
+    end
+
+    def stub_no_constituencies(postcode)
+      stub_constituency_from_file(postcode, Rails.root.join("spec", "fixtures", "constituency_api", "no_results.xml"))
+    end
+
+    def stub_broken_api
+      stub_request(:get, %r[#{ Regexp.escape(api_url) }/*]).to_return(status: 500)
+    end
+  end
+end


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/95513536

Touches so many things - might make sense to go through commit by commit as while there are alot, they are mostly quite small.

We:

1) store the constituency_id on the signature when it is created - this means we do a lookup for the constituency based on the postcode - we might want to offline this?
2) have a constituency petition journal model where we record the count of signatures for a petition for a given constituency and we increment the count on this whenever a signature is validated (it's silently cool with it if the signature has no constituency_id)
3) allow a user to search by their postcode to find petitions that are popular in their constituency - this throws away petitions that have no signatures (absence of a journal, or a journal with 0 count) for that constituency and orders
