### PR TITLE
Change epetition wording to petition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-e-petitions
+Petitions
 ===========
 
-This is the code base for the UK Government's e-petitions service (http://epetitions.direct.gov.uk).
+This is the code base for the UK Government's petitions service (http://epetitions.direct.gov.uk).
 We have open sourced the code for you to use under the terms of licence contained in this repository.
 
 We hope you enjoy it!

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -32,7 +32,7 @@ class SignaturesController < ApplicationController
     @petition = @signature.petition
 
     if @signature.validated?
-      flash[:notice] = "Thank you. Your signature has already been added to the <span class='nowrap'>e-petition</span>."
+      flash[:notice] = "Thank you. Your signature has already been added to the petition."
       redirect_to signed_petition_signature_url(@petition, @signature.perishable_token) and return
     end
 

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -20,7 +20,6 @@ class PetitionMailer < ApplicationMailer
     @petition = petition
     to = @petition.creator_signature.email
     bcc = @petition.sponsor_signatures.validated.map(&:email)
-
     mail to: to, bcc: bcc, subject: subject_for(:petition_rejected)
   end
 

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1>e-petition statistics</h1>
+<h1>petition statistics</h1>
 <br />
 <h2>Trending Petitions</h2>
 

--- a/app/views/admin/searches/new.html.erb
+++ b/app/views/admin/searches/new.html.erb
@@ -4,8 +4,8 @@
 <br/>
 
 <ul>
-  <li>an id to find an e-petition with that id;
-  <li>an email address to see all e-petitions that that email address has signed.
+  <li>an id to find a petition with that id;
+  <li>an email address to see all petitions that that email address has signed.
 </ul>
 <br/>
 

--- a/app/views/archived/petitions/index.html.erb
+++ b/app/views/archived/petitions/index.html.erb
@@ -1,16 +1,16 @@
 <div class="cta_block" id="search_pet_cta_block">
-  <h1>Archived e-petitions</h1>
+  <h1>Archived petitions</h1>
 
   <form method="get" action="/archived/petitions/search">
-    <label for="search">Search for an archived e-petition</label>
+    <label for="search">Search for an archived petition</label>
     <input type='text' name="q" id="search" />
     <input type='submit' value='Search' class="button" id="home_search_button"/>
   </form>
 </div>
 
 <div class="cta_block" id="create_pet_cta_block">
-  <h2>What are e-petitions?</h2>
-  <p>e-petitions <span class="nowrap">are</span> an easy, personal way for you to influence government and Parliament in the UK. You can create an e-petition about anything that the government is responsible for and if it gets at least 100,000 signatures, it will be considered for debate in the House of Commons.  You can find more information about how the House of Commons deals with e-petitions on the <%= new_window_link_to "Backbench Business Committee website", "http://www.parliament.uk/bbcom" %>.</p>
-  <%= link_to 'How e-petitions work', help_path, :class => 'large_link' %>
-  <%= link_to "Create a new e-petition", check_petitions_path, :class => 'link_button large_link_button' %>
+  <h2>What are petitions?</h2>
+  <p>Petitions are an easy, personal way for you to influence government and Parliament in the UK. You can create a petition about anything that the government is responsible for and if it gets at least 100,000 signatures, it will be considered for debate in the House of Commons.  You can find more information about how the House of Commons deals with petitions on the <%= new_window_link_to "Backbench Business Committee website", "http://www.parliament.uk/bbcom" %>.</p>
+  <%= link_to 'How petitions work', help_path, :class => 'large_link' %>
+  <%= link_to "Create a new petition", check_petitions_path, :class => 'link_button large_link_button' %>
 </div>

