### PR TITLE
Moderator can edit petition before publishing

### DIFF
--- a/app/controllers/admin/petition_details_controller.rb
+++ b/app/controllers/admin/petition_details_controller.rb
@@ -1,0 +1,20 @@
+class Admin::PetitionDetailsController < Admin::AdminController
+  respond_to :html
+  before_action :find_petition
+
+  def show
+    if @petition.in_todo_list?
+    else
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+
+  def update
+  end
+
+  private
+
+  def find_petition
+    @petition = Petition.find(params[:petition_id])
+  end
+end

--- a/app/controllers/admin/petition_details_controller.rb
+++ b/app/controllers/admin/petition_details_controller.rb
@@ -1,20 +1,27 @@
 class Admin::PetitionDetailsController < Admin::AdminController
   respond_to :html
-  before_action :find_petition
+  before_action :fetch_petition
 
   def show
-    if @petition.in_todo_list?
-    else
-      raise ActiveRecord::RecordNotFound
-    end
   end
 
   def update
+    if @petition.update_attributes(petition_params)
+      flash[:notice] = 'Petition has been successfully updated'
+      redirect_to edit_admin_petition_path(@petition)
+    else
+      render :show
+    end
   end
 
   private
 
-  def find_petition
-    @petition = Petition.find(params[:petition_id])
+  def fetch_petition
+    @petition = Petition.todo_list.find(params[:petition_id])
+    #raise ActiveRecord::RecordNotFound unless @petition.in_todo_list?
+  end
+
+  def petition_params
+    params.require(:petition).permit(:title, :action, :description)
   end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -198,6 +198,10 @@ class Petition < ActiveRecord::Base
     self.open? || self.closed?
   end
 
+  def in_todo_list?
+    TODO_LIST_STATES.include? state
+  end
+
   def state_label
     if (self.closed?)
       CLOSED_STATE

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -170,10 +170,6 @@ class Petition < ActiveRecord::Base
     self.state == SPONSORED_STATE
   end
 
-  def collecting_sponsors?
-    self.state == VALIDATED_STATE || self.state == PENDING_STATE
-  end
-
   def open?
     self.state == OPEN_STATE
   end

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -1,0 +1,29 @@
+<%= form_for @petition, url: admin_petition_petition_details_path(@petition), method: :patch do |f| %>
+
+  <h2>Edit petition</h2>
+
+  <%= form_row for: [f.object, :title] do %>
+    <%= f.label :title, class: 'form-label' %>
+    <%= error_messages_for_field @petition, :title %>
+    <%= f.text_area :title, tabindex: increment, rows: 3, maxlength: 80, class: 'form-control' %>
+  <% end %>
+
+  <%= form_row for: [f.object, :action] do %>
+    <%= f.label :action, class: 'form-label' %>
+    <%= error_messages_for_field @petition, :action %>
+    <%= f.text_area :action, tabindex: increment, rows: 5, class: 'form-control' %>
+  <% end %>
+
+  <%= form_row for: [f.object, :description] do %>
+    <%= f.label :description, class: 'form-label' %>
+    <%= error_messages_for_field @petition, :description %>
+    <%= f.text_area :description, tabindex: increment, rows: 7, class: 'form-control' %>
+  <% end %>
+
+  <%= form_row do %>
+    <%= f.submit 'Save' %>
+  <% end %>
+
+  <%= link_to 'Cancel', edit_admin_petition_path(@petition) %>
+
+<% end %>

--- a/app/views/admin/petitions/edit.html.erb
+++ b/app/views/admin/petitions/edit.html.erb
@@ -2,7 +2,11 @@
 
   <%= render :partial => 'petition_details', :locals => { :f => f } %>
 
-  <div>
+  <div class="row">
+    <%= link_to 'Edit petition content', admin_petition_petition_details_path(@petition) %>
+  </div>
+
+  <div class="row">
     <%= submit_tag 'Publish this petition', :data => { :confirm => "Are you sure you want to publish this petition?" } %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
         patch :take_down
       end
       resource 'debate-outcome', only: [:show, :update], as: :debate_outcome, controller: :debate_outcomes
+      resource :petition_details, :only => [:show, :update]
     end
     resources :profile, :only => [:edit, :update]
     resources :reports,  :only => [:index]

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -1,7 +1,7 @@
 Feature: Moderator respond to petition
   In order to allow or prevent the signing of petitions
   As a moderator
-  I want to respond to a petition, accepting, rejecting or re-assigning it
+  I want to respond to a petition, editing, accepting, rejecting or re-assigning it
 
   Scenario: Accessing the petitions page
     Given a sponsored petition "More money for charities"
@@ -10,6 +10,44 @@ Feature: Moderator respond to petition
     Then I should be connected to the server via an ssl connection
     And the markup should be valid
     And I should see the petition details
