### PR TITLE
Create a new list view for 'Petitions awaiting a Government response'

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -40,7 +40,6 @@ class SignaturesController < ApplicationController
 
     if @signature.sponsor?
       send_sponsor_support_notification_email_to_petition_owner(@petition, @signature)
-      @petition.validate_creator_signature!
       @petition.update_state_after_new_validated_sponsor!
       redirect_to sponsored_petition_sponsor_url(@petition, token: @petition.sponsor_token)
     else

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -2,22 +2,15 @@ class SponsorsController < ApplicationController
   include ManagingMoveParameter
 
   before_action :retrieve_petition
-  before_action :validate_token_and_petition_match
+  before_action :redirect_to_petition_url, if: :moderated?
+  before_action :redirect_to_moderation_info_url, if: :has_maximum_sponsors?
 
   respond_to :html
 
   def show
-    if @petition.hidden?
-      raise ActiveRecord::RecordNotFound
-    elsif @petition.rejected? || @petition.closed? || @petition.open?
-      redirect_to petition_url(@petition)
-    elsif @petition.has_maximum_sponsors?
-      redirect_to moderation_info_petition_url(@petition)
-    else
-      assign_stage
-      @sponsor = @petition.sponsors.build
-      @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, @petition, params[:stage], params[:move])
-    end
+    assign_stage
+    @sponsor = @petition.sponsors.build
+    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, @petition, params[:stage], params[:move])
   end
 
   def update
@@ -42,13 +35,29 @@ class SponsorsController < ApplicationController
   end
 
   private
+
   def retrieve_petition
-    # TODO: scope the petitions we look at?
-    @petition = Petition.find(params[:petition_id])
+    @petition = Petition.not_hidden.find_by!(sponsor_token_and_id)
   end
 
-  def validate_token_and_petition_match
-    raise ActiveRecord::RecordNotFound unless @petition.sponsor_token == params[:token]
+  def sponsor_token_and_id
+    { sponsor_token: params[:token].to_s, id: params[:petition_id].to_i }
+  end
+
+  def redirect_to_petition_url
+    redirect_to petition_url(@petition)
+  end
+
+  def redirect_to_moderation_info_url
+    redirect_to moderation_info_petition_url(@petition)
+  end
+
+  def moderated?
+    @petition.moderated?
+  end
+
+  def has_maximum_sponsors?
+    @petition.has_maximum_sponsors?
   end
 
   def assign_stage

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -4,6 +4,7 @@ class SponsorsController < ApplicationController
   before_action :retrieve_petition
   before_action :redirect_to_petition_url, if: :moderated?
   before_action :redirect_to_moderation_info_url, if: :has_maximum_sponsors?
+  before_action :validate_creator_signature, only: %i[show]
 
   respond_to :html
 
@@ -58,6 +59,10 @@ class SponsorsController < ApplicationController
 
   def has_maximum_sponsors?
     @petition.has_maximum_sponsors?
+  end
+
+  def validate_creator_signature
+    @petition.validate_creator_signature!
   end
 
   def assign_stage

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -20,6 +20,23 @@ module PetitionHelper
     t(:"petitions.rejection_reasons.descriptions")
   end
 
+  def waiting_for_response_in_words(petition)
+    if petition.response_threshold_reached_at
+      scope = :"petitions.waiting_for_response_in_words"
+      now   = Time.current.end_of_day
+      from  = petition.response_threshold_reached_at.end_of_day
+      count = ((now - from) / 86400.0).floor
+
+      key = case count
+            when 0 then :zero
+            when 1 then :one
+            else :other
+            end
+
+      t(key, scope: scope, formatted_count: number_with_delimiter(count))
+    end
+  end
+
   private
 
   def render_petition_hidden_details(stage_manager, form)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -154,6 +154,10 @@ class Petition < ActiveRecord::Base
     save
   end
 
+  def validate_creator_signature!
+    creator_signature.validate! && reload
+  end
+
   def count_validated_signatures
     signatures.validated.count
   end
@@ -256,10 +260,6 @@ class Petition < ActiveRecord::Base
 
   def below_sponsor_moderation_threshold?
     supporting_sponsors_count < Site.threshold_for_moderation
-  end
-
-  def validate_creator_signature!
-    creator_signature.update_attribute(:state, Signature::VALIDATED_STATE) if creator_signature.state == Signature::PENDING_STATE
   end
 
   def update_state_after_new_validated_sponsor!

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -68,11 +68,17 @@ class Signature < ActiveRecord::Base
 
   def validate!
     if pending?