--- a/app/views/archived/petitions/search.html.erb
+++ b/app/views/archived/petitions/search.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Search results - archived e-petitions" } %>
+<% content_for(:page_title) { "Search results - archived petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
   <h1>Search results <span class="search_terms">for "<%= params[:q] %>"</span></h1>
@@ -10,7 +10,7 @@
     <p class="no_petitions_warning">No archived petitions could be found matching your search terms.</p>
   <% else %>
     <div class="title_pagination_row">
-      <h2>Archive e-petitions matching your search terms</h2>
+      <h2>Archive petitions matching your search terms</h2>
     </div>
     <ol>
       <% @petitions.each do |petition| %>

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -1,12 +1,12 @@
-<% content_for(:page_title) { "#{@petition.title} - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
-  <h2>e-petition</h2>
+  <h2>Petition</h2>
 </div>
 <% end %>
 
 <%= content_tag :p, :class => 'flash-notice' do -%>
-  This e-petition is now closed
+  This petition is now closed
 <% end if @petition.closed? %>
 
 <div class="petition_view">
@@ -16,14 +16,14 @@
 
     <% if @petition.rejected? -%>
       <div class="petition_rejected">
-        <h2>This e-petition has been rejected with the following reason given:</h2>
+        <h2>This petition has been rejected with the following reason given:</h2>
         <div class"reason"><%= raw auto_link(simple_format(h(@petition.reason_for_rejection)), :html => { :target => '_blank' }) %></div>
       </div>
     <% end -%>
 
     <% if @petition.response? -%>
       <div class="petition_response">
-        <h2>This e-petition has received the following response:</h2>
+        <h2>This petition has received the following response:</h2>
         <%= raw auto_link(simple_format(h(@petition.response), :class => 'response'), :html => { :target => '_blank' }) %>
       </div>
     <% end -%>

--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Send feedback - e-petitions" } %>
+<% content_for(:page_title) { "Send feedback - Petitions" } %>
 <% # set tab index to start at 5
  increment(5) %>
 

--- a/app/views/feedback/thanks.html.erb
+++ b/app/views/feedback/thanks.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Thank you - e-petitions" } %>
+<% content_for(:page_title) { "Thank you - Petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
   <h1>Your feedback has been sent</h1>

--- a/app/views/petition_mailer/double_signature_confirmation.html.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @signature_one.name %> and <%= @signature_two.name %>,</p>
 
-<p>Your signatures have already been added to the e-petition "<%= @signature_one.petition.title %>"</p>
+<p>Your signatures have already been added to the petition "<%= @signature_one.petition.title %>"</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/double_signature_confirmation.html.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.html.erb
@@ -4,4 +4,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= home_url %></p>

--- a/app/views/petition_mailer/double_signature_confirmation.text.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.text.erb
@@ -4,4 +4,4 @@ Your signatures have already been added to the petition "<%= @signature_one.peti
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/double_signature_confirmation.text.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @signature_one.name %> and <%= @signature_two.name %>,
 
-Your signatures have already been added to the e-petition "<%= @signature_one.petition.title %>"
+Your signatures have already been added to the petition "<%= @signature_one.petition.title %>"
 
 Thanks,
 

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Your signature has already been added to the e-petition "<%= @signature.petition.title %>"</p>
+<p>Your signature has already been added to the petition "<%= @signature.petition.title %>"</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
@@ -4,4 +4,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= home_url %></p>

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @signature.name %>,
 
-Your signature has already been added to the e-petition "<%= @signature.petition.title %>"
+Your signature has already been added to the petition "<%= @signature.petition.title %>"
 
 Thanks,
 

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
@@ -4,4 +4,4 @@ Your signature has already been added to the petition "<%= @signature.petition.t
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.html.erb
@@ -1,12 +1,12 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Before your signature is added to the e-petition "<%= @signature.petition.title %>" you need to confirm your email address by clicking on the link below:</p>
+<p>Before your signature is added to the petition "<%= @signature.petition.title %>" you need to confirm your email address by clicking on the link below:</p>
 
 <%=
   link_to nil, verify_signature_url(@signature, @signature.perishable_token)
 %>
 
-<p>If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.</p>
+<p>If you don't want to sign this petition or believe this message was sent in error, please ignore this email.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= link_to home_url, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to home_url, home_url %></p>

--- a/app/views/petition_mailer/email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.text.erb
@@ -8,4 +8,4 @@ If you don't want to sign this petition or believe this message was sent in erro
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @signature.name %>,
 
-Before your signature is added to the e-petition "<%= @signature.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
+Before your signature is added to the petition "<%= @signature.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
 
 <%= verify_signature_url(@signature, @signature.perishable_token) %>
 
-If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.
+If you don't want to sign this petition or believe this message was sent in error, please ignore this email.
 
 Thanks,
 

--- a/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
@@ -18,4 +18,4 @@
 
 <p>Thanks,</p>
 
-<p>Parliament e-petitions <%= link_to nil, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to nil, home_url %></p>

--- a/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
@@ -18,4 +18,4 @@ Full description: <%= @petition.description %>
 
 Thanks,
 
-Parliament e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/no_signature_for_petition.html.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.html.erb
@@ -1,12 +1,12 @@
 <p>Dear Sir/Madam,</p>
 
-<p>A request has been made to re-send a confirmation email to this address to complete the signing process for the e-petition '<%= @petition.title %>'.</p>
+<p>A request has been made to re-send a confirmation email to this address to complete the signing process for the petition '<%= @petition.title %>'.</p>
 
-<p>This email address has not been used to sign this e-petition. If you want to sign the petition you can do so at the following address:</p>
+<p>This email address has not been used to sign this petition. If you want to sign the petition you can do so at the following address:</p>
 
 <p><%= link_to nil, petition_url(@petition) %></p>
 
-<p>If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.</p>
+<p>If you don't want to sign this petition or believe this message was sent in error, please ignore this email.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/no_signature_for_petition.html.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= home_url %></p>

--- a/app/views/petition_mailer/no_signature_for_petition.text.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.text.erb
@@ -11,4 +11,4 @@ If you don't want to sign this petition or believe this message was sent in erro
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/no_signature_for_petition.text.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.text.erb
@@ -1,13 +1,13 @@
 Dear Sir/Madam,
 
-A request has been made to re-send a confirmation email to this address to complete the signing process for the e-petition '<%= @petition.title %>'.
+A request has been made to re-send a confirmation email to this address to complete the signing process for the petition '<%= @petition.title %>'.
 
-This email address has not been used to sign this e-petition. If you want to sign the petition you can do so at the following address:
+This email address has not been used to sign this petition. If you want to sign the petition you can do so at the following address:
 
 <%= petition_url(@petition) %>
 
 
-If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.
+If you don't want to sign this petition or believe this message was sent in error, please ignore this email.
 
 Thanks,
 

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= link_to home_url, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to home_url, home_url %></p>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
@@ -10,4 +10,4 @@ I'm sorry you won't have as long to collect signatures as you expected. If you h
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
@@ -8,4 +8,4 @@
 <p>You can also share this URL to promote your petition or use the social network links available on your petition's page.</p>
 
 <p>Thanks,</p>
-<p>HM Government e-petitions <%= link_to home_url, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to home_url, home_url %></p>

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
@@ -1,11 +1,11 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Your e-petition "<%= @signature.petition.title %>" has now been published. You can view your e-petition at: <%=
+<p>Your petition "<%= @signature.petition.title %>" has now been published. You can view your petition at: <%=
   url = petition_url(@signature.petition)
   link_to url, url
   %></p>
 
-<p>You can also share this URL to promote your e-petition or use the social network links available on your e-petition's page.</p>
+<p>You can also share this URL to promote your petition or use the social network links available on your petition's page.</p>
 
 <p>Thanks,</p>
 <p>HM Government e-petitions <%= link_to home_url, home_url %></p>

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @signature.name %>
 
-Your e-petition "<%= @signature.petition.title %>" has now been published. You can view your e-petition by copying the following link and pasting it into your browser:
+Your petition "<%= @signature.petition.title %>" has now been published. You can view your petition by copying the following link and pasting it into your browser:
 
 <%= petition_url(@signature.petition) %>
 
-You can also share this URL to promote your e-petition or use the social network links available on your e-petition's page.
+You can also share this URL to promote your petition or use the social network links available on your petition's page.
 
 Thanks,
 

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
@@ -8,4 +8,4 @@ You can also share this URL to promote your petition or use the social network l
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -1,10 +1,10 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>The e-petition '<%= @petition.title %>' signed by you recently reached <%= number_with_delimiter(@petition.signature_count) %> signatures and a response has been made to it.</p>
+<p>The petition '<%= @petition.title %>' signed by you recently reached <%= number_with_delimiter(@petition.signature_count) %> signatures and a response has been made to it.</p>
 
 <p><%= @petition.response %></p>
 
-<p><%= link_to "View the response to the e-petition", petition_url(@signature.petition) %></p>
+<p><%= link_to "View the response to the petition", petition_url(@signature.petition) %></p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -8,6 +8,6 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= link_to home_url, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to home_url, home_url %></p>
 
 <p>Don't want to receive any more emails regarding this petition? Unsubscribe by clicking <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -10,6 +10,6 @@ View the response to the petition here:
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>
 
 Don't want to receive any more emails regarding this petition? Unsubscribe by clicking this link: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @signature.name %>,
 
-The e-petition '<%= @petition.title %>' signed by you recently reached <%= number_with_delimiter(@petition.signature_count) %> signatures and a response has been made to it.
+The petition '<%= @petition.title %>' signed by you recently reached <%= number_with_delimiter(@petition.signature_count) %> signatures and a response has been made to it.
 
 <%= @petition.response %>
 
-View the response to the e-petition here:
+View the response to the petition here:
 
 <%= petition_url(@signature.petition) %>
 

--- a/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
@@ -1,12 +1,12 @@
 <p>Dear <%= @pending_signature.name %> and <%= @validated_signature.name %>,</p>
 
-<p>Before your signatures can be added to the e-petition "<%= @pending_signature.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:</p>
+<p>Before your signatures can be added to the petition "<%= @pending_signature.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:</p>
 
 <p><%= @pending_signature.name %>: <%= link_to nil, verify_signature_url(@pending_signature, @pending_signature.perishable_token) %></p>
 
 <p>Signature for <%= @validated_signature.name %> has already been confirmed.</p>
 
-<p>If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.</p>
+<p>If you don't want to sign this petition or believe this message was sent in error, please ignore this email.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= home_url %></p>

--- a/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
@@ -10,4 +10,4 @@ If you don't want to sign this petition or believe this message was sent in erro
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
@@ -1,12 +1,12 @@
 Dear <%= @pending_signature.name %> and <%= @validated_signature.name %>,
 
-Before your signatures can be added to the e-petition "<%= @pending_signature.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
+Before your signatures can be added to the petition "<%= @pending_signature.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
 
 <%= @pending_signature.name %>: <%= verify_signature_url(@pending_signature, @pending_signature.perishable_token) %>
 
 Signature for <%= @validated_signature.name %> has already been confirmed.
 
-If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.
+If you don't want to sign this petition or believe this message was sent in error, please ignore this email.
 
 Thanks,
 

--- a/app/views/petition_mailer/petition_rejected.html.erb
+++ b/app/views/petition_mailer/petition_rejected.html.erb
@@ -1,4 +1,4 @@
-<p>e-petition "<%= @petition.title %>" hasn't been accepted.</p>
+<p>Petition "<%= @petition.title %>" hasn't been accepted.</p>
 
 <%= @petition.rejection_description.html_safe %>
 
@@ -7,10 +7,10 @@
 <% end %>
 
 <% if @petition.state != Petition::HIDDEN_STATE -%>
-  <p><%= link_to 'View your rejected e-petition', petition_url(@petition) %></p>
+  <p><%= link_to 'View your rejected petition', petition_url(@petition) %></p>
 <% end -%>
 
-<p>If you'd like to submit a new e-petition, please read the site's terms and conditions which explain the rules in detail.</p>
+<p>If you'd like to submit a new petition, please read the site's terms and conditions which explain the rules in detail.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/petition_rejected.html.erb
+++ b/app/views/petition_mailer/petition_rejected.html.erb
@@ -14,4 +14,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= link_to home_url, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to home_url, home_url %></p>

--- a/app/views/petition_mailer/petition_rejected.text.erb
+++ b/app/views/petition_mailer/petition_rejected.text.erb
@@ -1,16 +1,16 @@
-E-petition "<%= @petition.title %>" hasn't been accepted.
+Petition "<%= @petition.title %>" hasn't been accepted.
 
 <%= strip_tags(@petition.rejection_description) %>
 
 <%= @petition.rejection_text if @petition.rejection_text.present? %>
 
 <% if @petition.state != Petition::HIDDEN_STATE -%>
-Copy and paste the link below into your browser to view your rejected e-petition:
+Copy and paste the link below into your browser to view your rejected petition:
 
 <%= petition_url(@petition) %>
 
 <% end -%>
-If you'd like to submit a new e-petition, please read the site's terms and conditions which explain the rules in detail.
+If you'd like to submit a new petition, please read the site's terms and conditions which explain the rules in detail.
 
 Thanks,
 

--- a/app/views/petition_mailer/petition_rejected.text.erb
+++ b/app/views/petition_mailer/petition_rejected.text.erb
@@ -14,4 +14,4 @@ If you'd like to submit a new petition, please read the site's terms and conditi
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
@@ -12,4 +12,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= link_to home_url, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to home_url, home_url %></p>

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
@@ -1,14 +1,14 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>We notice that you signed the "<%= @signature.petition.title %>" e-petition recently, but haven't yet validated your email address.</p>
+<p>We notice that you signed the "<%= @signature.petition.title %>" petition recently, but haven't yet validated your email address.</p>
 
-<p>In order to add your signature to this e-petition, we need to confirm your email address by clicking on the link below.</p>
+<p>In order to add your signature to this petition, we need to confirm your email address by clicking on the link below.</p>
 
 <%=
   link_to nil, verify_signature_url(@signature, @signature.perishable_token)
 %>
 
-<p>If you no longer want to sign this e-petition or believe this message was received in error, please ignore this email.</p>
+<p>If you no longer want to sign this petition or believe this message was received in error, please ignore this email.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @signature.name %>,
 
-We notice that you signed the "<%= @signature.petition.title %>" e-petition recently, but haven't yet validated your email address.  In order to add your signature to this e-petition, we need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
+We notice that you signed the "<%= @signature.petition.title %>" petition recently, but haven't yet validated your email address.  In order to add your signature to this petition, we need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
 
 <%= verify_signature_url(@signature, @signature.perishable_token) %>
 
-If you no longer want to sign this e-petition or believe this message was received in error, please ignore this email.
+If you no longer want to sign this petition or believe this message was received in error, please ignore this email.
 
 Thanks,
 

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
@@ -8,4 +8,4 @@ If you no longer want to sign this petition or believe this message was received
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/two_pending_signatures.html.erb
+++ b/app/views/petition_mailer/two_pending_signatures.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,</p>
 
-<p>HM Government e-petitions <%= home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= home_url %></p>

--- a/app/views/petition_mailer/two_pending_signatures.html.erb
+++ b/app/views/petition_mailer/two_pending_signatures.html.erb
@@ -1,12 +1,12 @@
 <p>Dear <%= @signature_one.name %> and <%= @signature_two.name %>,<p>
 
-<p>Before your signatures can be added to the e-petition "<%= @signature_one.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:</p>
+<p>Before your signatures can be added to the petition "<%= @signature_one.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:</p>
 
 <p><%= @signature_one.name %>: <%= link_to nil, verify_signature_url(@signature_one, @signature_one.perishable_token) %></p>
 
 <p><%= @signature_two.name %>: <%= link_to nil, verify_signature_url(@signature_two, @signature_two.perishable_token) %></p>
 
-<p>If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.</p>
+<p>If you don't want to sign this petition or believe this message was sent in error, please ignore this email.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/petition_mailer/two_pending_signatures.text.erb
+++ b/app/views/petition_mailer/two_pending_signatures.text.erb
@@ -10,4 +10,4 @@ If you don't want to sign this petition or believe this message was sent in erro
 
 Thanks,
 
-HM Government e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/petition_mailer/two_pending_signatures.text.erb
+++ b/app/views/petition_mailer/two_pending_signatures.text.erb
@@ -1,12 +1,12 @@
 Dear <%= @signature_one.name %> and <%= @signature_two.name %>,
 
-Before your signatures can be added to the e-petition "<%= @signature_one.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
+Before your signatures can be added to the petition "<%= @signature_one.petition.title %>" you need to confirm your email address by clicking on the link below. You can also copy and paste this link into your browser:
 
 <%= @signature_one.name %>: <%= verify_signature_url(@signature_one, @signature_one.perishable_token) %>
 
 <%= @signature_two.name %>: <%= verify_signature_url(@signature_two, @signature_two.perishable_token) %>
 
-If you don't want to sign this e-petition or believe this message was sent in error, please ignore this email.
+If you don't want to sign this petition or believe this message was sent in error, please ignore this email.
 
 Thanks,
 

--- a/app/views/petitions/_petition_show.html.erb
+++ b/app/views/petitions/_petition_show.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :p, :class => 'flash-notice' do -%>
-    This e-petition is now closed
+    This petition is now closed
 <% end if petition.closed? %>
 
 <h1>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -2,7 +2,7 @@
   <h2>10,000 <span>signatures</span></h2>
   <%# Has response #%>
   <% if petition.response_summary.present? -%>
-    <h2>This e-petition has received the following response:</h2>
+    <h2>This petition has received the following response:</h2>
     <%= raw auto_link(simple_format( h(petition.response_summary) ), :html => { :target => '_blank' }) %>
 
     <% if petition.response.present? -%>

--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - Petitions" } %>
 <h1 class="page-title">What action would you like the government to take?</h1>
 
 <form method="get" action="/petitions/check_results">

--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new e-petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
 <h1 class="page-title">What action would you like the government to take?</h1>
 
 <form method="get" action="/petitions/check_results">

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new e-petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
 
 <%= link_to check_petitions_path, class: "back-page" do %>
   &#9664; Back

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - Petitions" } %>
 
 <%= link_to check_petitions_path, class: "back-page" do %>
   &#9664; Back

--- a/app/views/petitions/create/_replay_email_ui.html.erb
+++ b/app/views/petitions/create/_replay_email_ui.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - Petitions" } %>
 
 <%= f.submit raw('&#9664; Back'), :name => 'move:back', :class => 'back-page' %>
 

--- a/app/views/petitions/create/_replay_email_ui.html.erb
+++ b/app/views/petitions/create/_replay_email_ui.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new e-petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
 
 <%= f.submit raw('&#9664; Back'), :name => 'move:back', :class => 'back-page' %>
 

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - Petitions" } %>
 
 <%= f.submit raw('&#9664; Back'), :name => 'move:back', :class => 'back-page' %>
 

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new e-petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
 
 <%= f.submit raw('&#9664; Back'), :name => 'move:back', :class => 'back-page' %>
 

--- a/app/views/petitions/index.html.erb
+++ b/app/views/petitions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "View all petitions - e-petitions" } %>
+<% content_for(:page_title) { "View all petitions - Petitions" } %>
 <a class="lists-of-petitions" href="#other-search-lists">Lists of petitions</a>
 
 <h1 class="page-title"><%= t(@petitions.scope, scope: :"petitions.page_titles") %></h1>

--- a/app/views/petitions/index.html.erb
+++ b/app/views/petitions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "View all e-petitions - e-petitions" } %>
+<% content_for(:page_title) { "View all petitions - e-petitions" } %>
 <a class="lists-of-petitions" href="#other-search-lists">Lists of petitions</a>
 
 <h1 class="page-title"><%= t(@petitions.scope, scope: :"petitions.page_titles") %></h1>

--- a/app/views/petitions/moderation_info.html.erb
+++ b/app/views/petitions/moderation_info.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@petition.title} - has been already sent to moderation - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - has been already sent to moderation - Petitions" } %>
 <% content_for :title do %>
   <div class="title_block">
     <h2><%= @petition.creator_signature.name %>'s petition - "<%= @petition.title %>" already has its 5 sponsors and we're taking a look to make sure it meets the Petitions service terms and conditions.<h2>

