### PR TITLE
Remove pr_geohash gem from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,6 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    pr_geohash (1.0.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)


### PR DESCRIPTION
This gem should have been removed from Gemfile.lock automatically since it is
not used anywhere but apparently with versions of bundler < v1.9.5 it does not
do so. Bundler v1.9.5 does remove it.