-      self.update_columns(
-        state: VALIDATED_STATE,
-        updated_at: Time.current
-      )
-      ConstituencyPetitionJournal.record_new_signature_for(self)
+      Petition.transaction do
+        self.update_columns(
+          state:        VALIDATED_STATE,
+          validated_at: Time.current,
+          updated_at:   Time.current
+        )
+
+        ConstituencyPetitionJournal.record_new_signature_for(self)
+        petition.creator_signature.validate!
+        petition.increment_signature_count(petition_id)
+      end
     end
   end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -77,7 +77,7 @@ class Signature < ActiveRecord::Base
 
         ConstituencyPetitionJournal.record_new_signature_for(self)
         petition.creator_signature.validate!
-        petition.increment_signature_count(petition_id)
+        petition.increment_signature_count!
       end
     end
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -24,6 +24,10 @@ class Site < ActiveRecord::Base
       instance.enabled?
     end
 
+    def petition_closed_at(time = Time.current)
+      instance.petition_closed_at(time)
+    end
+
     def protected?
       instance.protected?
     end
@@ -158,6 +162,10 @@ class Site < ActiveRecord::Base
     else
       self.password_digest = nil
     end
+  end
+
+  def petition_closed_at(time = Time.current)
+    time.end_of_day + petition_duration.months
   end
 
   validates :title, presence: true, length: { maximum: 50 }

--- a/app/views/search/petitions/_petition_result_for_facet_awaiting_response.html.erb
+++ b/app/views/search/petitions/_petition_result_for_facet_awaiting_response.html.erb
@@ -1,2 +1,3 @@
 <%= link_to petition.action, petition_path(petition) %>
 <p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= waiting_for_response_in_words(petition) %></p>

--- a/app/views/search/petitions/_petition_result_for_facet_closed.html.erb
+++ b/app/views/search/petitions/_petition_result_for_facet_closed.html.erb
@@ -1,2 +1,2 @@
-<%= render "search/petitions/shared/petition_action_link", petition: petition %>
-<%= render "search/petitions/shared/signature_count", petition: petition %>
+<%= link_to petition.action, petition_path(petition) %>
+<p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/search/petitions/_petition_result_for_facet_open.html.erb
+++ b/app/views/search/petitions/_petition_result_for_facet_open.html.erb
@@ -1,2 +1,2 @@
-<%= render "search/petitions/shared/petition_action_link", petition: petition %>
-<%= render "search/petitions/shared/signature_count", petition: petition %>
+<%= link_to petition.action, petition_path(petition) %>
+<p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/search/petitions/_petition_result_for_facet_rejected.html.erb
+++ b/app/views/search/petitions/_petition_result_for_facet_rejected.html.erb
@@ -1,1 +1,1 @@
-<%= render "search/petitions/shared/petition_action_link", petition: petition %>
+<%= link_to petition.action, petition_path(petition) %>

--- a/app/views/search/petitions/_petition_result_for_facet_with_debate_outcome.html.erb
+++ b/app/views/search/petitions/_petition_result_for_facet_with_debate_outcome.html.erb
@@ -1,3 +1,3 @@
-<%= render "search/petitions/shared/petition_action_link", petition: petition %>
-<%= render "search/petitions/shared/signature_count", petition: petition %>
+<%= link_to petition.action, petition_path(petition) %>
+<p><%= signature_count(:default, petition.signature_count) %></p>
 <p>Debated <%= short_date_format(petition.debate_outcome.debated_on) %></p>

--- a/app/views/search/petitions/_petition_result_for_facet_with_response.html.erb
+++ b/app/views/search/petitions/_petition_result_for_facet_with_response.html.erb
@@ -1,3 +1,3 @@
-<%= render "search/petitions/shared/petition_action_link", petition: petition %>
-<%= render "search/petitions/shared/signature_count", petition: petition %>
+<%= link_to petition.action, petition_path(petition) %>
+<p><%= signature_count(:default, petition.signature_count) %></p>
 <p>Responded <%= short_date_format(petition.government_response_at) %></p>

--- a/app/views/search/petitions/shared/_petition_action_link.html.erb
+++ b/app/views/search/petitions/shared/_petition_action_link.html.erb
@@ -1,1 +1,0 @@
-<%= link_to petition.action, petition_path(petition) %>

