### PR TITLE
Fix view rejected petitions in admin

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -2,7 +2,7 @@ class Admin::PetitionsController < Admin::AdminController
   respond_to :html
 
   def index
-    @petitions = Petition.moderated.order(:signature_count)
+    @petitions = Petition.selectable.order(:signature_count)
     @petitions = @petitions.for_state(params[:state]) unless params[:state].blank?
     @petitions = @petitions.paginate(:page => params[:page], :per_page => params[:per_page] || 20)
   end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -77,6 +77,7 @@ class Petition < ActiveRecord::Base
   }
   scope :visible, -> { where(state: VISIBLE_STATES) }
   scope :moderated, -> { where(state: MODERATED_STATES) }
+  scope :selectable, -> { where(state: SELECTABLE_STATES) }
   scope :in_moderation, -> { where(state: SPONSORED_STATE) }
   scope :todo_list, -> { where(state: TODO_LIST_STATES) }
   scope :collecting_sponsors, -> { where(state: COLLECTING_SPONSORS_STATES) }

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -20,7 +20,7 @@
     <% @petitions.each do |petition| -%>
       <tr>
         <td class='petition_id'><%= petition.id %></td>
-        <td><%= link_to petition.title, edit_response_admin_petition_path(petition) %></td>
+        <td class='petition-title'><%= link_to petition.title, edit_response_admin_petition_path(petition) %></td>
         <td><%= petition.creator_signature.name %><br/>
         <%= mail_to petition.creator_signature.email %></td>
         <td><%= petition.state_label %></td>

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -17,11 +17,6 @@ Feature: A moderator user views all petitions
     And I view the petition
     Then I should see the petition details
 
-  Scenario: Can see hidden petitions
-    Given a libelous petition "You suck!" has been rejected
-    When I view all petitions
-    Then I should see the petition "You suck!"
-
   Scenario: Cannot see pending or validated petitions
     Given a pending petition "My pending petition"
     And a validated petition "My validated petition"
@@ -30,13 +25,33 @@ Feature: A moderator user views all petitions
     Then I should not see the petition "My validation petition"
 
   Scenario: Filter list by state
-    Given a petition "My open petition"
-    And a libelous petition "You suck!" has been rejected
+    Given an open petition exists with title: "My open petition"
+    And a closed petition exists with title: "My closed petition"
+    And a rejected petition exists with title: "My rejected petition"
+    And a hidden petition exists with title: "My hidden petition"
+
     When I view all petitions
+    Then I should see the following list of petitions:
+     | My open petition     |
+     | My closed petition   |
+     | My rejected petition |
+     | My hidden petition   |
+
     And I filter the list to show "open" petitions
-    Then I should not see any "rejected" petitions
-    When I filter the list to show "rejected" petitions
-    Then I should not see any "open" petitions
+    Then I should see the following list of petitions:
+     | My open petition     |
+     
+    And I filter the list to show "closed" petitions
+    Then I should see the following list of petitions:
+     | My closed petition   |
+
+    And I filter the list to show "rejected" petitions
+    Then I should see the following list of petitions:
+     | My rejected petition |
+
+    And I filter the list to show "hidden" petitions
+    Then I should see the following list of petitions:
+     | My hidden petition   |
 
   @javascript
   Scenario: Change number per page

--- a/features/step_definitions/inspection_steps.rb
+++ b/features/step_definitions/inspection_steps.rb
@@ -86,6 +86,12 @@ Then(/^I should see the following ordered list of petitions:$/) do |table|
   expect(actual_petitions).to eq(expected_petitions)
 end
 
+Then(/^I should see the following list of petitions:$/) do |table|
+  actual_petitions = page.all(:css, '.petition-title').map(&:text)
+  expected_petitions = table.raw.flatten
+  expect(actual_petitions).to match_array(expected_petitions)
+end
+
 Then /^I should see the creation date of the petition$/ do
   expect(page).to have_css("th", :text => "Created")
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -82,14 +82,6 @@ Given /^a petition "([^"]*)" has been closed$/ do |petition_title|
   @petition = FactoryGirl.create(:open_petition, :title => petition_title, :closed_at => 1.day.ago)
 end
 
