### PR TITLE
Add the uglifier gem to the gem bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'faraday'
 gem 'faraday_middleware'
 gem 'sass-rails', '~> 5.0'
 gem 'aws-sdk'
+gem 'uglifier'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,9 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uglifier (2.7.1)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -314,6 +317,7 @@ DEPENDENCIES
   sunspot_rails
   sunspot_solr
   tabnav
+  uglifier
   webmock
   whenever
   will_paginate

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,6 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w( application-ie7.css application-ie8.css ie.js )
+
+# Compress JavaScript assets.
+Rails.application.config.assets.js_compressor = :uglifier


### PR DESCRIPTION
The Uglifier gem is needed to compress and minify JavaScript assets.

https://www.pivotaltracker.com/story/show/96449472