### PR TITLE
Send emails to signatories about debate outcomes

### DIFF
--- a/app/controllers/admin/debate_outcomes_controller.rb
+++ b/app/controllers/admin/debate_outcomes_controller.rb
@@ -9,6 +9,7 @@ class Admin::DebateOutcomesController < Admin::AdminController
   def update
     fetch_debate_outcome
     if @debate_outcome.update_attributes(params_for_update)
+      EmailDebateOutcomesJob.run_later_tonight(@petition)
       redirect_to [:admin, @petition]
     else
       render :show

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -46,9 +46,7 @@ class Admin::PetitionsController < Admin::AdminController
       # if email signees has been selected then set up a delayed job to email out to all signees who opted in
       if @petition.email_signees
         # run the job at some random point beween midnight and 4 am
-        requested_at = Time.current
-        @petition.update_attribute(:email_requested_at, requested_at)
-        EmailThresholdResponseJob.set(wait_until: 1.day.from_now.at_midnight + rand(240).minutes + rand(60).seconds).perform_later(@petition, requested_at.getutc.iso8601, PetitionMailer.to_s)
+        EmailThresholdResponseJob.run_later_tonight(@petition)
       end
 
       redirect_to admin_petitions_url

--- a/app/jobs/email_debate_outcomes_job.rb
+++ b/app/jobs/email_debate_outcomes_job.rb
@@ -1,19 +1,12 @@
-class EmailDebateOutcomesJob < ActiveJob::Base
+class EmailDebateOutcomesJob < EmailPetitionSignatories::Job
   def self.run_later_tonight(petition)
     petition.set_email_requested_at_for('debate_outcome', to: Time.current)
-    EmailPetitionSignatories.run_later_tonight(self, petition, petition.get_email_requested_at_for('debate_outcome'))
+    super(petition, petition.get_email_requested_at_for('debate_outcome'))
   end
-
-  queue_as :default
 
   def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
-    @petition = petition
     @mailer = mailer.constantize
-    worker(requested_at_string, threshold_logger).do_work!
-  end
-
-  def worker(requested_at_string, threshold_logger)
-    EmailPetitionSignatories::Worker.new(self, @petition, requested_at_string, threshold_logger)
+    worker(petition, requested_at_string, threshold_logger).do_work!
   end
 
   def timestamp_name

--- a/app/jobs/email_debate_outcomes_job.rb
+++ b/app/jobs/email_debate_outcomes_job.rb
@@ -4,9 +4,9 @@ class EmailDebateOutcomesJob < EmailPetitionSignatories::Job
     super(petition, petition.get_email_requested_at_for('debate_outcome'))
   end
 
-  def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
+  def perform(petition, requested_at_string, mailer = PetitionMailer.name, logger = nil)
     @mailer = mailer.constantize
-    worker(petition, requested_at_string, threshold_logger).do_work!
+    worker(petition, requested_at_string, logger).do_work!
   end
 
   def timestamp_name

--- a/app/jobs/email_debate_outcomes_job.rb
+++ b/app/jobs/email_debate_outcomes_job.rb
@@ -1,0 +1,26 @@
+class EmailDebateOutcomesJob < ActiveJob::Base
+  def self.run_later_tonight(petition)
+    petition.set_email_requested_at_for('debate_outcome', to: Time.current)
+    EmailPetitionSignatories.run_later_tonight(self, petition, petition.get_email_requested_at_for('debate_outcome'))
+  end
+
+  queue_as :default
+
+  def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
+    @petition = petition
+    @mailer = mailer.constantize
+    worker(requested_at_string, threshold_logger).do_work!
+  end
+
+  def worker(requested_at_string, threshold_logger)
+    EmailPetitionSignatories::Worker.new(self, @petition, requested_at_string, threshold_logger)
+  end
+
+  def timestamp_name
+    'debate_outcome'
+  end
+
+  def create_email(petition, signature)
+    @mailer.notify_signer_of_debate_outcome(petition, signature)
+  end
+end

--- a/app/jobs/email_petition_signatories.rb
+++ b/app/jobs/email_petition_signatories.rb
@@ -14,17 +14,17 @@ class EmailPetitionSignatories
     end
     private_class_method :later_tonight
 
-    def worker(petition, requested_at_string, threshold_logger)
-      Worker.new(self, petition, requested_at_string, threshold_logger)
+    def worker(petition, requested_at_string, logger)
+      Worker.new(self, petition, requested_at_string, logger)
     end
   end
 
   class Worker
-    def initialize(job, petition, requested_at_string, threshold_logger = nil)
+    def initialize(job, petition, requested_at_string, logger = nil)
       @job = job
       @petition = petition
       @requested_at = requested_at_string.in_time_zone
-      @logger = threshold_logger || construct_threshold_logger
+      @logger = logger || construct_logger
     end
 
     def do_work!
@@ -84,7 +84,7 @@ class EmailPetitionSignatories
       raise PleaseRetry
     end
 
-    def construct_threshold_logger
+    def construct_logger
       logfilename = "#{job.class.name}_for_petition_id_#{petition.id}.log"
       AuditLogger.new(Rails.root.join('log', logfilename), "Email #{job.class.name} error")
     end

--- a/app/jobs/email_petition_signatories.rb
+++ b/app/jobs/email_petition_signatories.rb
@@ -46,7 +46,7 @@ class EmailPetitionSignatories
 
     def send_email_to(signature)
       create_email(petition, signature).deliver_now
-      signature.set_email_sent_timestamp(timestamp_name, petition_timestamp)
+      signature.set_email_sent_at_for(timestamp_name, to: petition_timestamp)
     end
 
     # admins can ask to send the email multiple times and each time they

--- a/app/jobs/email_petition_signatories.rb
+++ b/app/jobs/email_petition_signatories.rb
@@ -1,0 +1,85 @@
+class EmailPetitionSignatories
+  class PleaseRetry < StandardError; end
+
+  def self.run_later_tonight(job_class, petition, requested_at, *extra_args)
+    job_class.
+      set(wait_until: later_tonight).
+      perform_later(petition, requested_at.getutc.iso8601, *extra_args)
+  end
+
+  def self.later_tonight
+    1.day.from_now.at_midnight + rand(240).minutes + rand(60).seconds
+  end
+  private_class_method :later_tonight
+
+  class Worker
+    def initialize(job, petition, requested_at_string, threshold_logger = nil)
+      @job = job
+      @petition = petition
+      @requested_at = requested_at_string.in_time_zone
+      @logger = threshold_logger || construct_threshold_logger
+    end
+
+    def do_work!
+      return unless newest_request?
+
+      logger.info("Starting job for petition '#{petition.action}' with email requested at: #{petition_timestamp}")
+      email_signees
+      logger.info("Finished job for petition '#{petition.action}'")
+
+      assert_all_signees_notified
+    end
+
+    private
+
+    attr_reader :job, :petition, :requested_at, :logger
+
+    delegate :timestamp_name, :create_email, to: :job
+
+    def petition_timestamp
+      petition.get_email_requested_timestamp(timestamp_name)
+    end
+
+    def signatures_to_email
+      petition.signatures_to_email(timestamp_name)
+    end
+
+    def send_email_to(signature)
+      create_email(petition, signature).deliver_now
+      signature.set_email_sent_timestamp(timestamp_name, petition_timestamp)
+    end
+
+    # admins can ask to send the email multiple times and each time they
+    # ask we enqueues a new job to send out emails with a new timestamp
+    # we want to execute only the latest job enqueued
+    def newest_request?
+      # NOTE: to_i comparison is used to cater for precision differences
+      # between DB timestamp (petition_timestamp precise to fractional
+      # seconds) and job timestamp (requested_at - only seconds precise)
+      petition_timestamp.to_i == requested_at.to_i
+    end
+
+    def email_signees
+      signatures_to_email.find_each do |signature|
+        begin
+          send_email_to(signature)
+        rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Net::SMTPError => e
+          # try this one again later
+          logger.info("#{e.class.name} while sending email for #{job.class.name} to: #{signature.email}")
+        end
+      end
+    end
+
+    def assert_all_signees_notified
+      return if signatures_to_email.count == 0
+
+      logger.info("Raising error to force a retry of email send of '#{petition.action}'")
+      raise PleaseRetry
+    end
+
+    def construct_threshold_logger
+      logfilename = "#{job.class.name}_for_petition_id_#{petition.id}.log"
+      AuditLogger.new(Rails.root.join('log', logfilename), "Email #{job.class.name} error")
+    end
+  end
+end