--- a/app/views/petitions/new.html.erb
+++ b/app/views/petitions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - Petitions" } %>
 
 <%= form_for @stage_manager.stage_object, :url => create_petition_path do |f| %>
 

--- a/app/views/petitions/new.html.erb
+++ b/app/views/petitions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new e-petition - e-petitions" } %>
+<% content_for(:page_title) { "Create a new petition - e-petitions" } %>
 
 <%= form_for @stage_manager.stage_object, :url => create_petition_path do |f| %>
 

--- a/app/views/petitions/resend_confirmation_email.html.erb
+++ b/app/views/petitions/resend_confirmation_email.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Confirmation email re-sent - e-petitions" } %>
+<% content_for(:page_title) { "Confirmation email re-sent - Petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
   <h2>Confirmation email re-sent</h2>

--- a/app/views/petitions/resend_confirmation_email.html.erb
+++ b/app/views/petitions/resend_confirmation_email.html.erb
@@ -8,7 +8,7 @@
 
 <div class="petition_view">
   <p>
-    If you signed the e-petition with this email address, you will shortly receive
+    If you signed the petition with this email address, you will shortly receive
     an email to confirm your signature.
   </p>
 </div>

--- a/app/views/petitions/show.html.erb
+++ b/app/views/petitions/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@petition.title} - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Petitions" } %>
 
 <details class="petitions-details">
   <summary><span class="summary">How petitions work</span></summary>

