### PR TITLE
Use locale keys to correctly pluralize signature counts

### DIFF
--- a/app/helpers/signature_helper.rb
+++ b/app/helpers/signature_helper.rb
@@ -6,6 +6,10 @@ module SignatureHelper
     end
   end
 
+  def signature_count(key, count)
+    t(:"#{key}.html", scope: :"petitions.counts", count: count, formatted_count: number_with_delimiter(count))
+  end
+
   private
 
   def render_signature_hidden_details(stage_manager, form, options)

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -29,7 +29,7 @@
     <% end -%>
   </div>
 
-  <p class="signature-count"><%= number_with_delimiter(@petition.signature_count) %> <span>signatures</span></p>
+  <p class="signature-count"><%= signature_count(:default, @petition.signature_count) %></p>
 
   <ul class="petition-meta">
     <li class="meta-deadline">

--- a/app/views/petitions/_trending_petition.html.erb
+++ b/app/views/petitions/_trending_petition.html.erb
@@ -1,9 +1,4 @@
 <li class="petition-item">
   <%= link_to truncate(trending_petition.title, :length => 100), petition_path(trending_petition) %>
-  <p>
-    <span class="count">
-      <%= number_with_delimiter(trending_petition.signatures_in_last_hour) %>
-    </span>
-    signatures in the last hour
-  </p>
+  <p><%= signature_count(:trending, trending_petition.signatures_in_last_hour) %></p>
 </li>

--- a/app/views/petitions/show.html.erb
+++ b/app/views/petitions/show.html.erb
@@ -61,7 +61,7 @@
   </div>
 </details>
 
-<p class="signature-count"><%= number_with_delimiter(@petition.signature_count) %> <span>signatures</span></p>
+<p class="signature-count"><%= signature_count(:default, @petition.signature_count) %></p>
 
 <%= render 'shared/about_petitions', variation: 'about-petitions-light' %>
 

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -12,6 +12,16 @@ en-GB:
       closed: "Closed petitions (%{quantity})"
       rejected: "Rejected petitions (%{quantity})"
 
+    counts:
+      default:
+        html:
+          one: "%{formatted_count} <span>signature</span>"
+          other: "%{formatted_count} <span>signatures</span>"
+      trending:
+        html:
+          one: "<span class=\"count\">%{formatted_count}</span> signature in the last hour"
+          other: "<span class=\"count\">%{formatted_count}</span> signatures in the last hour"
+
     rejection_reasons:
       titles:
         no-action: "Does not include a request for action"

--- a/spec/helpers/signature_helper_spec.rb
+++ b/spec/helpers/signature_helper_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe SearchHelper, type: :helper do
+  describe "#signature_count" do
+    describe "for normal petition lists" do
+      it "returns a HTML-safe string" do
+        expect(helper.signature_count(:default, 1)).to be_an(ActiveSupport::SafeBuffer)
+      end
+
+      context "when the signature count is 1" do
+        it "returns a correctly formatted signature count" do
+          expect(helper.signature_count(:default, 1)).to eq("1 <span>signature</span>")
+        end
+      end
+
+      context "when the signature count is 100" do
+        it "returns a correctly formatted signature count" do
+          expect(helper.signature_count(:default, 100)).to eq("100 <span>signatures</span>")
+        end
+      end
+
+      context "when the signature count is 1000" do
+        it "returns a correctly formatted signature count" do
+          expect(helper.signature_count(:default, 1000)).to eq("1,000 <span>signatures</span>")
+        end
+      end
+    end
+
+    describe "for trending petition lists" do
+      it "returns a HTML-safe string" do
+        expect(helper.signature_count(:trending, 1)).to be_an(ActiveSupport::SafeBuffer)
+      end
+
+      context "when the signature count is 1" do
+        it "returns a correctly formatted signature count" do
+          expect(helper.signature_count(:trending, 1)).to eq("<span class=\"count\">1</span> signature in the last hour")
+        end
+      end
+
+      context "when the signature count is 100" do
+        it "returns a correctly formatted signature count" do
+          expect(helper.signature_count(:trending, 100)).to eq("<span class=\"count\">100</span> signatures in the last hour")
+        end
+      end
+
+      context "when the signature count is 1000" do
+        it "returns a correctly formatted signature count" do
+          expect(helper.signature_count(:trending, 1000)).to eq("<span class=\"count\">1,000</span> signatures in the last hour")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The i18n gem has a feature where if you pass it an option called count then it will use the sub key called one if the value of count is 1 and if the value of count is more than 1 then it uses other. Coupled with the use of the html key to mark the output as HTML-safe allows us to localize the language and formatting if needed at some point.

https://www.pivotaltracker.com/story/show/96644444