--- a/app/jobs/email_petition_signatories.rb
+++ b/app/jobs/email_petition_signatories.rb
@@ -41,7 +41,7 @@ class EmailPetitionSignatories
     end
 
     def signatures_to_email
-      petition.signatures_to_email(timestamp_name)
+      petition.signatures_to_email_for(timestamp_name)
     end
 
     def send_email_to(signature)

--- a/app/jobs/email_petition_signatories.rb
+++ b/app/jobs/email_petition_signatories.rb
@@ -37,7 +37,7 @@ class EmailPetitionSignatories
     delegate :timestamp_name, :create_email, to: :job
 
     def petition_timestamp
-      petition.get_email_requested_timestamp(timestamp_name)
+      petition.get_email_requested_at_for(timestamp_name)
     end
 
     def signatures_to_email

--- a/app/jobs/email_threshold_response_job.rb
+++ b/app/jobs/email_threshold_response_job.rb
@@ -4,9 +4,9 @@ class EmailThresholdResponseJob < EmailPetitionSignatories::Job
     super(petition, petition.get_email_requested_at_for('government_response'))
   end
 
-  def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
+  def perform(petition, requested_at_string, mailer = PetitionMailer.name, logger = nil)
     @mailer = mailer.constantize
-    worker(petition, requested_at_string, threshold_logger).do_work!
+    worker(petition, requested_at_string, logger).do_work!
   end
 
   def timestamp_name

--- a/app/jobs/email_threshold_response_job.rb
+++ b/app/jobs/email_threshold_response_job.rb
@@ -1,57 +1,26 @@
-class PleaseRetryEmailJob < StandardError
-end
-
 class EmailThresholdResponseJob < ActiveJob::Base
+  def self.run_later_tonight(petition)
+    petition.set_email_requested_timestamp('email_requested_at', Time.current)
+    EmailPetitionSignatories.run_later_tonight(self, petition, petition.get_email_requested_timestamp('email_requested_at'))
+  end
+
   queue_as :default
 
-  def setup_job(petition, email_requested_at, mailer, threshold_logger)
+  def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
     @petition = petition
-    @email_requested_at = email_requested_at.in_time_zone
     @mailer = mailer.constantize
-    @logger = threshold_logger || construct_threshold_logger
+    worker(requested_at_string, threshold_logger).do_work!
   end
 
-  def perform(petition, email_requested_at, mailer, threshold_logger = nil)
-    setup_job(petition, email_requested_at, mailer, threshold_logger)
-    return unless newest_threshold_email_request?
-
-    @logger.info("Starting job for petition '#{petition.action}' with email requested at : #{petition.email_requested_at}")
-    email_signees
-    @logger.info("Finished job for petition '#{@petition.action}'")
-
-    assert_all_signees_notified
+  def worker(requested_at_string, threshold_logger)
+    EmailPetitionSignatories::Worker.new(self, @petition, requested_at_string, threshold_logger)
   end
 
-  private
-
-  # admins can modify threshold response message multiple times
-  # each of those modifications enqueues a new job to send out emails
-  # we want to execute only the latest job enqueued
-  def newest_threshold_email_request?
-    @petition.email_requested_at.to_i == @email_requested_at.to_i
+  def timestamp_name
+    'email_requested_at'
   end
 
-  def email_signees
-    @petition.need_emailing.find_each do |signature|
-      begin
-        @mailer.notify_signer_of_threshold_response(@petition, signature).deliver_now
-        signature.update_attribute(:last_emailed_at, @petition.email_requested_at)
-      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Net::SMTPError => e
-        # try this one again later
-        @logger.info("#{e.class.name} while sending to: #{signature.email}")
-      end
-    end
-  end
-
-  def assert_all_signees_notified
-    return if @petition.need_emailing.count == 0
-
-    @logger.info("Raising error to force a retry of email send of '#{@petition.action}'")
-    raise PleaseRetryEmailJob
-  end
-
-  def construct_threshold_logger
-    logfilename = "threshold_response_for_petition_id_#{@petition_id}.log"
-    AuditLogger.new(Rails.root.join('log', logfilename), 'Email threshold response error')
+  def create_email(petition, signature)
+    @mailer.notify_signer_of_threshold_response(petition, signature)
   end
 end

--- a/app/jobs/email_threshold_response_job.rb
+++ b/app/jobs/email_threshold_response_job.rb
@@ -1,19 +1,12 @@
-class EmailThresholdResponseJob < ActiveJob::Base
+class EmailThresholdResponseJob < EmailPetitionSignatories::Job
   def self.run_later_tonight(petition)
     petition.set_email_requested_at_for('government_response', to: Time.current)
-    EmailPetitionSignatories.run_later_tonight(self, petition, petition.get_email_requested_at_for('government_response'))
+    super(petition, petition.get_email_requested_at_for('government_response'))
   end
-
-  queue_as :default
 
   def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
-    @petition = petition
     @mailer = mailer.constantize
-    worker(requested_at_string, threshold_logger).do_work!
-  end
-
-  def worker(requested_at_string, threshold_logger)
-    EmailPetitionSignatories::Worker.new(self, @petition, requested_at_string, threshold_logger)
+    worker(petition, requested_at_string, threshold_logger).do_work!
   end
 
   def timestamp_name

--- a/app/jobs/email_threshold_response_job.rb
+++ b/app/jobs/email_threshold_response_job.rb
@@ -1,7 +1,7 @@
 class EmailThresholdResponseJob < ActiveJob::Base
   def self.run_later_tonight(petition)
-    petition.set_email_requested_timestamp('email_requested_at', Time.current)
-    EmailPetitionSignatories.run_later_tonight(self, petition, petition.get_email_requested_timestamp('email_requested_at'))
+    petition.set_email_requested_at_for('government_response', to: Time.current)
+    EmailPetitionSignatories.run_later_tonight(self, petition, petition.get_email_requested_at_for('government_response'))
   end
 
   queue_as :default
@@ -17,7 +17,7 @@ class EmailThresholdResponseJob < ActiveJob::Base
   end
 
   def timestamp_name
-    'email_requested_at'
+    'government_response'
   end
 
   def create_email(petition, signature)

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -63,6 +63,15 @@ class PetitionMailer < ApplicationMailer
     mail to: @creator.email, subject: subject_for(:gather_sponsors_for_petition)
   end
 
+  def notify_signer_of_debate_outcome(petition, signature)
+    @petition = petition
+    @signature = signature
+    mail(
+      subject: subject_for(:notify_signer_of_debate_outcome),
+      to: @signature.email
+    )
+  end
+
   private
 
   def subject_for(key, options = {})

--- a/app/models/email_requested_receipt.rb
+++ b/app/models/email_requested_receipt.rb
@@ -1,0 +1,6 @@
+class EmailRequestedReceipt < ActiveRecord::Base
+  belongs_to :petition, touch: true
+
+  validates :petition, presence: true
+  validates :petition_id, uniqueness: true
+end

--- a/app/models/email_requested_receipt.rb
+++ b/app/models/email_requested_receipt.rb
@@ -3,4 +3,23 @@ class EmailRequestedReceipt < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :petition_id, uniqueness: true
+
+  def get(name)
+    raise ArgumentError unless valid_timestamp?(name)
+    self[name]
+  end
+
+  def set(name, time)
+    raise ArgumentError unless valid_timestamp?(name)
+    update_column(name, time)
+  end
+
+  private
+  def valid_timestamp?(name)
+    possible_timestamps.include? name
+  end
+
+  def possible_timestamps
+    @_possiblities ||= attributes.keys - ['id', 'petition_id', 'created_at', 'updated_at']
+  end
 end

--- a/app/models/email_sent_receipt.rb
+++ b/app/models/email_sent_receipt.rb
@@ -1,0 +1,25 @@
+class EmailSentReceipt < ActiveRecord::Base
+  belongs_to :signature, touch: true
+
+  validates :signature, presence: true
+  validates :signature_id, uniqueness: true
+
+  def get(name)
+    raise ArgumentError unless valid_timestamp?(name)
+    self[name]
+  end
+
+  def set(name, time)
+    raise ArgumentError unless valid_timestamp?(name)
+    update_column(name, time)
+  end
+
+  private
+  def valid_timestamp?(name)
+    possible_timestamps.include? name
+  end
+
+  def possible_timestamps
+    @_possiblities ||= attributes.keys - ['id', 'signature_id', 'created_at', 'updated_at']
+  end
+end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -299,11 +299,11 @@ class Petition < ActiveRecord::Base
     self.class.unscoped.where(id: id).update_all(updates)
   end
 