--- a/app/views/petitions/thank_you.html.erb
+++ b/app/views/petitions/thank_you.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Thank you - e-petitions" } %>
+<% content_for(:page_title) { "Thank you - Petitions" } %>
 
 <h1 class="page-title">
   <span class="icon icon-email" aria-hidden></span>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Search results - e-petitions" } %>
+<% content_for(:page_title) { "Search results - Petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
   <h1>Search results <span class="search_terms">For "<%= @petitions.query %>"</span></h1>

--- a/app/views/shared/_share_petition.html.erb
+++ b/app/views/shared/_share_petition.html.erb
@@ -1,5 +1,5 @@
 <h2>Share this petition</h2>
-<% title = petition.title + " - e-petitions" -%>
+<% title = petition.title + " - Petitions" -%>
 <ul class="petition-share">
   <li>
     <%= link_to "http://www.facebook.com/sharer.php?t=#{URI.escape(title)}&u=#{URI.escape(petition_url(petition))}" do %>

--- a/app/views/signatures/new.html.erb
+++ b/app/views/signatures/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@petition.title} - Sign this petition - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Sign this petition - Petitions" } %>
 
 <%= form_for @stage_manager.stage_object, :url => sign_petition_signatures_path, :html => {:class => 'wizard_form new_petition_form'} do |f| %>
   <%= render_signature_form @stage_manager, f %>

--- a/app/views/signatures/new.html.erb
+++ b/app/views/signatures/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@petition.title} - Sign this e-petition - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Sign this petition - e-petitions" } %>
 
 <%= form_for @stage_manager.stage_object, :url => sign_petition_signatures_path, :html => {:class => 'wizard_form new_petition_form'} do |f| %>
   <%= render_signature_form @stage_manager, f %>

--- a/app/views/signatures/signed.html.erb
+++ b/app/views/signatures/signed.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Thank you - e-petitions" } %>
+<% content_for(:page_title) { "Thank you - Petitions" } %>
 <h1 class="page-title">
   <span class="icon icon-confirmation-tick"></span>
   Thank you

--- a/app/views/signatures/thank_you.html.erb
+++ b/app/views/signatures/thank_you.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Thank you - e-petitions" } %>
+<% content_for(:page_title) { "Thank you - Petitions" } %>
 <h1 class="page-title">
   <span class="icon icon-email" aria-hidden></span>
   One more step&hellip;

--- a/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.html.erb
+++ b/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.html.erb
@@ -20,4 +20,4 @@
 
 <p>Thanks,</p>
 
-<p>Parliament e-petitions <%= link_to nil, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to nil, home_url %></p>

--- a/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.html.erb
+++ b/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.html.erb
@@ -16,7 +16,7 @@
   </li>
 </ol>
 
-<p>If you don't want to sponsor this e-petition or believe this message was sent in error, please ignore this email.</p>
+<p>If you don't want to sponsor this petition or believe this message was sent in error, please ignore this email.</p>
 
 <p>Thanks,</p>
 

--- a/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.text.erb
+++ b/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.text.erb
@@ -14,4 +14,4 @@ If you don't want to sponsor this petition or believe this message was sent in e
 
 Thanks,
 
-Parliament e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.text.erb
+++ b/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.text.erb
@@ -10,7 +10,7 @@ To confirm your support for <%= @petition.creator_signature.name %>'s petition "
 2. Click the link below to confirm your email address:
    <%= verify_signature_url(@signature, @signature.perishable_token, protocol: 'https') %>
 
-If you don't want to sponsor this e-petition or believe this message was sent in error, please ignore this email.
+If you don't want to sponsor this petition or believe this message was sent in error, please ignore this email.
 
 Thanks,
 

--- a/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.html.erb
@@ -6,4 +6,4 @@
 
 <p>Thanks,</p>
 
-<p>Parliament e-petitions <%= link_to nil, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to nil, home_url %></p>

--- a/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.text.erb
@@ -6,4 +6,4 @@ You have support from <%= @supporting_sponsors_count %> of your nominated sponso
 
 Thanks,
 
-Parliament e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
@@ -6,4 +6,4 @@
 
 <p>Thanks,</p>
 
-<p>Parliament e-petitions <%= link_to nil, home_url %></p>
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to nil, home_url %></p>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
@@ -6,4 +6,4 @@ Congratulations, you have support from <%= @moderation_threshold %> sponsors, en
 
 Thanks,
 
-Parliament e-petitions <%= home_url %>
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>

--- a/app/views/sponsors/show.html.erb
+++ b/app/views/sponsors/show.html.erb
@@ -1,6 +1,6 @@
-<% content_for(:page_title) { "#{@petition.title} - Support this e-petition - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Support this petition - e-petitions" } %>
 <div class="title_block">
-  <h2>Support this e-petition</h2>
+  <h2>Support this petition</h2>
   <h1 class="petition_title"><%= @petition.title %></h1>
   <h2>By <%= @petition.creator_signature.name %></h2>
 </div>

--- a/app/views/sponsors/show.html.erb
+++ b/app/views/sponsors/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@petition.title} - Support this petition - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Support this petition - Petitions" } %>
 <div class="title_block">
   <h2>Support this petition</h2>
   <h1 class="petition_title"><%= @petition.title %></h1>