-Given /^a libelous petition "([^"]*)" has been rejected$/ do |petition_title|
-  @petition = FactoryGirl.create(:petition,
-    :title => petition_title,
-    :state => Petition::HIDDEN_STATE,
-    :rejection_code => "libellous",
-    :rejection_text => "You can't say that!")
-end
-
 Given /^a petition "([^"]*)" has been rejected( with the reason "([^"]*)")?$/ do |petition_title, reason_or_not, reason|
   reason_text = reason.nil? ? "It doesn't make any sense" : reason
   @petition = FactoryGirl.create(:petition,

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -10,28 +10,28 @@ describe Admin::PetitionsController do
 
   describe "not logged in" do
     describe "GET 'edit'" do
-      it "should redirect to the login page" do
+      it "redirects to the login page" do
         get :edit, :id => @petition.id
         expect(response).to redirect_to("https://petition.parliament.uk/admin/login")
       end
     end
 
     describe "GET 'threshold'" do
-      it "should redirect to the login page" do
+      it "redirects to the login page" do
         get :threshold
         expect(response).to redirect_to("https://petition.parliament.uk/admin/login")
       end
     end
 
     describe "GET 'index'" do
-      it "should redirect to the login page" do
+      it "redirects to the login page" do
         get :index
         expect(response).to redirect_to("https://petition.parliament.uk/admin/login")
       end
     end
 
     describe "GET 'show'" do
-      it "should redirect to the login page" do
+      it "redirects to the login page" do
         get :show, :id => @petition.id
         expect(response).to redirect_to("https://petition.parliament.uk/admin/login")
       end
@@ -44,7 +44,7 @@ describe Admin::PetitionsController do
       login_as(@user)
     end
 
-    it "should redirect to edit profile page" do
+    it "redirects to edit profile page" do
       expect(@user.has_to_change_password?).to be_truthy
       get :edit, :id => @petition.id
       expect(response).to redirect_to("https://petition.parliament.uk/admin/profile/#{@user.id}/edit")
@@ -67,18 +67,18 @@ describe Admin::PetitionsController do
       FactoryGirl.create(:system_setting, :key => SystemSetting::THRESHOLD_SIGNATURE_COUNT, :value => "10")
     end
 
-    it "should return all petitions that have more than the threshold number of signatures in ascending count order" do
+    it "returns all petitions that have more than the threshold number of signatures in ascending count order" do
       get :threshold
       expect(assigns[:petitions]).to eq([@p2, @p1, @p4])
     end
 
-    it "should assign petition" do
+    it "assigns petition" do
       get :edit_response, :id => @p1.id
       expect(assigns[:petition]).to eq(@p1)
     end
 
     context 'update internal response' do
-      it "should update internal response and response required flag" do
+      it "updates internal response and response required flag" do
         patch :update_response, :id => @p1.id, :petition => {:internal_response => 'This is popular', :response_required => '1'}
         @p1.reload
         expect(@p1.internal_response).to eq('This is popular')
@@ -90,7 +90,7 @@ describe Admin::PetitionsController do
       def do_patch(options = {})
         patch :update_response, :id => @p1.id, :petition => { :response => 'Doh!', :response_summary => 'Summary', :email_signees => '1'}.merge(options)
       end
-      it "should update response and email signees flag with true" do
+      it "updates response and email signees flag with true" do
         do_patch
         assert_enqueued_jobs 1
         expect(response).to redirect_to("https://petition.parliament.uk/admin/petitions")
@@ -99,7 +99,7 @@ describe Admin::PetitionsController do
         expect(@p1.email_requested_at).not_to be_nil
       end
 
-      it "should update response and email signees flag with false" do
+      it "updates response and email signees flag with false" do
         do_patch(:email_signees => '0')
         assert_enqueued_jobs 0
         @p1.reload
@@ -107,7 +107,7 @@ describe Admin::PetitionsController do
         expect(@p1.email_requested_at).to be_nil
       end
 
-      it "should fail to update response and email signees flag due to validation error" do
+      it "fails to update response and email signees flag due to validation error" do
         do_patch(:response => '', :email_signees => '1')
         assert_enqueued_jobs 0
         expect(response).to be_success
@@ -130,13 +130,13 @@ describe Admin::PetitionsController do
           Petition.update_all_signature_counts
         end
 
-        it "should setup a delayed job" do
+        it "sets up a delayed job" do
           assert_enqueued_jobs 1 do
             patch :update_response, :id => @petition.id, :petition => { :response => 'Doh!', :response_summary => 'Summary', :email_signees => '1'}
           end
         end
 
-        it "should set the email signees flag to false when the job runs" do
+        it "sets the email signees flag to false when the job runs" do
           perform_enqueued_jobs do
             patch :update_response, :id => @petition.id, :petition => { :response => 'Doh!', :response_summary => 'Summary', :email_signees => '1'}
             @petition.reload
@@ -147,7 +147,7 @@ describe Admin::PetitionsController do
           end
         end
 
-        it "should email out to the validated signees who have opted in when the delayed job runs" do
+        it "emails out to the validated signees who have opted in when the delayed job runs" do
           perform_enqueued_jobs do
             no_emails = ActionMailer::Base.deliveries.length
             patch :update_response, :id => @petition.id, :petition => { :response => 'Doh!', :response_summary => 'Summary', :email_signees => '1'}
@@ -186,12 +186,12 @@ describe Admin::PetitionsController do
     end
 
     context "edit" do
-      it "should be successful" do
+      it "assigns petition successfully" do
         get :edit, :id => @petition.id
         expect(assigns[:petition]).to eq(@petition)
       end
 
-      it "should be unsuccessful for a petition that is not validated" do
+      it "is unsuccessful for a petition that is not validated" do
         petition = FactoryGirl.create(:open_petition)
         expect {
           get :edit, :id => petition.id
@@ -200,7 +200,7 @@ describe Admin::PetitionsController do
     end
 
     context "show" do
-      it "should be successful" do
+      it "assigns petition successfully" do
         get :show, :id => @petition.id
         expect(assigns(:petition)).to eq(@petition)
       end
@@ -211,7 +211,7 @@ describe Admin::PetitionsController do
         patch :update, {:id => @petition.id}.merge(options)
       end
 
-      it "should be unsuccessful for a petition that is not validated" do
+      it "is unsuccessful for a petition that is not validated" do
         petition = FactoryGirl.create(:open_petition)
         expect {
           do_post(:id => petition.id)

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -171,11 +171,11 @@ describe Admin::PetitionsController do
       let(:petitions) { double.as_null_object }
 
       before do
-        allow(Petition).to receive(:moderated).and_return(petitions)
+        allow(Petition).to receive(:selectable).and_return(petitions)
       end
 
-      it "shows all moderated petitions" do
-        expect(Petition).to receive(:moderated).and_return(petitions)
+      it "shows all selectable petitions" do
+        expect(Petition).to receive(:selectable).and_return(petitions)
         get :index
       end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -327,6 +327,24 @@ describe Petition do
         expect(Petition.with_response).to match_array([@p1, @p2])
       end
     end
+
+    context "selectable" do
+      before :each do
+        @non_selectable_petition_1 = FactoryGirl.create(:petition, :state => Petition::PENDING_STATE)
+        @non_selectable_petition_2 = FactoryGirl.create(:petition, :state => Petition::VALIDATED_STATE)
+        @non_selectable_petition_3 = FactoryGirl.create(:petition, :state => Petition::SPONSORED_STATE)
+
+        @selectable_petition_1 = FactoryGirl.create(:open_petition)
+        @selectable_petition_2 = FactoryGirl.create(:rejected_petition)
+        @selectable_petition_3 = FactoryGirl.create(:open_petition, :closed_at => 1.day.ago)
+        @selectable_petition_4 = FactoryGirl.create(:petition, :state => Petition::HIDDEN_STATE)
+      end
+
+      it "returns only selectable petitions" do
+        expect(Petition.selectable.size).to eq(4)
+        expect(Petition.selectable).to include(@selectable_petition_1, @selectable_petition_2, @selectable_petition_3, @selectable_petition_4)
+      end
+    end
   end
 
   describe '.popular_in_constituency' do


### PR DESCRIPTION
for https://www.pivotaltracker.com/story/show/97006760

The issue was that rejected petitions did not show up when searching for them. This appears have been caused by use of 'moderated' petition scope which only returns petitions with states OPEN and HIDDEN.
Wondering whether it was intentional to not have REJECTED as part of this. But there are no tests to confirm this, so just changed it to use a new scope for 'selectable' states (OPEN, CLOSED, REJECTED, HIDDEN) which fixes the bug. Have also added more comprehensive testing for these state searches.