### PR TITLE
Fix the bottom paragraph 'jumping' word into form fields with errors on a signature form page

### DIFF
--- a/app/assets/stylesheets/petitions/_forms.scss
+++ b/app/assets/stylesheets/petitions/_forms.scss
@@ -20,3 +20,11 @@ select.form-control {
 .form-control {
   padding: 0.5em;
 }
+
+.error,
+.error-summary {
+  @include media(tablet) {
+    padding-left: $gutter - 5px;
+    padding-right: $gutter;
+  }
+}


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/n/projects/307301/stories/96649748