--- a/app/views/sponsors/sponsored.html.erb
+++ b/app/views/sponsors/sponsored.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Thank you - e-petitions" } %>
+<% content_for(:page_title) { "Thank you - Petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
   <h2>Thank you.</h1>

--- a/app/views/sponsors/sponsored.html.erb
+++ b/app/views/sponsors/sponsored.html.erb
@@ -8,9 +8,9 @@
 <% end %>
 
 <div class="cta_block thank_you_block">
-  <p>Your signature has now been added to this e-petition as a sponsor.</p>
+  <p>Your signature has now been added to this petition as a sponsor.</p>
 
-  <p>This e-petition is waiting for more sponsors before being checked to make sure it complies with the terms &amp; conditions for creating an e-petition.</p>
+  <p>This petition is waiting for more sponsors before being checked to make sure it complies with the terms &amp; conditions for creating a petition.</p>
 
   <p>You will be notified once a decision has been reached.</p>
 

--- a/app/views/sponsors/thank_you.html.erb
+++ b/app/views/sponsors/thank_you.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "#{@petition.title} - Thank you for supporting this petition - e-petitions" } %>
+<% content_for(:page_title) { "#{@petition.title} - Thank you for supporting this petition - Petitions" } %>
 <% content_for :title do %>
 <div class="title_block">
   <h2>Thank you.</h1>

--- a/app/views/sponsors/thank_you.html.erb
+++ b/app/views/sponsors/thank_you.html.erb
@@ -10,7 +10,7 @@
 <div class="cta_block thank_you_block">
   <p>An email will be sent to you now to confirm your email address.  If we're busy this may take a few hours to arrive, thanks for your patience.</p>
 
-  <p>We can't add you as a sponsor to the e-petition until you've clicked on the link in this email.</p>
+  <p>We can't add you as a sponsor to the petition until you've clicked on the link in this email.</p>
 
   <%= link_to "Return to home page", home_path, :class => 'link_button large_link_button return_to_homepage_button' %>
 </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -13,7 +13,7 @@
       </ul>
     </section>
   <% end %>
-  <%= link_to 'View all e-petitions', petitions_path, :class => 'view-all' %>
+  <%= link_to 'View all petitions', petitions_path, :class => 'view-all' %>
 </div>
 
 <section class="section-panel local-to-you">
@@ -30,7 +30,7 @@
 
 <form method="get" action="/search" class="search-form">
   <div class="form-group">
-    <label for="search" class="form-label">Search for an e-petition to sign</label>
+    <label for="search" class="form-label">Search for a petition to sign</label>
     <input type='text' name="q" id="search" class="form-control" />
   </div>
   <input type='submit' value='Search' class="button" />

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -17,29 +17,30 @@ en-GB:
     emails:
       subjects:
         email_confirmation_for_signer: |-
-          HM Government e-petitions: Email address confirmation
+          HM Government & Parliament Petitions: Email address confirmation
         special_resend_of_email_confirmation_for_signer: |-
-          HM Government e-petitions: Email address confirmation
+          HM Government & Parliament Petitions: Email address confirmation
         notify_creator_that_petition_is_published: |-
-          HM Government e-petitions: Your e-petition has been published
+          HM Government & Parliament Petitions: Your petition has been published
         petition_rejected: |-
-          HM Government e-petitions: e-petition has been rejected
+          HM Government & Parliament Petitions: petition has been rejected
         notify_signer_of_threshold_response: |-
-          HM Government e-petitions: The petition '%{title}' has reached %{formatted_count} signatures"
+          HM Government & Parliament Petitions: The petition '%{title}' has reached %{formatted_count} signatures"
         no_signature_for_petition: |-
-          HM Government e-petitions: a confirmation email has been requested
+          HM Government & Parliament Petitions: a confirmation email has been requested
         email_already_confirmed_for_signature: |-
-          HM Government e-petitions: Signature already confirmed
+          HM Government & Parliament Petitions: Signature already confirmed
         two_pending_signatures: |-
-          HM Government e-petitions: Signature confirmations
+          HM Government & Parliament Petitions: Signature confirmations
         one_pending_one_validated_signature: |-
-          HM Government e-petitions: Signature confirmation
+          HM Government & Parliament Petitions: Signature confirmation
         double_signature_confirmation: |-
-          HM Government e-petitions: Signatures already confirmed
+          HM Government & Parliament Petitions: Signatures already confirmed
         notify_creator_of_closing_date_change: |-
-          HM Government e-petitions: change to your e-petition closing date
+          HM Government & Parliament Petitions: change to your petition closing date
         gather_sponsors_for_petition: |-
           Parliament petitions - It's time to get sponsors to support your petition
+      signoff_prefix: "HM Government & Parliament Petitions"
 
     counts:
       default:
@@ -62,18 +63,18 @@ en-GB:
     rejection_reasons:
       titles:
         no-action: "Does not include a request for action"
-        duplicate: "Duplicate of an existing e-petition"
+        duplicate: "Duplicate of an existing petition"
         libellous: "Confidential, libellous, false or defamatory statements"
-        offensive: "Offensive, joke or nonsense e-petitions"
+        offensive: "Offensive, joke or nonsense petitions"
         irrelevant: "Matters which are not the responsibility of HM Government"
         honours: "Matters relating to honours or appointments"
       descriptions:
         no-action: |
           <p>It did not have a clear statement explaining what action you want the government to take.</p>
         duplicate: |
-          <p>There is already an e-petition about this issue.</p>
+          <p>There is already a petition about this issue.</p>
         libellous: |
-          <p>E-petitions will not be accepted if they:</p>
+          <p>Petitions will not be accepted if they:</p>
           <ul>
             <li>contain information which may be protected by an injunction or court order</li>
             <li>contain material that is potentially confidential, commercially sensitive or which may cause personal distress or loss</li>
@@ -82,7 +83,7 @@ en-GB:
             <li>include the names of family members of elected representatives, eg MPs, or officials who work for public bodies</li>
           </ul>
         offensive: |
-          <p>E-petitions will not be accepted if they:</p>
+          <p>Petitions will not be accepted if they:</p>
           <ul>
             <li>contain offensive, joke or nonsense content</li>
             <li>use language which may cause offence, is provocative or extreme in its views</li>
@@ -90,14 +91,14 @@ en-GB:
             <li>include statements that amount to advertisements</li>
           </ul>
         irrelevant: |
-          <p>E-petitions cannot be used to request action on issues that are outside the responsibility of the government. This includes:</p>
+          <p>Petitions cannot be used to request action on issues that are outside the responsibility of the government. This includes:</p>
           <ul>
             <li>party political material</li>
             <li>commercial endorsements including the promotion of any product, service or publication</li>
             <li>issues that are dealt with by devolved bodies, eg The Scottish Parliament</li>
             <li>correspondence on personal issues</li>
           </ul>
-          <p>E-petitions cannot be used for freedom of information requests.</p>
+          <p>Petitions cannot be used for freedom of information requests.</p>
         honours: |
-          <p>E-petitions cannot include information about honours or appointments.</p>
+          <p>Petitions cannot include information about honours or appointments.</p>
           <p>Find information about nominations for honours at: <a href='https://www.gov.uk/honours'>https://www.gov.uk/honours</a></p>

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -34,7 +34,7 @@ Feature: Moderator respond to petition
   Scenario: Moderator rejects petition with a suitable reason code and text
     Given I am logged in as a moderator
     When I look at the next petition on my list
-    And I reject the petition with a reason code "Duplicate of an existing e-petition" and some explanatory text
+    And I reject the petition with a reason code "Duplicate of an existing petition" and some explanatory text
     Then the explanation is displayed on the petition for viewing by the public
     And the creator should receive a rejection notification email
 

--- a/features/admin/reports.feature
+++ b/features/admin/reports.feature
@@ -1,5 +1,5 @@
 Feature: Viewing reports
-  In order to gauge utilisation of the e-petitions site
+  In order to gauge utilisation of the petitions site
   As Maggie or Terry
   I would like to be able to see summary of number of petitions in particular states
 

