### PR TITLE
Tell the signatory their actual number

### DIFF
--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -6,10 +6,23 @@
 .page-title {
   margin-top: em(40, 36);
   margin-bottom: 1em;
+  position: relative;
 
   .icon {
-    margin-right: $gutter;
+    background-position: left center;
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 25px;
   }
+
+  .signature-number {
+    @include bold-48();
+    display: block;
+  }
+}
+.page-title-with-icon {
+  padding-left: $gutter * 1.5;
 }
 .page-subtitle {
   @include bold-27();

--- a/app/assets/stylesheets/petitions/views/_sign.scss
+++ b/app/assets/stylesheets/petitions/views/_sign.scss
@@ -1,3 +1,8 @@
 .uk-citizen p {
   margin-bottom: 0;
 }
+
+.signed-petition-title {
+  padding-left: $gutter * 1.5;
+  margin-bottom: $gutter * 1.3;
+}

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -38,8 +38,18 @@ class Signature < ActiveRecord::Base
   # = Methods =
   attr_accessor :uk_citizenship
 
+  def self.signature_number(validated_at)
+    where(arel_table[:validated_at].lt(validated_at)).count + 1
+  end
+
   def email=(value)
     super(value.to_s.downcase)
+  end
+
+  def number
+    if validated_at?
+      @number ||= self.class.signature_number(validated_at)
+    end
   end
 
   def postcode=(value)

--- a/app/views/petitions/thank_you.html.erb
+++ b/app/views/petitions/thank_you.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title) { "Thank you - Petitions" } %>
 
-<h1 class="page-title">
+<h1 class="page-title page-title-with-icon">
   <span class="icon icon-email" aria-hidden></span>
   One more step&hellip;
 </h1>

--- a/app/views/signatures/signed.html.erb
+++ b/app/views/signatures/signed.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_title) { "Thank you - Petitions" } %>
-<h1 class="page-title">
+<h1 class="page-title page-title-with-icon">
   <span class="icon icon-confirmation-tick"></span>
-  Thank you
+  You are signature <span class="signature-number"><%= number_with_delimiter(@signature.number) %></span>
 </h1>
 
-<p>Your signature has now been added to the <%= link_to @petition.action, petition_path(@petition) %> petition.</p>
+<p class="signed-petition-title"><%= link_to @petition.action, petition_path(@petition) %></p>
 
 <%= render 'shared/share_petition', petition: @petition %>
 

--- a/app/views/signatures/thank_you.html.erb
+++ b/app/views/signatures/thank_you.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_title) { "Thank you - Petitions" } %>
-<h1 class="page-title">
+<h1 class="page-title page-title-with-icon">
   <span class="icon icon-email" aria-hidden></span>
   One more step&hellip;
 </h1>

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -24,7 +24,6 @@ When /^I confirm my email address$/ do
   steps %Q(
     And I open the email with text "confirm your email address"
     When I click the first link in the email
-    Then I should see "Thank you"
   )
 end
 

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -30,12 +30,12 @@ Feature: Suzie signs a petition
     And "womboid@wimbledon.com" should receive no email
     And "womboidian@wimbledon.com" should receive 1 email
     When I confirm my email address
-    Then I am taken to a landing page
+    Then I should see "You are signature 1"
     And I should see my constituency "Islington South and Finsbury"
     And I should see my MP
     And I can click on a link to visit my MP
     And I can click on a link to return to the petition
-    And I should have signed the petition
+    And I should see "You are signature 1"
 
   Scenario: Suzie signs a petition with invalid postcode SW14 9RQ
     When I go to the new signature page for "Do something!"
@@ -47,7 +47,7 @@ Feature: Suzie signs a petition
     Then I am told to check my inbox to complete signing
     And "womboid@wimbledon.com" should receive 1 email
     When I confirm my email address
-    Then I am taken to a landing page
+    Then I should see "You are signature 1"
     And I should not see the text "Your constituency is"
     And I should not see the text "Your MP is"
 
@@ -96,10 +96,10 @@ Feature: Suzie signs a petition
   Scenario: Suzie sees notice that she has already signed when she validates more than once
     When I fill in my details and sign a petition
     And I confirm my email address
-    And I am taken to a landing page
+    And I should see "You are signature 1"
     And I can click on a link to return to the petition
     And I should have signed the petition
     When I confirm my email address
-    And I am taken to a landing page
+    And I should see "You are signature 1"
     And I can click on a link to return to the petition
     Then I should see that I have already signed the petition

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -159,7 +159,8 @@ FactoryGirl.define do
   end
 
   factory :validated_signature, :parent => :signature do
-    state      Signature::VALIDATED_STATE
+    state          Signature::VALIDATED_STATE
+    validated_at { Time.current }
   end
 
   sequence(:sponsor_email) { |n| "sponsor#{n}@example.com" }

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -304,6 +304,52 @@ RSpec.describe Signature, type: :model do
     end
   end
 
+  describe "#number" do
+    let(:attributes) { FactoryGirl.attributes_for(:petition) }
+    let(:creator) { FactoryGirl.create(:pending_signature) }
+    let(:petition) do
+      Petition.create(attributes) do |petition|
+        petition.creator_signature = creator
+
+        5.times do
+          petition.signatures << FactoryGirl.create(:pending_signature)
+        end
+      end
+    end
+
+    before do
+      petition.signatures.each do |signature|
+        signature.validate!
+      end
+
+      petition.publish!
+    end
+
+    it "returns the signature number" do
+      signature = FactoryGirl.create(:pending_signature, petition: petition)
+      signature.validate!
+
+      expect(petition.signature_count).to eq(7)
+      expect(signature.number).to eq(7)
+    end
+
+    it "remains the same after another signature is added" do
+      signature = FactoryGirl.create(:pending_signature, petition: petition)
+      later_signature = FactoryGirl.create(:pending_signature, petition: petition)
+      signature.validate!
+
+      expect { later_signature.validate! }.not_to change{ signature.number }
+    end
+
+    it "remains the same even if an earlier signature is validated" do
+      earlier_signature = FactoryGirl.create(:pending_signature, petition: petition)
+      signature = FactoryGirl.create(:pending_signature, petition: petition)
+      signature.validate!
+
+      expect { earlier_signature.validate! }.not_to change{ signature.number }
+    end
+  end
+
   describe "#pending?" do
     it "returns true if the signature has a pending state" do
       signature = FactoryGirl.build(:pending_signature)


### PR DESCRIPTION
Rather than a generic thank you message, display the actual number at which the person signed by counting the number of signatures with a earlier validated_at date.

https://www.pivotaltracker.com/story/show/96865510