--- a/app/views/search/petitions/shared/_signature_count.html.erb
+++ b/app/views/search/petitions/shared/_signature_count.html.erb
@@ -1,3 +1,0 @@
-<p>
-  <%= signature_count(:default, petition.signature_count) %>
-</p>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -13,7 +13,8 @@ en-GB:
       open: "Open petitions (%{quantity})"
       closed: "Closed petitions (%{quantity})"
       rejected: "Rejected petitions (%{quantity})"
-      with_response: "Petitions with a Government response (%{quantity})"
+      awaiting_response: "Awaiting a government response (%{quantity})"
+      with_response: "Government responses (%{quantity})"
       with_debate_outcome: "Petitions debated in Parliament (%{quantity})"
 
     emails:
@@ -43,6 +44,11 @@ en-GB:
         gather_sponsors_for_petition: |-
           Parliament petitions - It's time to get sponsors to support your petition
       signoff_prefix: "HM Government & Parliament Petitions"
+
+    waiting_for_response_in_words:
+      zero: "Waiting for less than a day"
+      one: "Waiting for 1 day"
+      other: "Waiting for %{formatted_count} days"
 
     counts:
       default:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,7 +26,3 @@ end
 every :weekday, :at => '6.30am' do # Use any day of the week or :weekend, :weekday
   rake "epets:threshold_email_reminder", :output => nil
 end
-
-every 5.minutes do
-  runner "Petition.update_all_signature_counts", :output => nil
-end

--- a/db/migrate/20150618233548_add_validated_at_to_signatures.rb
+++ b/db/migrate/20150618233548_add_validated_at_to_signatures.rb
@@ -1,0 +1,8 @@
+class AddValidatedAtToSignatures < ActiveRecord::Migration
+  def change
+    change_table :signatures do |t|
+      t.datetime :validated_at
+      t.index :validated_at
+    end
+  end
+end

--- a/db/migrate/20150618233718_add_last_signed_at_to_petitions.rb
+++ b/db/migrate/20150618233718_add_last_signed_at_to_petitions.rb
@@ -1,0 +1,8 @@
+class AddLastSignedAtToPetitions < ActiveRecord::Migration
+  def change
+    change_table :petitions do |t|
+      t.datetime :last_signed_at
+      t.index :last_signed_at
+    end
+  end
+end

--- a/db/migrate/20150619075903_add_response_threshold_reached_at_to_petition.rb
+++ b/db/migrate/20150619075903_add_response_threshold_reached_at_to_petition.rb
@@ -1,0 +1,8 @@
+class AddResponseThresholdReachedAtToPetition < ActiveRecord::Migration
+  def change
+    change_table :petitions do |t|
+      t.datetime :response_threshold_reached_at
+      t.index :response_threshold_reached_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -245,7 +245,8 @@ CREATE TABLE petitions (
     sponsor_token character varying(255),
     response_summary character varying(500),
     government_response_at timestamp without time zone,
-    scheduled_debate_date date
+    scheduled_debate_date date,
+    last_signed_at timestamp without time zone
 );
 
 
@@ -296,7 +297,8 @@ CREATE TABLE signatures (
     last_emailed_at timestamp without time zone,
     email character varying(255),
     unsubscribe_token character varying,
-    constituency_id character varying
+    constituency_id character varying,
+    validated_at timestamp without time zone
 );
 
 
@@ -630,6 +632,13 @@ CREATE UNIQUE INDEX index_petitions_on_creator_signature_id ON petitions USING b
 
 
 --