--- a/features/admin/takedown.feature
+++ b/features/admin/takedown.feature
@@ -11,7 +11,7 @@ Feature: Terry (or Sheila) takes down a petition
     When I view all petitions
     And I follow "Mistakenly published petition"
     And I follow "Edit parliament response"
-    And I take down the petition with a reason code "Duplicate of an existing e-petition"
+    And I take down the petition with a reason code "Duplicate of an existing petition"
     Then the petition is not available for signing
     And I should not be able to take down the petition
 
@@ -20,6 +20,6 @@ Feature: Terry (or Sheila) takes down a petition
     When I view all petitions
     And I follow "Mistakenly published petition"
     And I follow "Edit parliament response"
-    And I take down the petition with a reason code "Duplicate of an existing e-petition"
+    And I take down the petition with a reason code "Duplicate of an existing petition"
     Then the petition is not available for signing
     And I should not be able to take down the petition

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -38,10 +38,10 @@ Scenario: Charlie creates a petition
   And "womboid@wimbledon.com" should be emailed a link for gathering support from sponsors
 
 Scenario: First person sponsors a petition
-  When I have created an e-petition and told people to sponsor it
-  And a sponsor supports my e-petition
-  Then the e-petition should be validated
-  And the e-petition creator signature should be validated
+  When I have created a petition and told people to sponsor it
+  And a sponsor supports my petition
+  Then my petition should be validated
+  And the petition creator signature should be validated
 
 Scenario: Charlie creates a petition with invalid postcode SW14 9RQ
   Given I start a new petition

--- a/features/charlie_is_notified_about_sponsors_signing_his_petition.feature
+++ b/features/charlie_is_notified_about_sponsors_signing_his_petition.feature
@@ -4,20 +4,20 @@ Feature: Charlie is notified to get an MP
   I want to be emailed when they sign with a countdown to the threshold
 
   Background:
-    Given I have created an e-petition and told people to sponsor it
+    Given I have created a petition and told people to sponsor it
 
   Scenario: Charlie is emailed about sponsor support before passing the threshold
-    When a sponsor supports my e-petition
+    When a sponsor supports my petition
     Then I should receive a sponsor support notification email
     And the sponsor support notification email should include the countdown to the threshold
 
   Scenario: Charlie is emailed about moderation upon hitting the sponsor support threshold
-    Given I only need one more sponsor to support my e-petition
-    When a sponsor supports my e-petition
+    Given I only need one more sponsor to support my petition
+    When a sponsor supports my petition
     Then I should receive a sponsor support notification email
-    And the sponsor support notification email should tell me about my e-petition going into moderation
+    And the sponsor support notification email should tell me about my petition going into moderation
 
   Scenario: Charlie is no longer emailed about sponsor support after passing the threshold
-    Given I have enough support from sponsors for my e-petition
-    When a sponsor supports my e-petition
+    Given I have enough support from sponsors for my petition
+    When a sponsor supports my petition
     Then I should not receive a sponsor support notification email

--- a/features/joe_searches_for_an_archived_petition.feature
+++ b/features/joe_searches_for_an_archived_petition.feature
@@ -16,7 +16,7 @@ Feature: Joe searches for an archived petition
     And I fill in "search" with "Wombles"
     And I press "Search"
     Then I should be on the archived petitions search results page
-    And I should see "Search results - archived e-petitions" in the browser page title
+    And I should see "Search results - archived petitions" in the browser page title
     And I should see /for "Wombles"/
     But I should see the following search results:
       | Eavis vs the Wombles (Rejected)   | –   | –          |

--- a/features/joe_views_an_archived_petition.feature
+++ b/features/joe_views_an_archived_petition.feature
@@ -7,17 +7,17 @@ Feature: Joe views an archived petition
     Given an archived petition "Spend more money on Defence"
     When I view the petition
     Then I should see the petition details
-    And I should see "Spend more money on Defence - e-petitions" in the browser page title
+    And I should see "Spend more money on Defence - Petitions" in the browser page title
     And I should see the vote count, closed and open dates
-    And I should see "This e-petition is now closed"
+    And I should see "This petition is now closed"
 
   Scenario: Joe views an archived petition at the old url and is redirected
     Given an archived petition "Spend more money on Defence"
     When I view the petition at the old url
     Then I should be redirected to the archived url
-    And I should see "Spend more money on Defence - e-petitions" in the browser page title
+    And I should see "Spend more money on Defence - Petitions" in the browser page title
     And I should see the vote count, closed and open dates
-    And I should see "This e-petition is now closed"
+    And I should see "This petition is now closed"
 
   Scenario: Joe views an archived petition containing urls, email addresses and html tags
     Given an archived petition exists with title: "Defence review", description: "<i>We<i> like http://www.google.com and bambi@gmail.com"
@@ -45,4 +45,4 @@ Feature: Joe views an archived petition
   Scenario: Joe sees a 'closed' message when viewing an archived petition
     Given an archived petition "Spend more money on Defence"
     When I view the petition
-    Then I should see "This e-petition is now closed"
+    Then I should see "This petition is now closed"

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -105,8 +105,8 @@ Then /^I should not see any "([^"]*)" petitions$/ do |state|
 end
 
 Then /^I see relevant reason descriptions when I browse different reason codes$/ do
-  select "Duplicate of an existing e-petition", :from => :petition_rejection_code
-  expect(page).to have_content "already an e-petition"
+  select "Duplicate of an existing petition", :from => :petition_rejection_code
+  expect(page).to have_content "already a petition"
   select "Confidential, libellous, false or defamatory statements", :from => :petition_rejection_code
   expect(page).to have_content "injunction or court order"
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -58,7 +58,7 @@ Given /^a ?(open|closed)? petition "([^"]*)" exists and has received a parliamen
   FactoryGirl.create(:open_petition, petition_attributes)
 end
 
-Given /^I have created an e-petition$/ do
+Given /^I have created a petition$/ do
   @petition = FactoryGirl.create(:open_petition)
   reset_mailer
 end
@@ -223,7 +223,7 @@ end
 When /^I start a new petition/ do
   steps %Q(
     Given I am on the new petition page
-    Then I should see "Create a new e-petition - e-petitions" in the browser page title
+    Then I should see "Create a new petition - Petitions" in the browser page title
     And I should be connected to the server via an ssl connection
   )
 end
@@ -260,12 +260,12 @@ Then /^I should not see the text "([^"]*)"/ do |text|
   expect(page).to_not have_text(text)
 end
 
-Then(/^the e\-petition should be validated$/) do
+Then(/^my petition should be validated$/) do
   @sponsor_petition.reload
   expect(@sponsor_petition.state).to eq Petition::VALIDATED_STATE
 end
 
-Then(/^the e\-petition creator signature should be validated$/) do
+Then(/^the petition creator signature should be validated$/) do
   @sponsor_petition.reload
   expect(@sponsor_petition.creator_signature.state).to eq Signature::VALIDATED_STATE
 end

--- a/features/step_definitions/resend_confirmation_steps.rb
+++ b/features/step_definitions/resend_confirmation_steps.rb
@@ -10,7 +10,7 @@ Then /^I should see an ambiguous message telling me I'll receive an email$/ do
 end
 
 Then /^I should receive an email telling me that I've not signed this petition$/ do