-  def get_email_requested_timestamp(_)
-    email_requested_at
+  def get_email_requested_at_for(name)
+    email_requested_receipt!.get(name)
   end
-  def set_email_requested_timestamp(_, timestamp)
-    self.update_column(:email_requested_at, timestamp)
+  def set_email_requested_at_for(name, to: Time.current)
+    email_requested_receipt!.set(name, to)
   end
 
   def signatures_to_email(_)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -298,4 +298,15 @@ class Petition < ActiveRecord::Base
   def update_all(updates)
     self.class.unscoped.where(id: id).update_all(updates)
   end
+
+  def get_email_requested_timestamp(_)
+    email_requested_at
+  end
+  def set_email_requested_timestamp(_, timestamp)
+    self.update_column(:email_requested_at, timestamp)
+  end
+
+  def signatures_to_email(_)
+    need_emailing
+  end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -173,10 +173,6 @@ class Petition < ActiveRecord::Base
     signatures.validated.count
   end
 
-  def need_emailing
-    signatures.need_emailing(email_requested_at)
-  end
-
   def awaiting_moderation?
     state == VALIDATED_STATE
   end
@@ -306,8 +302,10 @@ class Petition < ActiveRecord::Base
     email_requested_receipt!.set(name, to)
   end
 
-  def signatures_to_email(_)
-    need_emailing
+  def signatures_to_email_for(name)
+    timestamp = get_email_requested_at_for(name)
+    raise ArgumentError if timestamp.nil?
+    signatures.need_emailing_for(name, since: timestamp)
   end
 
   has_one :email_requested_receipt, dependent: :destroy

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -309,4 +309,9 @@ class Petition < ActiveRecord::Base
   def signatures_to_email(_)
     need_emailing
   end
+
+  has_one :email_requested_receipt, dependent: :destroy
+  def email_requested_receipt!
+    email_requested_receipt || create_email_requested_receipt
+  end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -102,10 +102,15 @@ class Signature < ActiveRecord::Base
     save if constituency_id_changed?
   end
 
-  def set_email_sent_timestamp(_, timestamp)
-    self.update_column(:last_emailed_at, timestamp)
+  def get_email_sent_at_for(name)
+    email_sent_receipt!.get(name)
   end
-  def get_email_sent_timestamp(_)
-    last_emailed_at
+  def set_email_sent_at_for(name, to: Time.current)
+    email_sent_receipt!.set(name, to)
+  end
+
+  has_one :email_sent_receipt, dependent: :destroy
+  def email_sent_receipt!
+    email_sent_receipt || create_email_sent_receipt
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -101,5 +101,11 @@ class Signature < ActiveRecord::Base
     set_constituency_id
     save if constituency_id_changed?
   end
-end
 
+  def set_email_sent_timestamp(_, timestamp)
+    self.update_column(:last_emailed_at, timestamp)
+  end
+  def get_email_sent_timestamp(_)
+    last_emailed_at
+  end
+end

--- a/app/views/admin/debate_outcomes/show.html.erb
+++ b/app/views/admin/debate_outcomes/show.html.erb
@@ -29,6 +29,6 @@
   <% end %>
 
   <%= form_row do %>
-    <%= f.submit 'Publish', data: { confirm: "Are you sure you want to publish these debate outcome details?" } %>
+    <%= f.submit 'Publish & Send Email', data: { confirm: "Are you sure you want to publish these debate outcome details and email all of the supporters?" } %>
   <% end %>
 <% end -%>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -1,0 +1,11 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The petition '<%= @petition.action %>' you've supported has been debated by parliament. Please read the outcome of the debate:</p>
+
+<p><%= link_to nil, petition_url(@signature.petition) %></p>
+
+<p>Thanks,</p>
+
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to nil, home_url %></p>
+
+<p>Don't want to receive any more emails regarding this petition? Unsubscribe by clicking <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @signature.name %>,
+
+The petition '<%= @petition.action %>' you've supported has been debated by parliament. Please read the outcome of the debate:
+
+<%= petition_url(@signature.petition) %>
+
+Thanks,
+
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>
+
+Don't want to receive any more emails regarding this petition? Unsubscribe by clicking <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -43,6 +43,8 @@ en-GB:
           HM Government & Parliament Petitions: change to your petition closing date
         gather_sponsors_for_petition: |-
           Parliament petitions - It's time to get sponsors to support your petition
+        notify_signer_of_debate_outcome: |-
+          Parliament petitions - The petition '%{action}' has been debated
       signoff_prefix: "HM Government & Parliament Petitions"
 
     waiting_for_response_in_words:

--- a/db/migrate/20150617114935_create_email_requested_receipts.rb
+++ b/db/migrate/20150617114935_create_email_requested_receipts.rb
@@ -1,0 +1,32 @@
+class CreateEmailRequestedReceipts < ActiveRecord::Migration
+  def change
+    create_table :email_requested_receipts do |t|
+      t.references :petition, index: true, foreign_key: true
+      t.datetime :government_response
+      t.datetime :debate_outcome
+
+      t.timestamps null: false
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL.strip_heredoc
+          INSERT INTO email_requested_receipts
+          SELECT nextval('email_requested_receipts_id_seq'), petitions.id, petitions.email_requested_at, NULL, current_timestamp, current_timestamp
+          FROM petitions
+          WHERE petitions.email_requested_at IS NOT NULL
+        SQL
+      end
+      dir.down do
+        execute <<-SQL.strip_heredoc
+          UPDATE petitions
+          SET email_requested_at = email_requested_receipts.government_response
+          FROM email_requested_receipts
+          WHERE petitions.id = email_requested_receipts.petition_id
+        SQL
+      end
+    end
+
+    remove_column :petitions, :email_requested_at, :datetime
+  end
+end

--- a/db/migrate/20150617135014_create_email_sent_receipts.rb
+++ b/db/migrate/20150617135014_create_email_sent_receipts.rb
@@ -1,0 +1,32 @@
+class CreateEmailSentReceipts < ActiveRecord::Migration
+  def change
+    create_table :email_sent_receipts do |t|
+      t.references :signature, index: true, foreign_key: true
+      t.datetime :government_response
+      t.datetime :debate_outcome
+
+      t.timestamps null: false
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL.strip_heredoc
+          INSERT INTO email_sent_receipts
+          SELECT nextval('email_sent_receipts_id_seq'), signatures.id, signatures.last_emailed_at, NULL, current_timestamp, current_timestamp
+          FROM signatures
+          WHERE signatures.last_emailed_at IS NOT NULL
+        SQL
+      end
+      dir.down do
+        execute <<-SQL.strip_heredoc
+          UPDATE signatures
+          SET last_emailed_at = email_sent_receipts.government_response
+          FROM email_sent_receipts
+          WHERE signatures.id = email_sent_receipts.signature_id
+        SQL
+      end
+    end
+
+    remove_column :signatures, :last_emailed_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -253,6 +253,39 @@ ALTER SEQUENCE email_requested_receipts_id_seq OWNED BY email_requested_receipts
 
 
 --