+-- Name: index_petitions_on_last_signed_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_petitions_on_last_signed_at ON petitions USING btree (last_signed_at);
+
+
+--
 -- Name: index_petitions_on_response_required_and_signature_count; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -693,6 +702,13 @@ CREATE INDEX index_signatures_on_updated_at ON signatures USING btree (updated_a
 
 
 --
+-- Name: index_signatures_on_validated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_validated_at ON signatures USING btree (validated_at);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -736,6 +752,10 @@ INSERT INTO schema_migrations (version) VALUES ('20150618134919');
 INSERT INTO schema_migrations (version) VALUES ('20150618143114');
 
 INSERT INTO schema_migrations (version) VALUES ('20150618144922');
+
+INSERT INTO schema_migrations (version) VALUES ('20150618233548');
+
+INSERT INTO schema_migrations (version) VALUES ('20150618233718');
 
 INSERT INTO schema_migrations (version) VALUES ('20150619090833');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -246,7 +246,8 @@ CREATE TABLE petitions (
     response_summary character varying(500),
     government_response_at timestamp without time zone,
     scheduled_debate_date date,
-    last_signed_at timestamp without time zone
+    last_signed_at timestamp without time zone,
+    response_threshold_reached_at timestamp without time zone
 );
 
 
@@ -646,6 +647,13 @@ CREATE INDEX index_petitions_on_response_required_and_signature_count ON petitio
 
 
 --
+-- Name: index_petitions_on_response_threshold_reached_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_petitions_on_response_threshold_reached_at ON petitions USING btree (response_threshold_reached_at);
+
+
+--
 -- Name: index_petitions_on_state_and_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -756,6 +764,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150618144922');
 INSERT INTO schema_migrations (version) VALUES ('20150618233548');
 
 INSERT INTO schema_migrations (version) VALUES ('20150618233718');
+
+INSERT INTO schema_migrations (version) VALUES ('20150619075903');
 
 INSERT INTO schema_migrations (version) VALUES ('20150619090833');
 

--- a/features/admin/threshold.feature
+++ b/features/admin/threshold.feature
@@ -17,7 +17,6 @@ Feature: Threshold list
     And the petition "Petition 4" has 10 validated signatures
     And an open petition "p5" exists with action: "Petition 5", response_required: false
     And a closed petition "p6" exists with action: "Petition 6", response_required: true, closed_at: "21 April 2011"
-    And all petitions have had their signatures counted
 
   Scenario: A moderator user sees all petitions above the threshold signature count
     When I go to the admin threshold page

--- a/features/sam_signs_a_petition_with_suzies_email_address.feature
+++ b/features/sam_signs_a_petition_with_suzies_email_address.feature
@@ -5,7 +5,6 @@ Feature: Sam signs a petition
 
   Background:
     Given a petition "Do something!"
-    And all petitions have had their signatures counted
     And Suzie has already signed the petition
 
   Scenario: Sam can sign the petition with a different name

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -34,7 +34,6 @@ Given(/^(a|few|some|many) constituents? in "(.*?)" supports? "(.*?)"$/) do |how_
   how_many.times do
     FactoryGirl.create(:pending_signature, petition: petition, constituency_id: constituency.id).validate!
   end
-  Petition.update_all_signature_counts
 end
 
 When(/^I search for petitions local to me in "(.*?)"$/) do |postcode|

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -65,6 +65,18 @@ Given /^a ?(open|closed)? petition "([^"]*)" exists and has received a governmen
   FactoryGirl.create(:open_petition, petition_attributes)
 end
 
+Given(/^a petition "(.*?)" exists and hasn't passed the threshold for a response$/) do |action|
+  FactoryGirl.create(:open_petition, action: action)
+end
+
+Given(/^a petition "(.*?)" exists and passed the threshold for a response less than a day ago$/) do |action|
+  FactoryGirl.create(:open_petition, action: action, response_threshold_reached_at: 2.hours.ago)
+end
+
+Given(/^a petition "(.*?)" exists and passed the threshold for a response (\d+) days? ago$/) do |action, amount|
+  FactoryGirl.create(:open_petition, action: action, response_threshold_reached_at: amount.days.ago)
+end
+
 Given /^I have created a petition$/ do
   @petition = FactoryGirl.create(:open_petition)
   reset_mailer

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -33,8 +33,9 @@ end
 
 Given /^the petition "([^"]*)" has (\d+) validated and (\d+) pending signatures$/ do |petition_action, no_validated, no_pending|
   petition = Petition.find_by(action: petition_action)
-  (no_validated - 1).times { petition.signatures << FactoryGirl.create(:validated_signature) }
-  no_pending.times { petition.signatures << FactoryGirl.create(:pending_signature) }
+  (no_validated - 1).times { FactoryGirl.create(:validated_signature, petition: petition) }
+  no_pending.times { FactoryGirl.create(:pending_signature, petition: petition) }
+  petition.reload
 end
 
 Given /^(\d+) petitions exist with a signature count of (\d+)$/ do |number, count|
@@ -71,7 +72,9 @@ end
 
 Given /^the petition "([^"]*)" has (\d+) validated signatures$/ do |petition_action, no_validated|
   petition = Petition.find_by(action: petition_action)