-  open_email("suzie@example.com", :with_text => "This email address has not been used to sign this e-petition")
+  open_email("suzie@example.com", :with_text => "This email address has not been used to sign this petition")
 end
 
 Then /^I should receive an email with my confirmation link$/ do

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -77,7 +77,7 @@ end
 When /^I fill in my details and sign a petition$/ do
   steps %Q(
     When I go to the new signature page for "Do something!"
-    And I should see "Do something! - Sign this e-petition - e-petitions" in the browser page title
+    And I should see "Do something! - Sign this petition - Petitions" in the browser page title
     And I should be connected to the server via an ssl connection
     And I fill in my details
     And I try to sign
@@ -88,7 +88,7 @@ When /^I fill in my details and sign a petition$/ do
 end
 
 Then /^I should see that I have already signed the petition$/ do
-  expect(page).to have_text("Thank you. Your signature has already been added to the e-petition.")
+  expect(page).to have_text("Thank you. Your signature has already been added to the petition.")
 end
 
 Then(/^I am asked to review my email address$/) do

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -5,7 +5,7 @@ Given(/^I have been told about a petition that needs sponsoring$/) do
     state: Petition::VALIDATED_STATE)
 end
 
-Given(/^I have created an e\-petition and told people to sponsor it$/) do
+Given(/^I have created a petition and told people to sponsor it$/) do
   @sponsor_petition = FactoryGirl.create(:pending_petition,
     title: 'Charles to be nominated for sublimation',
     closed_at: 1.day.from_now,
@@ -13,7 +13,7 @@ Given(/^I have created an e\-petition and told people to sponsor it$/) do
     creator_signature_attributes: { email: 'charlie.the.creator@example.com' })
 end
 