+
+  Scenario: Moderator edits petition before publishing
+    Given I am logged in as a moderator
+    And I visit a sponsored petition with title: "wee need to save our plaanet", that has action: "Reduce polootion" and description: "Enforce Kyotoe protocol in more countries"
+    And I follow "Edit petition content"
+    Then I am redirected to the petition edit details page
+    And the markup should be valid
+    And the "Title" field should contain "wee need to save our plaanet"
+    And the "Action" field should contain "Reduce polootion"
+    And the "Description" field should contain "Enforce Kyotoe protocol in more countries"
+    Then I fill in "Title" with "We need to save our planet"
+    And I fill in "Action" with "Reduce pollution"
+    And I fill in "Description" with "Enforce Kyoto Protocol in more countries"
+    And I press "Save"
+    Then I am redirected to the petition edit page
+    And I should see "We need to save our planet"
+    And I should see "Reduce pollution"
+    And I should see "Enforce Kyoto Protocol in more countries"
+
+  Scenario: Moderator edits and tries to save an invalid petition
+    Given I am logged in as a moderator
+    And I visit a sponsored petition with title: "wee need to save our plaanet", that has action: "Reduce polootion" and description: "Enforce Kyotoe protocol in more countries"
+    And I follow "Edit petition content"
+    Then I fill in "Title" with ""
+    And I fill in "Action" with ""
+    And I fill in "Description" with ""
+    And I press "Save"
+    Then I should see "Action must be completed"
+    And I should see "Background must be completed"
+    And I should see "Supporting details must be completed"
+
+  Scenario: Moderator cancel editing petition
+    Given I am logged in as a moderator
+    And I visit a sponsored petition with title: "Blah", that has action: "Blah" and description: "Blah"
+    And I follow "Edit petition content"
+    Then I am redirected to the petition edit details page
+    When I follow "Cancel"
+    Then I am redirected to the petition edit page
 
   Scenario: Moderator publishes petition
     Given I am logged in as a moderator

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -130,3 +130,7 @@ end
 Then(/^I am redirected to the petition edit page$/) do
   expect(current_path).to eq(edit_admin_petition_path(@sponsored_petition))
 end
+
+Then(/^I am redirected to the petition edit details page$/) do
+  expect(current_path).to eq(admin_petition_petition_details_path(@sponsored_petition))
+end

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -3,6 +3,11 @@ When /^I look at the next petition on my list$/ do
   visit edit_admin_petition_path(@petition)
 end
 
+When /^I visit a sponsored petition with title: "([^"]*)", that has action: "([^"]*)" and description: "([^"]*)"$/ do |title, action, description|
+  @sponsored_petition = FactoryGirl.create(:sponsored_petition, title: title, action: action, description: description)
+  visit edit_admin_petition_path(@sponsored_petition)
+end
+
 When /^I reject the petition with a reason code "([^"]*)"$/ do |reason_code|
   select reason_code, :from => :petition_rejection_code
   click_button "Reject"
@@ -120,4 +125,8 @@ Given(/^a moderator responds to the petition$/) do
     And I check "Email signees"
     And I press "Save"
   )
+end
+
+Then(/^I am redirected to the petition edit page$/) do
+  expect(current_path).to eq(edit_admin_petition_path(@sponsored_petition))
 end

--- a/spec/controllers/admin/petition_details_controller_spec.rb
+++ b/spec/controllers/admin/petition_details_controller_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe Admin::PetitionDetailsController do
         expect(response).to redirect_to('https://petition.parliament.uk/admin/login')
       end
     end
+
+    describe 'PATCH #update' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to('https://petition.parliament.uk/admin/login')
+      end
+    end
   end
 
   context 'logged in as moderator user but need to reset password' do
@@ -23,6 +30,13 @@ RSpec.describe Admin::PetitionDetailsController do
         expect(response).to redirect_to("https://petition.parliament.uk/admin/profile/#{user.id}/edit")
       end
     end
+
+    describe 'PATCH #update' do
+      it 'redirects to edit profile page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
   end
 
   describe 'logged in as moderator user' do
@@ -30,7 +44,6 @@ RSpec.describe Admin::PetitionDetailsController do
     before { login_as(user) }
 
     describe 'GET #show' do
-
       shared_examples_for 'viewing a petition in the correct state' do
         it 'fetches the requested petition' do
           get :show, petition_id: petition.id
@@ -79,6 +92,93 @@ RSpec.describe Admin::PetitionDetailsController do
       describe 'for a hidden petition' do
         before { petition.update_column(:state, Petition::HIDDEN_STATE) }
         it_behaves_like 'trying to view a petition in the wrong state'