-  (no_validated - 1).times { petition.signatures << FactoryGirl.create(:validated_signature) }
+  (no_validated - 1).times { FactoryGirl.create(:validated_signature, petition: petition) }
+  petition.reload
+  @petition.reload if @petition
 end
 
 And (/^the petition "([^"]*)" has reached maximum amount of sponsors$/) do |petition_action|
@@ -152,7 +155,7 @@ end
 
 Then /^I should see the vote count, closed and open dates$/ do
   @petition.reload
-  expect(page).to have_css("p.signature-count", :text => @petition.signature_count.to_s + " signatures")
+  expect(page).to have_css("p.signature-count", :text => "#{@petition.signature_count} #{'signature'.pluralize(@petition.signature_count)}")
   expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.closed_at.strftime("%e %B %Y").squish)
 
   unless @petition.is_a?(ArchivedPetition)
@@ -178,10 +181,6 @@ Then /^I should see the reason for rejection$/ do
   else
     expect(page).to have_content(@petition.rejection_text)
   end
-end
-
-And /^all petitions have had their signatures counted$/ do
-  Petition.update_all_signature_counts
 end
 
 Then /^I should be asked to search for a new petition$/ do
@@ -316,7 +315,6 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |
   }
   petition = FactoryGirl.create(:open_petition, petition_args)
   5.times { FactoryGirl.create(:validated_signature, petition: petition) }
-  Petition.update_all_signature_counts
 end
 
 Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -29,7 +29,6 @@ When /^I confirm my email address$/ do
 end
 
 def should_be_signature_count_of(count)
-  Petition.update_all_signature_counts
   visit petition_path(@petition)
   expect(page).to have_css("p.signature-count", :text => count.to_s + " signatures")
 end
@@ -164,7 +163,6 @@ Then /^I should have signed the petition after confirming my email address$/ do
   steps %Q(
     And "womboid@wimbledon.com" should receive 1 email
     When I confirm my email address
-    And all petitions have had their signatures counted
   )
   should_be_signature_count_of(3)
 end

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -15,7 +15,6 @@ Feature: Suzy Singer searches by free text
     And a rejected petition exists with action: "Eavis vs the Wombles"
     And a hidden petition exists with action: "The Wombles are profane"
     And an open petition exists with action: "Wombles", closed_at: "10 days from now"
-    And all petitions have had their signatures counted
 
   Scenario: Search for open petitions
     When I search for "Wombles"
@@ -73,7 +72,6 @@ Feature: Suzy Singer searches by free text
     And the petition "Wombles" has 2 validated and 20 pending signatures
     And the petition "Common People" has 10 validated and 10 pending signatures
     And the petition "Overthrow the Wombles" has 4 validated and 0 pending signatures
-    And all petitions have had their signatures counted
     When I go to the search page
     And I search for "open" petitions with "WOMBLES" ordered by "count"
     Then I should see the following search results:
@@ -87,7 +85,6 @@ Feature: Suzy Singer searches by free text
     And the petition "Wombles" has 2 validated and 20 pending signatures
     And the petition "Common People" has 10 validated and 10 pending signatures
     And the petition "Overthrow the Wombles" has 4 validated and 0 pending signatures
-    And all petitions have had their signatures counted
     When I go to the search page
     And I search for "open" petitions with "WOMBLES" ordered by "count asc"
     Then I should see the following search results:

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -5,7 +5,6 @@ Feature: Suzie signs a petition
 
   Background:
     Given a petition "Do something!"
-    And all petitions have had their signatures counted
 
   Scenario: Suzie signs a petition after validating her email
     When I decide to sign the petition
@@ -15,7 +14,6 @@ Feature: Suzie signs a petition
     Then I am told to check my inbox to complete signing
     And "womboid@wimbledon.com" should receive 1 email
     When I confirm my email address
-    And all petitions have had their signatures counted
     Then I should have signed the petition
 
   Scenario: Suzie signs a petition after validating her email

--- a/features/suzie_unsubscribes_from_petition_updates.feature
+++ b/features/suzie_unsubscribes_from_petition_updates.feature
@@ -8,7 +8,6 @@ Feature: Unsubscribing from petiton updates as Suzie
     And the petition "Wombles of Wimbledon" has 5 validated signatures
     And Suzie has already signed the petition
     And the threshold for a parliamentary debate is "5"