-When(/^a sponsor supports my e\-petition$/) do
+When(/^a sponsor supports my petition$/) do
   sponsor_email = FactoryGirl.generate(:sponsor_email)
   steps %{
     When I visit the "sponsor this petition" url I was given
@@ -32,11 +32,11 @@ When(/^a sponsor supports my e\-petition$/) do
   expect(signature).to be_sponsor
 end
 
-Given(/^I only need one more sponsor to support my e\-petition$/) do
+Given(/^I only need one more sponsor to support my petition$/) do
   before_threshold = Site.threshold_for_moderation - 1
   while (@sponsor_petition.supporting_sponsors_count < before_threshold) do
     steps %Q{
-      And a sponsor supports my e-petition
+      And a sponsor supports my petition
     }
   end
   steps %Q{
@@ -44,10 +44,10 @@ Given(/^I only need one more sponsor to support my e\-petition$/) do
   }
 end
 
-Given(/^I have enough support from sponsors for my e\-petition$/) do
+Given(/^I have enough support from sponsors for my petition$/) do
   while (@sponsor_petition.supporting_sponsors_count < Site.threshold_for_moderation) do
     steps %Q{
-      And a sponsor supports my e-petition
+      And a sponsor supports my petition
     }
   end
   steps %Q{

--- a/features/step_definitions/sponsor_support_nofitication_steps.rb
+++ b/features/step_definitions/sponsor_support_nofitication_steps.rb
@@ -20,7 +20,7 @@ Then(/^the sponsor support notification email should include the countdown to th
   expect(mail_body).to include "still need #{threshold - signed} more before"
 end
 
-Then(/^the sponsor support notification email should tell me about my e\-petition going into moderation$/) do
+Then(/^the sponsor support notification email should tell me about my petition going into moderation$/) do
   threshold = Site.threshold_for_moderation
 
   email = open_last_email_for("charlie.the.creator@example.com")

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -20,7 +20,7 @@ Feature: Suzy Singer searches by free text
   Scenario: Search for open petitions
     When I search for "Wombles"
     Then I should be on the search results page
-    And I should see "Search results - e-petitions" in the browser page title
+    And I should see "Search results - Petitions" in the browser page title
     And I should see /For "Wombles"/
     And I should not see "Wombles are great"
     And I should not see "The Wombles of Wimbledon"

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -20,7 +20,7 @@ Feature: Suzie signs a petition
 
   Scenario: Suzie signs a petition after validating her email
     When I go to the new signature page for "Do something!"
-    And I should see "Do something! - Sign this e-petition - e-petitions" in the browser page title
+    And I should see "Do something! - Sign this petition - Petitions" in the browser page title
     And I should be connected to the server via an ssl connection
     And I fill in my details with email "womboid@wimbledon.com"
     And I fill in my postcode with "N1 1TY"

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -7,9 +7,9 @@ Feature: Suzie views a petition
     Given an open petition "Spend more money on Defence"
     When I view the petition
     Then I should see the petition details
-    And I should see "Spend more money on Defence - e-petitions" in the browser page title
+    And I should see "Spend more money on Defence - Petitions" in the browser page title
     And I should see the vote count, closed and open dates
-    And I should not see "This e-petition is now closed"
+    And I should not see "This petition is now closed"
     And I can share it via Email
     And I can share it via Facebook
     And I can share it via Twitter
@@ -54,7 +54,7 @@ Feature: Suzie views a petition
   Scenario: Suzie sees a 'closed' message when viewing a closed petition
     Given a petition "Spend more money on Defence" has been closed
     When I view the petition
-    Then I should see "This e-petition is now closed"
+    Then I should see "This petition is now closed"
 
   Scenario: Suzie sees information about the outcomes when viewing a debated petition
     Given a petition "Ban Badger Baiting" has been debated

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -15,11 +15,11 @@ namespace :import do
 
     rejection_reasons = {
       "no-action"  => "It did not have a clear statement explaining what action you want the government to take.",
-      "duplicate"  => "There is already an e-petition about this issue.",
-      "libellous"  => "E-petitions will not be accepted if they contain information which may be protected by an injunction or court order; contain material that is potentially confidential, commercially sensitive or which may cause personal distress or loss; include the names of individuals if they have been accused of a crime or information that may identify them; include the names of individual officials who work for public bodies, unless they are part of the senior management of those organisations; include the names of family members of elected representatives, eg MPs, or officials who work for public bodies.",
-      "offensive"  => "E-petitions will not be accepted if they contain offensive, joke or nonsense content; use language which may cause offence, is provocative or extreme in its views; use wording that is impossible to understand; include statements that amount to advertisements.",
-      "irrelevant" => "E-petitions cannot be used to request action on issues that are outside the responsibility of the government. This includes party political material; commercial endorsements including the promotion of any product, service or publication; issues that are dealt with by devolved bodies, eg The Scottish Parliament; correspondence on personal issues. E-petitions cannot be used for freedom of information requests.",
-      "honours"    => "E-petitions cannot include information about honours or appointments. Find information about nominations for honours at https://www.gov.uk/honours.",
+      "duplicate"  => "There is already a petition about this issue.",
+      "libellous"  => "Petitions will not be accepted if they contain information which may be protected by an injunction or court order; contain material that is potentially confidential, commercially sensitive or which may cause personal distress or loss; include the names of individuals if they have been accused of a crime or information that may identify them; include the names of individual officials who work for public bodies, unless they are part of the senior management of those organisations; include the names of family members of elected representatives, eg MPs, or officials who work for public bodies.",
+      "offensive"  => "Petitions will not be accepted if they contain offensive, joke or nonsense content; use language which may cause offence, is provocative or extreme in its views; use wording that is impossible to understand; include statements that amount to advertisements.",
+      "irrelevant" => "Petitions cannot be used to request action on issues that are outside the responsibility of the government. This includes party political material; commercial endorsements including the promotion of any product, service or publication; issues that are dealt with by devolved bodies, eg The Scottish Parliament; correspondence on personal issues. E-petitions cannot be used for freedom of information requests.",
+      "honours"    => "Petitions cannot include information about honours or appointments. Find information about nominations for honours at https://www.gov.uk/honours.",
     }
 
     converters = [

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>e-Petitions</title>
+    <title>Petitions</title>
     <link href="/stylesheets/application.css?1308657040" media="screen" rel="stylesheet" type="text/css" />
     <!--[if IE 6]><link href="/stylesheets/ie6.css?1308579977" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if lte IE 7]><link href="/stylesheets/ie7under.css?1308568036" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
@@ -14,10 +14,10 @@
         </div>
         <div id="page_content">
           <div class="title_block">
-            <h1>The e-petitions service is currently down for maintenance</h1>
+            <h1>The petitions service is currently down for maintenance</h1>
           </div>
           <div class="cta_block">
-            <p>e-petitions is unavailable over as we're making a number of enhancements. Sorry for the inconvenience. We'll be back online soon.</p>
+            <p>Petitions is unavailable as we're making a number of enhancements. Sorry for the inconvenience. We'll be back online soon.</p>
           </div>
         </div>
       </div>

--- a/public/overloaded.html
+++ b/public/overloaded.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>e-Petitions</title>
+    <title>Petitions</title>
     <link href="/stylesheets/application.css?1308657040" media="screen" rel="stylesheet" type="text/css" />
     <!--[if IE 6]><link href="/stylesheets/ie6.css?1308579977" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if lte IE 7]><link href="/stylesheets/ie7under.css?1308568036" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
@@ -14,11 +14,11 @@
         </div>
         <div id="page_content">
           <div class="title_block">
-            <h1>Sorry, e-petitions is overloaded.</h1>
+            <h1>Sorry, petitions is overloaded.</h1>
           </div>
 
           <div class="cta_block">
-            <p>We're sorry but we are currently experiencing a very high level of demand for the e-petitions service.</p>
+            <p>We're sorry but we are currently experiencing a very high level of demand for the petitions service.</p>
 
             <p>Please come back and try again later.</p>
           </div>

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Admin::PetitionsController, type: :controller do
         it "sends an email to the petition creator" do
           set_up
           email = ActionMailer::Base.deliveries.last
-          expect(email.subject).to match(/Your e-petition has been published/)
+          expect(email.subject).to match(/Your petition has been published/)
         end
       end
 
@@ -280,7 +280,7 @@ RSpec.describe Admin::PetitionsController, type: :controller do
           email = ActionMailer::Base.deliveries.last
           expect(email.from).to eq(["no-reply@test.epetitions.website"])
           expect(email.to).to eq(["john@example.com"])
-          expect(email.subject).to match(/e-petition has been rejected/)
+          expect(email.subject).to match(/petition has been rejected/)
         end
 
         it "sends an email to validated petition sponsors" do

--- a/spec/controllers/admin/searches_controller_spec.rb
+++ b/spec/controllers/admin/searches_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Admin::SearchesController, type: :controller do
         end
       end
 
-      context "searching for e-petition by id" do
+      context "searching for petition by id" do
         let(:petition) { double(:id => 123, :to_param => '123', :editable_by? => false, :response_editable_by? => false) }
 
         before do

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -16,16 +16,17 @@ RSpec.describe PetitionMailer, type: :mailer do
   end
   let(:pending_signature) { FactoryGirl.create(:pending_signature, :petition => petition) }
   let(:validated_signature) { FactoryGirl.create(:validated_signature, :petition => petition) }
-
+  let(:subject_prefix) { "HM Government & Parliament Petitions" }
+  
   describe "When no signature for an email address exists on a petition" do
     let(:mail) { PetitionMailer.no_signature_for_petition(petition, 'wibble@example.com') }
 
     it "has an appropriate header for the email" do
-      expect(mail.subject).to eq("HM Government e-petitions: a confirmation email has been requested")
+      expect(mail.subject).to eq("#{subject_prefix}: a confirmation email has been requested")
     end
 
     it "informs them there is no signature for that email address on the petition" do
-      expect(mail.body.encoded).to match("This email address has not been used to sign this e-petition")
+      expect(mail.body.encoded).to match("This email address has not been used to sign this petition")
       expect(mail.body.encoded).to have_css("a", "/petitions/#{petition.id}")
     end
   end
@@ -35,11 +36,11 @@ RSpec.describe PetitionMailer, type: :mailer do
     let(:mail) { PetitionMailer.email_already_confirmed_for_signature(signature) }
 
     it "has an appropriate header for the email" do
-      expect(mail.subject).to eq("HM Government e-petitions: Signature already confirmed")
+      expect(mail.subject).to eq("#{subject_prefix}: Signature already confirmed")
     end
 
     it "informs the user they've already signed the petition" do
-      expect(mail.body.encoded).to match("Your signature has already been added to the e-petition")
+      expect(mail.body.encoded).to match("Your signature has already been added to the petition")
     end
   end
 
@@ -49,7 +50,7 @@ RSpec.describe PetitionMailer, type: :mailer do
     let(:mail) { PetitionMailer.two_pending_signatures(signature_one, signature_two) }
 
     it "has an appropriate header for the email" do
-      expect(mail.subject).to eq("HM Government e-petitions: Signature confirmations")
+      expect(mail.subject).to eq("#{subject_prefix}: Signature confirmations")
     end
 
     it "is addressed to both signees" do
@@ -68,7 +69,7 @@ RSpec.describe PetitionMailer, type: :mailer do
     let(:mail) { PetitionMailer.one_pending_one_validated_signature(pending_signature, validated_signature) }
 
     it "has an appropriate header for the email" do
-      expect(mail.subject).to eq("HM Government e-petitions: Signature confirmation")
+      expect(mail.subject).to eq("#{subject_prefix}: Signature confirmation")
     end
 
     it "is addressed to both signees" do
@@ -90,7 +91,7 @@ RSpec.describe PetitionMailer, type: :mailer do
     let(:mail) { PetitionMailer.double_signature_confirmation([signature_one, signature_two]) }
 
     it "has an appropriate header for the email" do
-      expect(mail.subject).to eq("HM Government e-petitions: Signatures already confirmed")
+      expect(mail.subject).to eq("#{subject_prefix}: Signatures already confirmed")
     end
 
     it "is addressed to both signees" do
@@ -98,7 +99,7 @@ RSpec.describe PetitionMailer, type: :mailer do
     end
 
     it "Informs the signees that their signatures have both been confirmed" do
-      expect(mail.body.encoded).to match("signatures have already been added to the e-petition")
+      expect(mail.body.encoded).to match("signatures have already been added to the petition")
     end
   end
 
@@ -107,7 +108,7 @@ RSpec.describe PetitionMailer, type: :mailer do
     let(:mail) { PetitionMailer.notify_creator_of_closing_date_change(signature) }
 
     it 'has an appropriate subject heading' do
-      expect(mail.subject).to eq("HM Government e-petitions: change to your e-petition closing date")
+      expect(mail.subject).to eq("#{subject_prefix}: change to your petition closing date")
     end
 
     it 'is addressed to the creator' do

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Feedback, type: :model do
     expect(Feedback.new(:email => 'foo').email).to eq('foo')
   end
 
-  it "has an e-petition link or title" do
+  it "has a petition link or title" do
     expect(Feedback.new(:petition_link_or_title => 'foo').petition_link_or_title).to eq('foo')
   end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -522,14 +522,14 @@ RSpec.describe Petition, type: :model do
   describe "rejection_reason" do
     it "gives rejection reason from the locale file" do
       petition = FactoryGirl.build(:rejected_petition, :rejection_code => 'duplicate')
-      expect(petition.rejection_reason).to eq('Duplicate of an existing e-petition')
+      expect(petition.rejection_reason).to eq('Duplicate of an existing petition')
     end
   end
 
   describe "rejection_description" do
     it "gives rejection description from the locale file" do
       petition = FactoryGirl.build(:rejected_petition, :rejection_code => 'duplicate')
-      expect(petition.rejection_description).to eq('<p>There is already an e-petition about this issue.</p>')
+      expect(petition.rejection_description).to eq('<p>There is already a petition about this issue.</p>')
     end
   end
 


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/97092986

Other than lots of renaming, the main change is the use of locale definitions for email signoff, making it easier to change it in future.