### PR TITLE
Fix redirect after editing scheduled_debate_date

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -76,7 +76,7 @@ class Admin::PetitionsController < Admin::AdminController
   def update_scheduled_debate_date
     fetch_petition_for_scheduled_debate_date
     if @petition.update(update_scheduled_debate_date_params)
-      redirect_to edit_response_admin_petition_path(@petition), notice: "Scheduled debate date was successfully updated."
+      redirect_to admin_petition_path(@petition), notice: "Scheduled debate date was successfully updated."
     else
       render :edit_scheduled_debate_date
     end


### PR DESCRIPTION
Redirect to admin_petition_path instead of edit_response

Fix for https://www.pivotaltracker.com/n/projects/307301/stories/96655554