-    And all petitions have had their signatures counted
     And a moderator responds to the petition
 
   Scenario: Suzie receives and email containing an unsubscription link

--- a/features/suzie_views_all_petitions.feature
+++ b/features/suzie_views_all_petitions.feature
@@ -32,12 +32,25 @@ Feature: Suzy Signer views all petitions
      | Free the wombles                                    |
     And the markup should be valid
 
+  Scenario: Suzie browses petitions awaiting a goverment response
+    Given a petition "Abolish bank holidays" exists and hasn't passed the threshold for a response
+    Given a petition "Free the wombles" exists and passed the threshold for a response less than a day ago
+    Given a petition "Force supermarkets to give unsold food to charities" exists and passed the threshold for a response 1 day ago
+    Given a petition "Make every monday bank holiday" exists and passed the threshold for a response 10 days ago
+    When I view all petitions from the home page
+    And I follow "Awaiting a government response"
+    Then I should see the following ordered list of petitions:
+     | Make every monday bank holiday                      |
+     | Force supermarkets to give unsold food to charities |
+     | Free the wombles                                    |
+    And the markup should be valid
+
   Scenario: Suzie browses petitions with a goverment response
     Given a closed petition "Free the wombles" exists and has received a government response 100 days ago
     Given a petition "Force supermarkets to give unsold food to charities" exists and has received a government response 10 days ago
     Given a petition "Make every monday bank holiday" exists and has received a government response 1 days ago
     When I view all petitions from the home page
-    And I follow "Petitions with a Government response"
+    And I follow "Government responses"
     Then I should see the following ordered list of petitions:
      | Make every monday bank holiday                      |
      | Force supermarkets to give unsold food to charities |

--- a/lib/tasks/data-generator.rake
+++ b/lib/tasks/data-generator.rake
@@ -104,8 +104,5 @@ namespace :data do
         ) if @should_create_response
       end
     end
-
-    #Update the horrible cache of signature counts
-    Petition.update_all_signature_counts
   end
 end

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -341,36 +341,33 @@ RSpec.describe Admin::PetitionsController, type: :controller do
       end
 
       context "publishing" do
-        let(:now) { Chronic.parse("1 Jan 2011") }
-        def set_up
-          allow(Time).to receive(:current).and_return(now)
+        let(:now) { Time.current }
+        let(:email) { ActionMailer::Base.deliveries.last }
+        let(:duration) { Site.petition_duration.months }
+        let(:closing_date) { (now + duration).end_of_day }
+
+        before do
           do_post :commit => 'Publish this petition'
           @petition.reload
         end
 
         it "opens the petition" do
-          set_up
           expect(@petition.state).to eq(Petition::OPEN_STATE)
         end
 
         it "sets the open date to now" do
-          set_up
-          expect(@petition.open_at.change(usec: 0)).to eq(now.change(usec: 0))
+          expect(@petition.open_at).to be_within(1.second).of(now)
         end
 
         it "sets the closed date to the end of the day on the date #{Site.petition_duration} months from now" do
-          set_up
-          expect(@petition.closed_at.change(usec: 0)).to eq( (now + Site.petition_duration.months).end_of_day.change(usec: 0) )
+          expect(@petition.closed_at).to be_within(1.second).of(closing_date)
         end
 
         it "redirects to the main admin page" do
-          set_up
           expect(response).to redirect_to("https://petition.parliament.uk/admin")
         end
 
         it "sends an email to the petition creator" do
-          set_up
-          email = ActionMailer::Base.deliveries.last
           expect(email.subject).to match(/Your petition has been published/)
         end
       end

--- a/spec/controllers/admin/profile_controller_spec.rb
+++ b/spec/controllers/admin/profile_controller_spec.rb
@@ -40,11 +40,6 @@ RSpec.describe Admin::ProfileController, type: :controller do
     end
 
     describe "GET 'update'" do
-      before :each do
-        @time = Chronic.parse('4 August 2010 13:41')
-        allow(Time).to receive(:current).and_return(@time)
-      end
-
       def do_patch(current_password, new_password, password_confirmation)
         patch :update, :id => 50000, :current_password => current_password,
               :admin_user => {:password => new_password, :password_confirmation => password_confirmation}
@@ -60,7 +55,7 @@ RSpec.describe Admin::ProfileController, type: :controller do
         it "should update password_changed_at to current time" do
           do_patch('Letmein1!', 'Letmeout1!', 'Letmeout1!')
           @user.reload