+-- Name: email_sent_receipts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE email_sent_receipts (
+    id integer NOT NULL,
+    signature_id integer,
+    government_response timestamp without time zone,
+    debate_outcome timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: email_sent_receipts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE email_sent_receipts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_sent_receipts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE email_sent_receipts_id_seq OWNED BY email_sent_receipts.id;
+
+
+--
 -- Name: petitions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -327,7 +360,6 @@ CREATE TABLE signatures (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     notify_by_email boolean DEFAULT true,
-    last_emailed_at timestamp without time zone,
     email character varying(255),
     unsubscribe_token character varying,
     constituency_id character varying,
@@ -477,6 +509,13 @@ ALTER TABLE ONLY email_requested_receipts ALTER COLUMN id SET DEFAULT nextval('e
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY email_sent_receipts ALTER COLUMN id SET DEFAULT nextval('email_sent_receipts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY petitions ALTER COLUMN id SET DEFAULT nextval('petitions_id_seq'::regclass);
 
 
@@ -547,6 +586,14 @@ ALTER TABLE ONLY delayed_jobs
 
 ALTER TABLE ONLY email_requested_receipts
     ADD CONSTRAINT email_requested_receipts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: email_sent_receipts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY email_sent_receipts
+    ADD CONSTRAINT email_sent_receipts_pkey PRIMARY KEY (id);
 
 
 --
@@ -656,6 +703,13 @@ CREATE INDEX index_delayed_jobs_on_priority_and_run_at ON delayed_jobs USING btr
 --
 
 CREATE INDEX index_email_requested_receipts_on_petition_id ON email_requested_receipts USING btree (petition_id);
+
+
+--
+-- Name: index_email_sent_receipts_on_signature_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_email_sent_receipts_on_signature_id ON email_sent_receipts USING btree (signature_id);
 
 
 --
@@ -786,6 +840,14 @@ ALTER TABLE ONLY email_requested_receipts
 
 
 --
+-- Name: fk_rails_e256832d5d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY email_sent_receipts
+    ADD CONSTRAINT fk_rails_e256832d5d FOREIGN KEY (signature_id) REFERENCES signatures(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -816,6 +878,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150615145953');
 INSERT INTO schema_migrations (version) VALUES ('20150615151103');
 
 INSERT INTO schema_migrations (version) VALUES ('20150617114935');
+
+INSERT INTO schema_migrations (version) VALUES ('20150617135014');
 
 INSERT INTO schema_migrations (version) VALUES ('20150617164310');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -220,6 +220,39 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
+-- Name: email_requested_receipts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE email_requested_receipts (
+    id integer NOT NULL,
+    petition_id integer,
+    government_response timestamp without time zone,
+    debate_outcome timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: email_requested_receipts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE email_requested_receipts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: email_requested_receipts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE email_requested_receipts_id_seq OWNED BY email_requested_receipts.id;
+
+
+--
 -- Name: petitions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -240,7 +273,6 @@ CREATE TABLE petitions (
     internal_response text,
     rejection_code character varying(50),
     notified_by_email boolean DEFAULT false,
-    email_requested_at timestamp without time zone,
     background character varying(200),
     sponsor_token character varying(255),
     response_summary character varying(500),
@@ -438,6 +470,13 @@ ALTER TABLE ONLY delayed_jobs ALTER COLUMN id SET DEFAULT nextval('delayed_jobs_
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY email_requested_receipts ALTER COLUMN id SET DEFAULT nextval('email_requested_receipts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY petitions ALTER COLUMN id SET DEFAULT nextval('petitions_id_seq'::regclass);
 
 
@@ -500,6 +539,14 @@ ALTER TABLE ONLY debate_outcomes
 
 ALTER TABLE ONLY delayed_jobs
     ADD CONSTRAINT delayed_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: email_requested_receipts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY email_requested_receipts
+    ADD CONSTRAINT email_requested_receipts_pkey PRIMARY KEY (id);
 
 
 --
@@ -602,6 +649,13 @@ CREATE INDEX index_debate_outcomes_on_petition_id_and_debated_on ON debate_outco
 --
 
 CREATE INDEX index_delayed_jobs_on_priority_and_run_at ON delayed_jobs USING btree (priority, run_at);
+
+
+--
+-- Name: index_email_requested_receipts_on_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_email_requested_receipts_on_petition_id ON email_requested_receipts USING btree (petition_id);
 
 
 --
@@ -724,6 +778,14 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 
 
 --
+-- Name: fk_rails_898597541e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY email_requested_receipts
+    ADD CONSTRAINT fk_rails_898597541e FOREIGN KEY (petition_id) REFERENCES petitions(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -752,6 +814,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150615131623');
 INSERT INTO schema_migrations (version) VALUES ('20150615145953');
 
 INSERT INTO schema_migrations (version) VALUES ('20150615151103');
+
+INSERT INTO schema_migrations (version) VALUES ('20150617114935');
 
 INSERT INTO schema_migrations (version) VALUES ('20150617164310');
 

--- a/features/admin/providing_debate_outcome_information.feature
+++ b/features/admin/providing_debate_outcome_information.feature
@@ -4,16 +4,18 @@ Feature: Providing debate outcome information
   I want to store information about debates on the petition
 
   Scenario: Adding debate outcome infromation
-    Given an open petition "Ban Badger Baiting"
+    Given an open petition "Ban Badger Baiting" with some signatures
     And I am logged in as a sysadmin
     When I am on the admin all petitions page
     And I follow "Ban Badger Baiting"
     And I follow "Debate outcomes"
     Then I should be on the admin debate outcomes form page for "Ban Badger Baiting"
     And the markup should be valid
-    When I press "Publish"
+    When I press "Publish & Send Email"
     Then the petition should not have debate details
     And I should see an error
     When I fill in the debate outcome details
-    And press "Publish"
+    And press "Publish & Send Email"
     Then the petition should have the debate details I provided
+    And the petition creator should have been emailed about the debate
+    And all the signatories of the petition should have been emailed about the debate

--- a/features/admin/threshold.feature
+++ b/features/admin/threshold.feature
@@ -56,7 +56,7 @@ Feature: Threshold list
     And I press "Save"
     Then I should be on the admin all petitions page
     And a petition should exist with action: "Petition 1", internal_response: "Parliament here it comes", response_required: true
-    But the petition with action: "Petition 1" should not have requested an email
+    But the petition with action: "Petition 1" should not have requested a government response email
     And the petition signatories of "Petition 1" should not receive a response notification email
 
   Scenario: A moderator user updates the public response to a petition
@@ -68,7 +68,7 @@ Feature: Threshold list
     And I check "Email signees"
     And I press "Save"
     Then I should be on the admin all petitions page
-    And the petition with action: "Petition 1" should have requested an email after "2010-12-03 01:00:00"
+    And the petition with action: "Petition 1" should have requested a government response email after "2010-12-03 01:00:00"
     And the response summary to "Petition 1" should be publicly viewable on the petition page
     And the response to "Petition 1" should be publicly viewable on the petition page
     And the petition signatories of "Petition 1" should receive a response notification email
@@ -80,5 +80,5 @@ Feature: Threshold list
     And I check "Email signees"
     And I press "Save"
     Then I should see "must be completed when email signees is checked"
-    And the petition with action: "Petition 1" should not have requested an email
+    And the petition with action: "Petition 1" should not have requested a government response email
     And the petition signatories of "Petition 1" should not receive a response notification email

--- a/features/admin/threshold.feature
+++ b/features/admin/threshold.feature
@@ -56,6 +56,8 @@ Feature: Threshold list
     And I press "Save"
     Then I should be on the admin all petitions page
     And a petition should exist with action: "Petition 1", internal_response: "Parliament here it comes", response_required: true
+    But the petition with action: "Petition 1" should not have requested an email
+    And the petition signatories of "Petition 1" should not receive a response notification email
 
   Scenario: A moderator user updates the public response to a petition
     Given the time is "3 Dec 2010 01:00"
@@ -69,6 +71,7 @@ Feature: Threshold list
     And the petition with action: "Petition 1" should have requested an email after "2010-12-03 01:00:00"
     And the response summary to "Petition 1" should be publicly viewable on the petition page
     And the response to "Petition 1" should be publicly viewable on the petition page
+    And the petition signatories of "Petition 1" should receive a response notification email
 
   Scenario: A moderator user unsuccessfully tries to update the public response to a petition
     Given the time is "3 Dec 2010 01:00"
@@ -78,3 +81,4 @@ Feature: Threshold list
     And I press "Save"
     Then I should see "must be completed when email signees is checked"
     And the petition with action: "Petition 1" should not have requested an email
+    And the petition signatories of "Petition 1" should not receive a response notification email

--- a/features/step_definitions/debate_outcome_steps.rb
+++ b/features/step_definitions/debate_outcome_steps.rb
@@ -48,3 +48,27 @@ Then(/^the petition should have the debate details I provided$/) do
   expect(@petition.debate_outcome.transcript_url).to eq 'http://transcripts.parliament.example.com/1.html'
   expect(@petition.debate_outcome.video_url).to eq 'http://videos.parliament.example.com/1.mp4'
 end
+
+Then(/^the petition creator should have been emailed about the debate$/) do
+  @petition.reload
+  steps %Q(
+    Then "#{@petition.creator_signature.email}" should receive an email
+    When they open the email
+    Then they should see "The petition '#{@petition.action}' you've supported has been debated by parliament. Please read the outcome of the debate:" in the email body
+    When they click the first link in the email
+    Then I should be on the petition page for "#{@petition.action}"
+  )
+end
+
+Then(/^all the signatories of the petition should have been emailed about the debate$/) do
+  @petition.reload
+  @petition.signatures.notify_by_email.validated.where.not(id: @petition.creator_signature.id).each do |signatory|
+    steps %Q(
+      Then "#{signatory.email}" should receive an email
+      When they open the email
+      Then they should see "The petition '#{@petition.action}' you've supported has been debated by parliament. Please read the outcome of the debate:" in the email body
+      When they click the first link in the email
+      Then I should be on the petition page for "#{@petition.action}"
+    )
+  end
+end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -325,8 +325,8 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |
     closed_at: petition_closed_at,
     state: petition_state
   }
-  petition = FactoryGirl.create(:open_petition, petition_args)
-  5.times { FactoryGirl.create(:validated_signature, petition: petition) }
+  @petition = FactoryGirl.create(:open_petition, petition_args)
+  5.times { FactoryGirl.create(:validated_signature, petition: @petition) }
 end
 
 Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -229,14 +229,17 @@ When(/^I am allowed to make the petition action too long$/) do
   page.execute_script "document.getElementById('petition_action').removeAttribute('maxlength');"
 end
 
-Then(/^the petition with action: "(.*?)" should have requested an email after "(.*?)"$/) do |petition_action, timestamp|
+Then(/^the petition with action: "(.*?)" should have requested a government response email after "(.*?)"$/) do |petition_action, timestamp|
   petition = Petition.find_by!(action: petition_action)
-  expect(petition.email_requested_at).to be >= timestamp.in_time_zone
+  email_requested_at = petition.get_email_requested_at_for('government_response')
+  expect(email_requested_at).to be_present
+  expect(email_requested_at).to be >= timestamp.in_time_zone
 end
 
-Then(/^the petition with action: "(.*?)" should not have requested an email$/) do |petition_action|
+Then(/^the petition with action: "(.*?)" should not have requested a government response email$/) do |petition_action|
   petition = Petition.find_by!(action: petition_action)
-  expect(petition.email_requested_at).to be_nil
+  email_requested_at = petition.get_email_requested_at_for('government_response')
+  expect(email_requested_at).to be_nil
 end
 
 When /^I start a new petition/ do

--- a/features/step_definitions/threshold_steps.rb
+++ b/features/step_definitions/threshold_steps.rb
@@ -9,3 +9,24 @@ Then /^the response summary to "([^"]*)" should be publicly viewable on the peti
   visit petition_path(petition)
   expect(page).to have_content(petition.response_summary)
 end
+
+Then(/^the petition signatories of "([^"]*)" should not receive a response notification email$/) do |petition_action|
+  petition = Petition.find_by(action: petition_action)
+  petition.signatures.validated.each do |signatory|
+    step %{"#{signatory.email}" should receive no email}
+  end
+end
+
+Then(/^the petition signatories of "([^"]*)" should receive a response notification email$/) do |petition_action|
+  petition = Petition.find_by(action: petition_action)
+  petition.signatures.notify_by_email.validated.each do |signatory|
+    steps %{
+      Then "#{signatory.email}" should receive an email
+      When they open the email
+      Then they should see "a response has been made to it." in the email body
+      And they should see "#{petition.response}" in the email body
+      When they follow "View the response to the petition" in the email
+      Then I should be on the petition page for "#{petition.action}"
+    }
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -207,4 +207,8 @@ FactoryGirl.define do
   factory :email_requested_receipt do
     association :petition, factory: :open_petition
   end
+
+  factory :email_sent_receipt do
+    association :signature, factory: :validated_signature
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -203,4 +203,8 @@ FactoryGirl.define do
 
     end
   end
+
+  factory :email_requested_receipt do
+    association :petition, factory: :open_petition
+  end
 end

--- a/spec/jobs/email_debate_outcomes_job_spec.rb
+++ b/spec/jobs/email_debate_outcomes_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+include ActiveJob::TestHelper
+
+RSpec.describe EmailDebateOutcomesJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:open_petition) }
+  let(:signature) { FactoryGirl.create(:validated_signature, :petition => petition) }
+
+  let(:mailer) { double.as_null_object }
+  let(:logger) { double.as_null_object }
+
+  before do
+    petition.set_email_requested_at_for('debate_outcome', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :count => 0)
+  end
+
+  def perform_job(requested_at = email_requested_at)
+    described_class.perform_now(petition, requested_at.getutc.iso8601, mailer, logger)
+  end
+
+  it "sends the notify_signer_of_debate_outcome emails to each signatory of a petition" do
+    expect(mailer).to receive(:notify_signer_of_debate_outcome).with(petition, signature).and_return(mailer)
+    perform_job
+  end
+
+  it "marks the signature with the 'debate_outcome' last emailing time" do
+    expect(signature).to receive(:set_email_sent_at_for).with('debate_outcome', to: email_requested_at)
+    perform_job
+  end
+
+  it 'uses a EmailPetitionSignatories::Worker to do the work' do
+    worker = double
+    expect(worker).to receive(:do_work!)
+    expect(EmailPetitionSignatories::Worker).to receive(:new).with(instance_of(described_class), petition, email_requested_at.getutc.iso8601, anything).and_return worker
+    perform_job
+  end
+end

--- a/spec/jobs/email_petition_signatories_spec.rb
+++ b/spec/jobs/email_petition_signatories_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe EmailPetitionSignatories do
     it "marks the signature using the timestamp name and the time the job was requested " do
       do_work
       signature.reload
-      expect(signature.get_email_sent_timestamp(timestamp_name)).to eq email_requested_at
+      expect(signature.get_email_sent_at_for(timestamp_name)).to eq email_requested_at
     end
 
     context "email sending fails" do
@@ -102,14 +102,14 @@ RSpec.describe EmailPetitionSignatories do
         it "does not mark the signature" do
           suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
           signature.reload
-          expect(signature.get_email_sent_timestamp(timestamp_name)).not_to eq email_requested_at
+          expect(signature.get_email_sent_at_for(timestamp_name)).not_to eq email_requested_at
         end
 
         it 'continues to process other signatures after the one that errored' do
           other_signature = FactoryGirl.create(:validated_signature, :petition => petition)
           suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
           other_signature.reload
-          expect(other_signature.get_email_sent_timestamp(timestamp_name)).to eq email_requested_at
+          expect(other_signature.get_email_sent_at_for(timestamp_name)).to eq email_requested_at
         end
       end
 
@@ -144,14 +144,14 @@ RSpec.describe EmailPetitionSignatories do
         it "does not mark the signature" do
           suppress(ActiveRecord::RecordNotSaved) { do_work }
           signature.reload
-          expect(signature.get_email_sent_timestamp(timestamp_name)).not_to eq email_requested_at
+          expect(signature.get_email_sent_at_for(timestamp_name)).not_to eq email_requested_at
         end
 
         it 'does not process other signatures after the one that errored' do
           other_signature = FactoryGirl.create(:validated_signature, :petition => petition)
           suppress(ActiveRecord::RecordNotSaved) { do_work }
           other_signature.reload
-          expect(other_signature.get_email_sent_timestamp(timestamp_name)).not_to eq email_requested_at
+          expect(other_signature.get_email_sent_at_for(timestamp_name)).not_to eq email_requested_at
         end
       end
     end

--- a/spec/jobs/email_petition_signatories_spec.rb
+++ b/spec/jobs/email_petition_signatories_spec.rb
@@ -1,0 +1,156 @@
+require 'net/smtp'
+require 'rails_helper'
+
+RSpec.describe EmailPetitionSignatories do
+  context '.run_later_tonight' do
+    include ActiveJob::TestHelper
+
+    let(:job) { EmailThresholdResponseJob }
+    let(:petition) { FactoryGirl.create(:open_petition, :email_requested_at => Time.current) }
+    before do
+      ActiveJob::Base.queue_adapter.enqueued_jobs = []
+      ActiveJob::Base.queue_adapter.performed_jobs = []
+    end
+
+    def global_id_job_arg_for(object)
+      { "_aj_globalid" => object.to_global_id.to_s }
+    end
+    def timestamp_job_arg_for(timestamp)
+      timestamp.getutc.iso8601
+    end
+
+    it 'queues up an instance of the supplied job' do
+      EmailPetitionSignatories.run_later_tonight(job, petition, petition.email_requested_at)
+      expect(enqueued_jobs.size).to eq 1
+      expect(enqueued_jobs.first[:job]).to eq job
+    end
+
+    it 'sets the job to run between midnight and 4am tomorrow' do
+      EmailPetitionSignatories.run_later_tonight(job, petition, petition.email_requested_at)
+      queued_at = enqueued_jobs.first[:at]
+      expect(queued_at).to satisfy { |at| at >= (1.day.from_now.midnight.to_i) }
+      expect(queued_at).to satisfy { |at| at <= (1.day.from_now.midnight + 4.hours).to_i }
+    end
+
+    it 'queues up the job to run with the petition and timestamp supplied as args' do
+      EmailPetitionSignatories.run_later_tonight(job, petition, petition.email_requested_at)
+      queued_args = enqueued_jobs.first[:args]
+      expect(queued_args[0]).to eq global_id_job_arg_for(petition)
+      expect(queued_args[1]).to eq timestamp_job_arg_for(petition.email_requested_at)
+    end
+
+    it 'adds any extra params provided as job args after the petition and timestamp' do
+      EmailPetitionSignatories.run_later_tonight(job, petition, petition.email_requested_at, 'cheese', 1, petition.creator_signature)
+      queued_args = enqueued_jobs.first[:args]
+      expect(queued_args[2]).to eq 'cheese'
+      expect(queued_args[3]).to eq 1
+      expect(queued_args[4]).to eq global_id_job_arg_for(petition.creator_signature)
+    end
+  end
+
+  describe EmailPetitionSignatories::Worker do
+    let(:email_requested_at) { Time.current }
+    let!(:petition) { FactoryGirl.create(:open_petition, :email_requested_at => email_requested_at) }
+    let!(:signature) { FactoryGirl.create(:validated_signature, :petition => petition) }
+
+    let(:timestamp_name) { 'email_requested_at' }
+    let(:job) { double(timestamp_name: timestamp_name).as_null_object }
+    let(:logger) { double.as_null_object }
+    let(:email) { double.as_null_object }
+
+    def do_work(requested_at = email_requested_at)
+      requested_at = requested_at.getutc.iso8601
+      described_class.new(job, petition, requested_at, logger).do_work!
+    end
+
+    it "asks the job to send an email to each signatory of a petition" do
+      expect(job).to receive(:create_email).with(petition, signature).and_return email
+      do_work
+    end
+
+    it "doesn't run unless it's the latest request according to the jobs timestamp name" do
+      expect(job).not_to receive(:create_email)
+      requested_at = email_requested_at - 1000
+      do_work(requested_at)
+    end
+
+    it "marks the signature using the timestamp name and the time the job was requested " do
+      do_work
+      signature.reload
+      expect(signature.get_email_sent_timestamp(timestamp_name)).to eq email_requested_at
+    end
+
+    context "email sending fails" do
+      shared_examples_for 'catching errors during individual email sending' do
+        before do
+          allow(job).to receive(:create_email).and_return email
+          allow(job).to receive(:create_email).with(petition, signature).and_raise(exception_class)
+        end
+
+        it "captures the error and raises a retry error" do
+          expect { do_work }.to raise_error(EmailPetitionSignatories::PleaseRetry)
+        end
+
+        it 'logs the email sending error as information' do
+          expect(logger).to receive(:info).with(/#{Regexp.escape(exception_class.name)}/)
+          suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
+        end
+
+        it "does not mark the signature" do
+          suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
+          signature.reload
+          expect(signature.get_email_sent_timestamp(timestamp_name)).not_to eq email_requested_at
+        end
+
+        it 'continues to process other signatures after the one that errored' do
+          other_signature = FactoryGirl.create(:validated_signature, :petition => petition)
+          suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
+          other_signature.reload
+          expect(other_signature.get_email_sent_timestamp(timestamp_name)).to eq email_requested_at
+        end
+      end
+
+      context "with connection refused" do
+        let(:exception_class) { Errno::ECONNREFUSED }
+
+        it_behaves_like 'catching errors during individual email sending'
+      end
+
+      context "with an SMTPError" do
+        let(:exception_class) { Net::SMTPFatalError }
+
+        it_behaves_like 'catching errors during individual email sending'
+      end
+
+      context 'with a timeout' do
+        let(:exception_class) { Errno::ETIMEDOUT }
+
+        it_behaves_like 'catching errors during individual email sending'
+      end
+
+      context "for some other reason" do
+        before do
+          allow(job).to receive(:create_email).and_return email
+          allow(job).to receive(:create_email).with(petition, signature).and_raise(ActiveRecord::RecordNotSaved, 'uh oh!')
+        end
+
+        it "raises the error" do
+          expect { do_work }.to raise_error(ActiveRecord::RecordNotSaved)
+        end
+
+        it "does not mark the signature" do
+          suppress(ActiveRecord::RecordNotSaved) { do_work }
+          signature.reload
+          expect(signature.get_email_sent_timestamp(timestamp_name)).not_to eq email_requested_at
+        end
+
+        it 'does not process other signatures after the one that errored' do
+          other_signature = FactoryGirl.create(:validated_signature, :petition => petition)
+          suppress(ActiveRecord::RecordNotSaved) { do_work }
+          other_signature.reload
+          expect(other_signature.get_email_sent_timestamp(timestamp_name)).not_to eq email_requested_at
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/email_petition_signatories_spec.rb
+++ b/spec/jobs/email_petition_signatories_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe EmailPetitionSignatories do
     it "marks the signature using the timestamp name and the time the job was requested " do
       do_work
       signature.reload
-      expect(signature.get_email_sent_at_for(timestamp_name)).to eq email_requested_at
+      expect(signature.get_email_sent_at_for(timestamp_name)).to be_usec_precise_with email_requested_at
     end
 
     context "email sending fails" do
@@ -102,14 +102,14 @@ RSpec.describe EmailPetitionSignatories do
         it "does not mark the signature" do
           suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
           signature.reload
-          expect(signature.get_email_sent_at_for(timestamp_name)).not_to eq email_requested_at
+          expect(signature.get_email_sent_at_for(timestamp_name)).not_to be_usec_precise_with email_requested_at
         end
 
         it 'continues to process other signatures after the one that errored' do
           other_signature = FactoryGirl.create(:validated_signature, :petition => petition)
           suppress(EmailPetitionSignatories::PleaseRetry) { do_work }
           other_signature.reload
-          expect(other_signature.get_email_sent_at_for(timestamp_name)).to eq email_requested_at
+          expect(other_signature.get_email_sent_at_for(timestamp_name)).to be_usec_precise_with email_requested_at
         end
       end
 
@@ -144,14 +144,14 @@ RSpec.describe EmailPetitionSignatories do
         it "does not mark the signature" do
           suppress(ActiveRecord::RecordNotSaved) { do_work }
           signature.reload
-          expect(signature.get_email_sent_at_for(timestamp_name)).not_to eq email_requested_at
+          expect(signature.get_email_sent_at_for(timestamp_name)).not_to be_usec_precise_with email_requested_at
         end
 
         it 'does not process other signatures after the one that errored' do
           other_signature = FactoryGirl.create(:validated_signature, :petition => petition)
           suppress(ActiveRecord::RecordNotSaved) { do_work }
           other_signature.reload
-          expect(other_signature.get_email_sent_at_for(timestamp_name)).not_to eq email_requested_at
+          expect(other_signature.get_email_sent_at_for(timestamp_name)).not_to be_usec_precise_with email_requested_at
         end
       end
     end

--- a/spec/jobs/email_petition_signatories_spec.rb
+++ b/spec/jobs/email_petition_signatories_spec.rb
@@ -2,50 +2,51 @@ require 'net/smtp'
 require 'rails_helper'
 
 RSpec.describe EmailPetitionSignatories do
-  context '.run_later_tonight' do
-    include ActiveJob::TestHelper
+  describe EmailPetitionSignatories::Job do
+    context '.run_later_tonight' do
+      include ActiveJob::TestHelper
 
-    let(:job) { EmailThresholdResponseJob }
-    let(:petition) { FactoryGirl.create(:open_petition) }
-    let(:requested_at) { Time.current }
-    before do
-      ActiveJob::Base.queue_adapter.enqueued_jobs = []
-      ActiveJob::Base.queue_adapter.performed_jobs = []
-    end
+      let(:petition) { FactoryGirl.create(:open_petition) }
+      let(:requested_at) { Time.current }
+      before do
+        ActiveJob::Base.queue_adapter.enqueued_jobs = []
+        ActiveJob::Base.queue_adapter.performed_jobs = []
+      end
 
-    def global_id_job_arg_for(object)
-      { "_aj_globalid" => object.to_global_id.to_s }
-    end
-    def timestamp_job_arg_for(timestamp)
-      timestamp.getutc.iso8601
-    end
+      def global_id_job_arg_for(object)
+        { "_aj_globalid" => object.to_global_id.to_s }
+      end
+      def timestamp_job_arg_for(timestamp)
+        timestamp.getutc.iso8601
+      end
 
-    it 'queues up an instance of the supplied job' do
-      EmailPetitionSignatories.run_later_tonight(job, petition, requested_at)
-      expect(enqueued_jobs.size).to eq 1
-      expect(enqueued_jobs.first[:job]).to eq job
-    end
+      it 'queues up a job' do
+        described_class.run_later_tonight(petition, requested_at)
+        expect(enqueued_jobs.size).to eq 1
+        expect(enqueued_jobs.first[:job]).to eq described_class
+      end
 
-    it 'sets the job to run between midnight and 4am tomorrow' do
-      EmailPetitionSignatories.run_later_tonight(job, petition, requested_at)
-      queued_at = enqueued_jobs.first[:at]
-      expect(queued_at).to satisfy { |at| at >= (1.day.from_now.midnight.to_i) }
-      expect(queued_at).to satisfy { |at| at <= (1.day.from_now.midnight + 4.hours).to_i }
-    end
+      it 'sets the job to run between midnight and 4am tomorrow' do
+        described_class.run_later_tonight(petition, requested_at)
+        queued_at = enqueued_jobs.first[:at]
+        expect(queued_at).to satisfy { |at| at >= (1.day.from_now.midnight.to_i) }
+        expect(queued_at).to satisfy { |at| at <= (1.day.from_now.midnight + 4.hours).to_i }
+      end
 
-    it 'queues up the job to run with the petition and timestamp supplied as args' do
-      EmailPetitionSignatories.run_later_tonight(job, petition, requested_at)
-      queued_args = enqueued_jobs.first[:args]
-      expect(queued_args[0]).to eq global_id_job_arg_for(petition)
-      expect(queued_args[1]).to eq timestamp_job_arg_for(requested_at)
-    end
+      it 'queues up the job to run with the petition and timestamp supplied as args' do
+        described_class.run_later_tonight(petition, requested_at)
+        queued_args = enqueued_jobs.first[:args]
+        expect(queued_args[0]).to eq global_id_job_arg_for(petition)
+        expect(queued_args[1]).to eq timestamp_job_arg_for(requested_at)
+      end
 
-    it 'adds any extra params provided as job args after the petition and timestamp' do
-      EmailPetitionSignatories.run_later_tonight(job, petition, requested_at, 'cheese', 1, petition.creator_signature)
-      queued_args = enqueued_jobs.first[:args]
-      expect(queued_args[2]).to eq 'cheese'
-      expect(queued_args[3]).to eq 1
-      expect(queued_args[4]).to eq global_id_job_arg_for(petition.creator_signature)
+      it 'adds any extra params provided as job args after the petition and timestamp' do
+        described_class.run_later_tonight(petition, requested_at, 'cheese', 1, petition.creator_signature)
+        queued_args = enqueued_jobs.first[:args]
+        expect(queued_args[2]).to eq 'cheese'
+        expect(queued_args[3]).to eq 1
+        expect(queued_args[4]).to eq global_id_job_arg_for(petition.creator_signature)
+      end
     end
   end
 

--- a/spec/jobs/email_threshold_response_job_spec.rb
+++ b/spec/jobs/email_threshold_response_job_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe EmailThresholdResponseJob, type: :job do
 
   before do
     petition.set_email_requested_at_for('government_response', to: email_requested_at)
-    allow(petition).to receive_message_chain(:need_emailing, :find_each).and_yield(signature)
-    allow(petition).to receive_message_chain(:need_emailing, :count => 0)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :count => 0)
   end
 
   def perform_job(requested_at = email_requested_at)

--- a/spec/jobs/email_threshold_response_job_spec.rb
+++ b/spec/jobs/email_threshold_response_job_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe EmailThresholdResponseJob, type: :job do
     perform_job
   end
 
-  it "marks the signature with the 'email_requested_at' last emailing time" do
-    expect(signature).to receive(:set_email_sent_timestamp).with('email_requested_at', email_requested_at)
+  it "marks the signature with the 'government_response' last emailing time" do
+    expect(signature).to receive(:set_email_sent_at_for).with('government_response', to: email_requested_at)
     perform_job
   end
 

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -153,4 +153,36 @@ RSpec.describe PetitionMailer, type: :mailer do
       expect(mail.body.encoded).to match(%r[To promote organic vegetables])
     end
   end
+
+  describe 'notifying signature of debate outcome' do
+    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: 'Laura Palmer', email: 'laura@red-room.example.com') }
+    before { FactoryGirl.create(:debate_outcome, petition: petition) }
+    subject(:mail) { described_class.notify_signer_of_debate_outcome(petition, signature) }
+
+    it "has the correct subject" do
+      expect(mail.subject).to eq("Parliament petitions - The petition '#{petition.action}' has been debated")
+    end
+
+    it "addresses the signatory by name" do
+      expect(mail.body.encoded).to match(/Dear Laura Palmer\,/)
+    end
+
+    it "sends it only to the signatory" do
+      expect(mail.to).to eq(%w[laura@red-room.example.com])
+      expect(mail.cc).to be_blank
+      expect(mail.bcc).to be_blank
+    end
+
+    it "includes a link to the petition page" do
+      expect(mail.body.encoded).to match(%r[https://www.example.com/petitions/#{petition.id}])
+    end
+
+    it "includes the petition action" do
+      expect(mail.body.encoded).to match(%r[Allow organic vegetable vans to use red diesel])
+    end
+
+    it 'includes an unsubscribe link' do
+      expect(mail.body.encoded).to match(%r[https://www.example.com/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+    end
+  end
 end

--- a/spec/models/email_requested_receipt_spec.rb
+++ b/spec/models/email_requested_receipt_spec.rb
@@ -15,4 +15,59 @@ RSpec.describe EmailRequestedReceipt, type: :model do
     it { is_expected.to validate_presence_of(:petition) }
     it { is_expected.to validate_uniqueness_of(:petition_id) }
   end
+
+  describe '#get' do
+    let(:receipt) { FactoryGirl.build(:email_requested_receipt) }
+    let(:the_stored_time) { 6.days.ago }
+
+    it 'returns nil when nothing has been stamped for the supplied name' do
+      expect(receipt.get('government_response')).to be_nil
+    end
+
+    it 'returns the stored timestamp for the supplied name' do
+      receipt.government_response = the_stored_time
+      expect(receipt.get('government_response')).to eq the_stored_time
+    end
+
+    it 'raises an error if the supplied name is not a valid timestamp' do
+      expect {
+        receipt.get('aint_no_such_timestamp')
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error if we try to access the rails created_at/updated_at stamps this way' do
+      expect {
+        receipt.get('created_at')
+      }.to raise_error(ArgumentError)
+      expect {
+        receipt.get('updated_at')
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#set' do
+    let(:receipt) { FactoryGirl.create(:email_requested_receipt) }
+    let(:the_stored_time) { 6.days.ago }
+
+    it 'saves the stored timestamp for the supplied name in the db to the supplied time' do
+      receipt.set('government_response', the_stored_time)
+      receipt.reload
+      expect(receipt.government_response).to eq the_stored_time
+    end
+
+    it 'raises an error if the supplied name is not a valid timestamp' do
+      expect {
+        receipt.set('aint_no_such_timestamp', the_stored_time)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error if we try to set the rails created_at/updated_at stamps this way' do
+      expect {
+        receipt.set('created_at', the_stored_time)
+      }.to raise_error(ArgumentError)
+      expect {
+        receipt.set('updated_at', the_stored_time)
+      }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/models/email_requested_receipt_spec.rb
+++ b/spec/models/email_requested_receipt_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe EmailRequestedReceipt, type: :model do
 
     it 'returns the stored timestamp for the supplied name' do
       receipt.government_response = the_stored_time
-      expect(receipt.get('government_response')).to eq the_stored_time
+      expect(receipt.get('government_response')).to be_usec_precise_with the_stored_time
     end
 
     it 'raises an error if the supplied name is not a valid timestamp' do
@@ -52,7 +52,7 @@ RSpec.describe EmailRequestedReceipt, type: :model do
     it 'saves the stored timestamp for the supplied name in the db to the supplied time' do
       receipt.set('government_response', the_stored_time)
       receipt.reload
-      expect(receipt.government_response).to eq the_stored_time
+      expect(receipt.government_response).to be_usec_precise_with the_stored_time
     end
 
     it 'raises an error if the supplied name is not a valid timestamp' do

--- a/spec/models/email_requested_receipt_spec.rb
+++ b/spec/models/email_requested_receipt_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe EmailRequestedReceipt, type: :model do
+  it "has a valid factory" do
+    expect(FactoryGirl.build(:email_requested_receipt)).to be_valid
+  end
+
+  describe 'petition' do
+    it { is_expected.to belong_to(:petition).touch(true) }
+  end
+
+  context "validations" do
+    subject { FactoryGirl.create(:email_requested_receipt) }
+
+    it { is_expected.to validate_presence_of(:petition) }
+    it { is_expected.to validate_uniqueness_of(:petition_id) }
+  end
+end

--- a/spec/models/email_sent_receipt_spec.rb
+++ b/spec/models/email_sent_receipt_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe EmailSentReceipt, type: :model do
+  it "has a valid factory" do
+    expect(FactoryGirl.build(:email_sent_receipt)).to be_valid
+  end
+
+  describe 'signature' do
+    it { is_expected.to belong_to(:signature).touch(true) }
+  end
+
+  context "validations" do
+    subject { FactoryGirl.create(:email_sent_receipt) }
+
+    it { is_expected.to validate_presence_of(:signature) }
+    it { is_expected.to validate_uniqueness_of(:signature_id) }
+  end
+
+  describe '#get' do
+    let(:receipt) { FactoryGirl.build(:email_sent_receipt) }
+    let(:the_stored_time) { 6.days.ago }
+
+    it 'returns nil when nothing has been stamped for the supplied name' do
+      expect(receipt.get('government_response')).to be_nil
+    end
+
+    it 'returns the stored timestamp for the supplied name' do
+      receipt.government_response = the_stored_time
+      expect(receipt.get('government_response')).to eq the_stored_time
+    end
+
+    it 'raises an error if the supplied name is not a valid timestamp' do
+      expect {
+        receipt.get('aint_no_such_timestamp')
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error if we try to access the rails created_at/updated_at stamps this way' do
+      expect {
+        receipt.get('created_at')
+      }.to raise_error(ArgumentError)
+      expect {
+        receipt.get('updated_at')
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#set' do
+    let(:receipt) { FactoryGirl.create(:email_sent_receipt) }
+    let(:the_stored_time) { 6.days.ago }
+
+    it 'saves the stored timestamp for the supplied name in the db to the supplied time' do
+      receipt.set('government_response', the_stored_time)
+      receipt.reload
+      expect(receipt.government_response).to eq the_stored_time
+    end
+
+    it 'raises an error if the supplied name is not a valid timestamp' do
+      expect {
+        receipt.set('aint_no_such_timestamp', the_stored_time)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error if we try to set the rails created_at/updated_at stamps this way' do
+      expect {
+        receipt.set('created_at', the_stored_time)
+      }.to raise_error(ArgumentError)
+      expect {
+        receipt.set('updated_at', the_stored_time)
+      }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/models/email_sent_receipt_spec.rb
+++ b/spec/models/email_sent_receipt_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe EmailSentReceipt, type: :model do
 
     it 'returns the stored timestamp for the supplied name' do
       receipt.government_response = the_stored_time
-      expect(receipt.get('government_response')).to eq the_stored_time
+      expect(receipt.get('government_response')).to be_usec_precise_with the_stored_time
     end
 
     it 'raises an error if the supplied name is not a valid timestamp' do
@@ -52,7 +52,7 @@ RSpec.describe EmailSentReceipt, type: :model do
     it 'saves the stored timestamp for the supplied name in the db to the supplied time' do
       receipt.set('government_response', the_stored_time)
       receipt.reload
-      expect(receipt.government_response).to eq the_stored_time
+      expect(receipt.government_response).to be_usec_precise_with the_stored_time
     end
 
     it 'raises an error if the supplied name is not a valid timestamp' do

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1014,4 +1014,25 @@ RSpec.describe Petition, type: :model do
   describe 'debate outcomes' do
     it { is_expected.to have_one(:debate_outcome).dependent(:destroy) }
   end
+
+  describe 'email requested receipts' do
+    it { is_expected.to have_one(:email_requested_receipt).dependent(:destroy) }
+
+    describe '#email_requested_receipt!' do
+      let(:petition) { FactoryGirl.create(:petition) }
+
+      it 'returns the existing db object if one exists' do
+        existing = petition.create_email_requested_receipt
+        expect(petition.email_requested_receipt!).to eq existing
+      end
+
+      it 'returns a newly created instance if does not already exist' do
+        instance = petition.email_requested_receipt!
+        expect(instance).to be_present
+        expect(instance).to be_a(EmailRequestedReceipt)
+        expect(instance.petition).to eq petition
+        expect(instance.petition).to be_persisted
+      end
+    end
+  end
 end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1034,5 +1034,40 @@ RSpec.describe Petition, type: :model do
         expect(instance.petition).to be_persisted
       end
     end
+
+    describe '#get_email_requested_at_for' do
+      let(:petition) { FactoryGirl.create(:open_petition) }
+      let(:receipt) { petition.email_requested_receipt! }
+      let(:the_stored_time) { 6.days.ago }
+
+      it 'returns nil when nothing has been stamped for the supplied name' do
+        expect(petition.get_email_requested_at_for('government_response')).to be_nil
+      end
+
+      it 'returns the stored timestamp for the supplied name' do
+        receipt.update_column('government_response', the_stored_time)
+        expect(petition.get_email_requested_at_for('government_response')).to eq the_stored_time
+      end
+    end
+
+    describe '#set_email_requested_at_for' do
+      include ActiveSupport::Testing::TimeHelpers
+
+      let(:petition) { FactoryGirl.create(:open_petition) }
+      let(:receipt) { petition.email_requested_receipt! }
+      let(:the_stored_time) { 6.days.ago }
+
+      it 'sets the stored timestamp for the supplied name to the supplied time' do
+        petition.set_email_requested_at_for('government_response', to: the_stored_time)
+        expect(receipt.government_response).to eq the_stored_time
+      end
+
+      it 'sets the stored timestamp for the supplied name to the current time if none is supplied' do
+        travel_to the_stored_time do
+          petition.set_email_requested_at_for('government_response')
+          expect(receipt.government_response).to eq Time.current
+        end
+      end
+    end
   end
 end

--- a/spec/support/time_comparison_helpers.rb
+++ b/spec/support/time_comparison_helpers.rb
@@ -1,0 +1,32 @@
+RSpec::Matchers.define :be_usec_precise_with do |expected|
+  match do |actual|
+    expect(actual).to be_within(usec_precision).of expected
+  end
+
+  failure_message do |actual|
+    "\nexpected #{expected_formatted} to #{description}\n\n\n"
+  end
+
+  failure_message_when_negated do |actual|
+    "\nexpected #{expected_formatted} not to #{description}\n\n\n"
+  end
+
+  description do
+    "be within 1 microsecond of #{expected_formatted}"
+  end
+
+  private
+
+  def usec_precision
+    @_usec ||= 0.000001.seconds
+  end
+  def expected_formatted
+    formatted(expected)
+  end
+  def actual_formatted
+    formatted(actual)
+  end
+  def formatted(object)
+    RSpec::Support::ObjectFormatter.format(object)
+  end
+end


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/96655040

Mostly the work here is around refactoring the existing ``EmailThresholdResponseJob`` to make the email behaviour more extensible.  See 33c3326b6f85935cc5dfd9ea71e81619bb5ccfbf for a description of that behaviour.  We add an ``EmailRequestedReceipt`` object which is attached to ``Petition`` and this holds the timestamp for when each email type was requested.  There is a corresponding ``EmailSentReceipt`` object attached to each ``Signature`` that contains the timestamp for when each email type was last sent to the signature.  Currently the receipt objects have two timestamps ``government_response`` for the ``PetitionMailer.notify_signer_of_threshold_response`` email and ``debate_outcome`` for the ``PetitionMailer.notify_signer_of_debate_outcome`` email.