### PR TITLE
Removing scheduled debate link from edit response view

### DIFF
--- a/app/views/admin/petitions/edit_response.html.erb
+++ b/app/views/admin/petitions/edit_response.html.erb
@@ -18,8 +18,6 @@
   <% end -%>
 <% end -%>
 
-<%= link_to("Publish Debate Schedule", edit_scheduled_debate_date_admin_petition_path(@petition)) %>
-
 <%= form_for [:admin, @petition ], :url => update_response_admin_petition_path(@petition), :builder => AdminFormBuilder do |f| -%>
   <%= render 'internal_response', :f => f %>
   <div>


### PR DESCRIPTION
We don't need this on this page right now, it may come back (where we can go from any edit page to any other) but as it's the only one right now, it feels a bit odd.