-          expect(@user.password_changed_at).to eq(@time)
+          expect(@user.password_changed_at).to be_within(1.second).of(Time.current)
         end
 
         it "should set force_password_reset to false" do
@@ -87,7 +82,7 @@ RSpec.describe Admin::ProfileController, type: :controller do
         it "should not update password_changed_at" do
           do_patch('Letmeout1!', 'Letmein1!', 'Letmein1!')
           @user.reload
-          expect(@user.password_changed_at).not_to eq(@time)
+          expect(@user.password_changed_at).not_to be_within(1.second).of(Time.current)
           expect(@user.valid_password?('Letmein1!')).to be_truthy
         end
 

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe SponsorsController, type: :controller do
       }.to raise_error ActiveRecord::RecordNotFound
     end
 
+    context 'creator signature is pending' do
+      let(:petition) { FactoryGirl.create(:pending_petition) }
+      let(:signature) { petition.creator_signature }
+
+      it 'validates the creator signature' do
+        expect {
+          get :show, petition_id: petition.id, token: petition.sponsor_token
+        }.to change{ signature.reload.validated? }.from(false).to(true)
+      end
+    end
+
     context 'petition has reached maximum amount of sponsors' do
       it 'redirects to petition moderation info page when petition is in sponsored state' do
         sponsored_petition = FactoryGirl.create(:sponsored_petition, sponsor_count: Site.maximum_number_of_sponsors)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -62,6 +62,10 @@ FactoryGirl.define do
       evaluator.sponsor_count.times do
         petition.sponsors.build(FactoryGirl.attributes_for(:sponsor))
       end
+
+      if petition.signature_count.zero?
+        petition.signature_count += 1 if petition.creator_signature.validated?
+      end
     end
 
     trait :with_additional_details do
@@ -134,6 +138,12 @@ FactoryGirl.define do
     uk_citizenship       '1'
     notify_by_email      '1'
     state                Signature::VALIDATED_STATE
+
+    after(:create) do |signature, evaluator|
+      if signature.petition
+        signature.petition.increment!(:signature_count) if signature.validated?
+      end
+    end
   end
 
   factory :pending_signature, :parent => :signature do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -113,6 +113,14 @@ FactoryGirl.define do
     state      Petition::HIDDEN_STATE
   end
 
+  factory :awaiting_petition, :parent => :open_petition do
+    response_threshold_reached_at { 1.week.ago }
+  end
+
+  factory :responded_petition, :parent => :awaiting_petition do
+    response "Government Response"
+  end
+
   factory :debated_petition, :parent => :open_petition do
     transient do
       debated_on { nil }

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe PetitionHelper, type: :helper do
+  describe "#waiting_for_response_in_words" do
+    let(:now) { Time.current.noon }
+
+    context "when the response threshold has not been reached" do
+      let(:petition) { double(:petition, response_threshold_reached_at: nil) }
+
+      it "returns nil" do
+        expect(helper.waiting_for_response_in_words(petition)).to be_nil
+      end
+    end
+
+    context "when the response threshold was reached today" do
+      let(:petition) { double(:petition, response_threshold_reached_at: 2.hours.ago(now)) }
+
+      it "returns 'Waiting for less than a day'" do
+        expect(helper.waiting_for_response_in_words(petition)).to eq("Waiting for less than a day")
+      end
+    end
+
+    context "when the response threshold was reached yesterday" do
+      let(:petition) { double(:petition, response_threshold_reached_at: 1.day.ago(now)) }
+
+      it "returns 'Waiting for 1 day'" do
+        expect(helper.waiting_for_response_in_words(petition)).to eq("Waiting for 1 day")
+      end
+    end
+
+    context "when the response threshold was reached last week" do
+      let(:petition) { double(:petition, response_threshold_reached_at: 7.days.ago(now)) }
+
+      it "returns 'Waiting for 7 days'" do
+        expect(helper.waiting_for_response_in_words(petition)).to eq("Waiting for 7 days")
+      end
+    end
+
+    context "when the response threshold was reached last month" do
+      let(:petition) { double(:petition, response_threshold_reached_at: 30.days.ago(now)) }
+
+      it "returns 'Waiting for 30 days'" do
+        expect(helper.waiting_for_response_in_words(petition)).to eq("Waiting for 30 days")
+      end
+    end
+
+    context "when the response threshold was reached 3 years ago" do
+      let(:petition) { double(:petition, response_threshold_reached_at: 1095.days.ago(now)) }
+
+      it "returns 'Waiting for 1,095 days'" do
+        expect(helper.waiting_for_response_in_words(petition)).to eq("Waiting for 1,095 days")
+      end
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -313,6 +313,14 @@ RSpec.describe Petition, type: :model do
       end
     end
 