+      end
+    end
+
+    describe 'PATCH #update' do
+      let(:petition) { FactoryGirl.create(:sponsored_petition, title: 'Old title', action: 'Old action', description: 'Old description') }
+
+      def do_update
+        patch :update,
+              petition_id: petition.id,
+              petition: petition_attributes
+      end
+
+      describe 'allowed params' do
+        it { should permit(:title, :action, :description).for(:update, params: { petition_id: petition.id }) }
+      end
+      
+      describe 'with valid params' do
+        let(:petition_attributes) do
+          {
+              title: 'New title',
+              action: 'New action',
+              description: 'New description'
+          }
+        end
+
+        shared_examples_for 'updating a petition in the correct state' do
+          it 'redirects to the edit petition page' do
+            do_update
+            petition.reload
+            expect(response).to redirect_to"https://petition.parliament.uk/admin/petitions/#{petition.id}/edit"
+          end
+
+          it 'updates the petition' do
+            do_update
+            petition.reload
+            expect(petition).to be_present
+            expect(petition.title).to eq('New title')
+            expect(petition.action).to eq('New action')
+            expect(petition.description).to eq('New description')
+          end
+        end
+
+        describe 'for a sponsored petition' do
+          it_behaves_like 'updating a petition in the correct state'
+        end
+
+        describe 'for a pending petition' do
+          before { petition.update_column(:state, Petition::PENDING_STATE) }
+          it_behaves_like 'updating a petition in the correct state'
+        end
+
+        describe 'for a validated petition' do
+          before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+          it_behaves_like 'updating a petition in the correct state'
+        end
+      end
+
+      describe 'with invalid params' do
+        let(:petition_attributes) do
+          {
+              title: '',
+              action: '',
+              description: 'Blah'
+          }
+        end
+
+        shared_examples_for 'updating a petition in the correct state' do
+          it 'renders the petition_details/show template again' do
+            do_update
+            expect(response).to be_success
+            expect(response).to render_template('petition_details/show')
+          end
+        end
+
+        describe 'for a sponsored petition' do
+          it_behaves_like 'updating a petition in the correct state'
+        end
+
+        describe 'for a pending petition' do
+          before { petition.update_column(:state, Petition::PENDING_STATE) }
+          it_behaves_like 'updating a petition in the correct state'
+        end
+
+        describe 'for a validated petition' do
+          before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+          it_behaves_like 'updating a petition in the correct state'
+        end
       end
     end
   end

--- a/spec/controllers/admin/petition_details_controller_spec.rb
+++ b/spec/controllers/admin/petition_details_controller_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PetitionDetailsController do
+
+  let(:petition) { FactoryGirl.create(:sponsored_petition) }
+
+  describe 'not logged in' do
+    describe 'GET #show' do
+      it 'redirects to the login page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to('https://petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe 'GET #show' do
+      it 'redirects to edit profile page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe 'logged in as moderator user' do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET #show' do
+
+      shared_examples_for 'viewing a petition in the correct state' do
+        it 'fetches the requested petition' do
+          get :show, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'responds successfully and renders the petition_details/show template' do
+          get :show, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petition_details/show')
+        end
+      end
+
+      describe 'for a sponsored petition' do
+        it_behaves_like 'viewing a petition in the correct state'
+      end
+
+      describe 'for a pending petition' do
+        before { petition.update_column(:state, Petition::PENDING_STATE) }
+        it_behaves_like 'viewing a petition in the correct state'
+      end
+
+      describe 'for a validated petition' do
+        before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+        it_behaves_like 'viewing a petition in the correct state'
+      end
+
+      shared_examples_for 'trying to view a petition in the wrong state' do
+        it 'raises a 404 error' do
+          expect {
+            get :show, petition_id: petition.id
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      describe 'for an open petition' do
+        before { petition.update_column(:state, Petition::OPEN_STATE) }
+        it_behaves_like 'trying to view a petition in the wrong state'
+      end
+
+      describe 'for a rejected petition' do
+        before { petition.update_column(:state, Petition::REJECTED_STATE) }
+        it_behaves_like 'trying to view a petition in the wrong state'
+      end
+
+      describe 'for a hidden petition' do
+        before { petition.update_column(:state, Petition::HIDDEN_STATE) }
+        it_behaves_like 'trying to view a petition in the wrong state'
+      end
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -519,6 +519,20 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe "#in_todo_list?" do
+    it "is in todo list when the state is sponsored" do
+      expect(FactoryGirl.build(:petition, :state => Petition::SPONSORED_STATE).in_todo_list?).to be_truthy
+    end
+
+    it "is in todo list when the state is validated" do
+      expect(FactoryGirl.build(:petition, :state => Petition::VALIDATED_STATE).in_todo_list?).to be_truthy
+    end
+
+    it "is in todo list when the state is pending" do
+      expect(FactoryGirl.build(:petition, :state => Petition::PENDING_STATE).in_todo_list?).to be_truthy
+    end
+  end
+
   describe "rejection_reason" do
     it "gives rejection reason from the locale file" do
       petition = FactoryGirl.build(:rejected_petition, :rejection_code => 'duplicate')


### PR DESCRIPTION
- Style is not implemented, but a template follows the markup we're gonna use while adding new style to the admin.
- After updating petition moderator is redirected to back to the petition page (not the index page)

PT: https://www.pivotaltracker.com/n/projects/307301/stories/96865488