+    context "not_hidden" do
+      let!(:petition) { FactoryGirl.create(:hidden_petition) }
+
+      it "returns only petitions that are not hidden" do
+        expect(Petition.not_hidden).not_to include(petition)
+      end
+    end
+
     context "with_response" do
       before do
         @p1 = FactoryGirl.create(:open_petition, :closed_at => 1.day.from_now, :response_summary => "summary", :response => "govt response")
@@ -532,6 +540,40 @@ RSpec.describe Petition, type: :model do
   describe "#in_moderation?" do
     it "is in moderation when the state is sponsored" do
       expect(FactoryGirl.build(:petition, :state => Petition::SPONSORED_STATE).in_moderation?).to be_truthy
+    end
+  end
+
+  describe "#moderated?" do
+    context "when the petition is hidden" do
+      subject { FactoryGirl.create(:hidden_petition) }
+
+      it "returns true" do
+        expect(subject.moderated?).to eq(true)
+      end
+    end
+
+    context "when the petition is rejected" do
+      subject { FactoryGirl.create(:rejected_petition) }
+
+      it "returns true" do
+        expect(subject.moderated?).to eq(true)
+      end
+    end
+
+    context "when the petition is open" do
+      subject { FactoryGirl.create(:open_petition) }
+
+      it "returns true" do
+        expect(subject.moderated?).to eq(true)
+      end
+    end
+
+    context "when the petition is closed" do
+      subject { FactoryGirl.create(:closed_petition) }
+
+      it "returns true" do
+        expect(subject.moderated?).to eq(true)
+      end
     end
   end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -806,17 +806,17 @@ RSpec.describe Petition, type: :model do
   end
 
   describe "#validate_creator_signature!" do
-    context "with first validated sponsor" do
+    let(:petition) { FactoryGirl.create(:pending_petition, attributes) }
+    let(:signature) { petition.creator_signature }
 
-      let(:petition){ FactoryGirl.create(:pending_petition) }
-      let(:sponsor){ FactoryGirl.create(:sponsor, :validated, petition: petition) }
+    let(:attributes) do
+      { created_at: 2.days.ago, updated_at: 2.days.ago }
+    end
 
-      it "changes creator signature state to validated" do
-        sponsor.reload
-        expect{petition.validate_creator_signature!}.to change{petition.creator_signature.state}
-                                                         .from(Signature::PENDING_STATE)
-                                                         .to(Signature::VALIDATED_STATE)
-      end
+    it "changes creator signature state to validated" do
+      expect {
+        petition.validate_creator_signature!
+      }.to change { signature.reload.validated? }.from(false).to(true)
     end
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -382,6 +382,20 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe ".petition_closed_at" do
+    let(:site) { double(:site) }
+    let(:closed_at) { 3.months.from_now.end_of_day }
+
+    before do
+      expect(Site).to receive(:first_or_create).and_return(site)
+    end
+
+    it "delegates petition_closed_at to the instance" do
+      expect(site).to receive(:petition_closed_at).and_return(closed_at)
+      expect(Site.petition_closed_at).to eq(closed_at)
+    end
+  end
+
   describe ".reload" do
     let(:site) { double(:site) }
 
@@ -488,6 +502,16 @@ RSpec.describe Site, type: :model do
 
     it "the protocol of the url" do
       expect(site.email_protocol).to eq("https")
+    end
+  end
+
+  describe "#petition_closed_at" do
+    subject :site do
+      described_class.create!(petition_duration: 3)
+    end
+
+    it "returns the closing date in petition_duration months" do
+      expect(site.petition_closed_at).to eq(3.months.from_now.end_of_day)
     end
   end
 end


### PR DESCRIPTION
When petitions have a signature count above a threshold (currently 10,000) they are meant to have a response from the Government. This adds a list for viewing those petitions which have reached this threshold but have yet to receive a response.

https://www.pivotaltracker.com/story/show/96278100

As part of this I needed to make signature counts live.

https://www.pivotaltracker.com/story/show/96434874