### PR TITLE
Add foreign keys to existing tables

### DIFF
--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -3,7 +3,7 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :constituency_id, presence: true, length: { maximum: 255 }
-  validates :petition_id, uniqueness: { scope: [:constituency_id] }
+  validates :constituency_id, uniqueness: { scope: [:petition_id] }
   validates :signature_count, presence: true
 
   scope :ordered, -> {

--- a/app/models/debate_outcome.rb
+++ b/app/models/debate_outcome.rb
@@ -2,6 +2,5 @@ class DebateOutcome < ActiveRecord::Base
   belongs_to :petition, touch: true
 
   validates :petition, :debated_on, presence: true
-  validates :petition_id, uniqueness: true
   validates :transcript_url, :video_url, length: { maximum: 500 }
 end

--- a/db/migrate/20150621200307_add_foreign_keys.rb
+++ b/db/migrate/20150621200307_add_foreign_keys.rb
@@ -1,0 +1,10 @@
+class AddForeignKeys < ActiveRecord::Migration
+  def change
+    add_foreign_key :constituency_petition_journals, :petitions, on_delete: :cascade
+    add_foreign_key :debate_outcomes, :petitions, on_delete: :cascade
+    add_foreign_key :petitions, :signatures, column: :creator_signature_id, on_delete: :cascade
+    add_foreign_key :signatures, :petitions, on_delete: :cascade
+    add_foreign_key :sponsors, :petitions, on_delete: :cascade
+    add_foreign_key :sponsors, :signatures, on_delete: :cascade
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -832,11 +832,59 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 
 
 --
+-- Name: fk_rails_38c9c83a88; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY sponsors
+    ADD CONSTRAINT fk_rails_38c9c83a88 FOREIGN KEY (signature_id) REFERENCES signatures(id) ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_3e01179571; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY signatures
+    ADD CONSTRAINT fk_rails_3e01179571 FOREIGN KEY (petition_id) REFERENCES petitions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_5186723bbd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY constituency_petition_journals
+    ADD CONSTRAINT fk_rails_5186723bbd FOREIGN KEY (petition_id) REFERENCES petitions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_5451a341b3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY petitions
+    ADD CONSTRAINT fk_rails_5451a341b3 FOREIGN KEY (creator_signature_id) REFERENCES signatures(id) ON DELETE CASCADE;
+
+
+--
 -- Name: fk_rails_898597541e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY email_requested_receipts
     ADD CONSTRAINT fk_rails_898597541e FOREIGN KEY (petition_id) REFERENCES petitions(id);
+
+
+--
+-- Name: fk_rails_bc381510eb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY sponsors
+    ADD CONSTRAINT fk_rails_bc381510eb FOREIGN KEY (petition_id) REFERENCES petitions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: fk_rails_cb057e3dd1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY debate_outcomes
+    ADD CONSTRAINT fk_rails_cb057e3dd1 FOREIGN KEY (petition_id) REFERENCES petitions(id) ON DELETE CASCADE;
 
 
 --
@@ -896,4 +944,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150618233718');
 INSERT INTO schema_migrations (version) VALUES ('20150619075903');
 
 INSERT INTO schema_migrations (version) VALUES ('20150619090833');
+
+INSERT INTO schema_migrations (version) VALUES ('20150621200307');
 

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -5,85 +5,89 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     expect(FactoryGirl.build(:constituency_petition_journal)).to be_valid
   end
 
-  context "defaults" do
+  describe "defaults" do
     subject { described_class.new }
     it "has 0 for initial signature_count" do
       expect(subject.signature_count).to eq 0
     end
   end
 
-  context "validations" do
+  describe "indexes" do
+    it { is_expected.to have_db_index([:petition_id, :constituency_id]).unique }
+  end
+
+  describe "validations" do
     subject { FactoryGirl.build(:constituency_petition_journal) }
 
     it { is_expected.to validate_presence_of(:constituency_id) }
     it { is_expected.to validate_length_of(:constituency_id).is_at_most(255) }
     it { is_expected.to validate_presence_of(:petition) }
-    it { is_expected.to validate_uniqueness_of(:petition_id).scoped_to(:constituency_id) }
+    it { is_expected.to validate_uniqueness_of(:constituency_id).scoped_to(:petition_id) }
     it { is_expected.to validate_presence_of(:signature_count) }
   end
 
-  context '.for' do
+  describe ".for" do
     let(:petition) { FactoryGirl.create(:petition) }
     let(:constituency_id) { FactoryGirl.generate(:constituency_id) }
 
-    context 'when there is a journal for the requested petition and constituency' do
+    context "when there is a journal for the requested petition and constituency" do
       let!(:existing_record) { FactoryGirl.create(:constituency_petition_journal, petition: petition, constituency_id: constituency_id, signature_count: 30) }
 
-      it 'doesn\'t create a new record' do
+      it "doesn't create a new record" do
         expect {
           described_class.for(petition, constituency_id)
         }.not_to change(described_class, :count)
       end
 
-      it 'fetches the instance from the DB' do
+      it "fetches the instance from the DB" do
         fetched = described_class.for(petition, constituency_id)
         expect(fetched).to eq existing_record
       end
     end
 
-    context 'when there is no journal for the requested petition and constituency' do
-      it 'creates a new instance in the DB' do
+    context "when there is no journal for the requested petition and constituency" do
+      it "creates a new instance in the DB" do
         expect {
           described_class.for(petition, constituency_id)
         }.to change(described_class, :count).by(1)
       end
 
-      it 'returns the newly created instance' do
+      it "returns the newly created instance" do
         fetched = described_class.for(petition, constituency_id)
         expect(fetched).to be_a described_class
         expect(fetched).to be_persisted
       end
 
-      it 'sets the petition of the new instance to the supplied petition' do
+      it "sets the petition of the new instance to the supplied petition" do
         fetched = described_class.for(petition, constituency_id)
         expect(fetched.petition).to eq petition
       end
 
-      it 'sets the constituency_id of the new instance to the supplied petition' do
+      it "sets the constituency_id of the new instance to the supplied petition" do
         fetched = described_class.for(petition, constituency_id)
         expect(fetched.constituency_id).to eq constituency_id
       end
 
-      it 'has 0 for a signature count' do
+      it "has 0 for a signature count" do
         fetched = described_class.for(petition, constituency_id)
         expect(fetched.signature_count).to eq 0
       end
     end
   end
 
-  context '#record_new_signature' do
+  describe "#record_new_signature" do
     let(:petition) { FactoryGirl.create(:petition) }
     let(:constituency_id) { FactoryGirl.generate(:constituency_id) }
 
     subject { described_class.for(petition, constituency_id) }
 
-    it 'increments signature_count by 1' do
+    it "increments signature_count by 1" do
       expect {
         subject.record_new_signature
       }.to change(subject, :signature_count).by(1)
     end
 
-    it 'persists the change' do
+    it "persists the change" do
       old_signature_count = subject.signature_count
       subject.record_new_signature
       subject.reload
@@ -91,46 +95,46 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     end
   end
 
-  context '.record_new_signature_for' do
+  describe ".record_new_signature_for" do
     let(:petition) { FactoryGirl.create(:open_petition) }
     let(:constituency_id) { FactoryGirl.generate(:constituency_id) }
     let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, constituency_id: constituency_id) }
 
-    it 'does nothing if the supplied signature is nil' do
+    it "does nothing if the supplied signature is nil" do
       expect {
         described_class.record_new_signature_for(nil)
       }.not_to change(described_class, :count)
     end
 
-    it 'does nothing if the supplied signature has no petition' do
+    it "does nothing if the supplied signature has no petition" do
       signature.petition = nil
       expect {
         described_class.record_new_signature_for(signature)
       }.not_to change(described_class, :count)
     end
 
-    it 'does nothing if the supplied signature has no constituency_id' do
+    it "does nothing if the supplied signature has no constituency_id" do
       signature.constituency_id = nil
       expect {
         described_class.record_new_signature_for(signature)
       }.not_to change(described_class, :count)
     end
 
-    it 'does nothing if the supplied signature is not validated?' do
+    it "does nothing if the supplied signature is not validated?" do
       signature.state = Signature::PENDING_STATE
       expect {
         described_class.record_new_signature_for(signature)
       }.not_to change(described_class, :count)
     end
 
-    it 'creates a new instance and sets the count to 1 if nothing exists already' do
+    it "creates a new instance and sets the count to 1 if nothing exists already" do
       expect {
         described_class.record_new_signature_for(signature)
       }.to change(described_class, :count).by(1)
       expect(described_class.for(petition, constituency_id).signature_count).to eq 1
     end
 
-    it 'increments the signature_count of the existing instance by 1' do
+    it "increments the signature_count of the existing instance by 1" do
       existing = described_class.for(signature.petition, signature.constituency_id)
       existing.update_column(:signature_count, 20)
 

--- a/spec/models/debate_outcome_spec.rb
+++ b/spec/models/debate_outcome_spec.rb
@@ -5,18 +5,20 @@ RSpec.describe DebateOutcome, type: :model do
     expect(FactoryGirl.build(:debate_outcome)).to be_valid
   end
 
-  describe 'petition' do
+  describe "associations" do
     it { is_expected.to belong_to(:petition).touch(true) }
   end
 
-  context "validations" do
+  describe "indexes" do
+    it { is_expected.to have_db_index([:petition_id]).unique }
+    it { is_expected.to have_db_index([:petition_id, :debated_on]) }
+  end
+
+  describe "validations" do
     subject { FactoryGirl.build(:debate_outcome) }
 
     it { is_expected.to validate_presence_of(:debated_on) }
-
     it { is_expected.to validate_presence_of(:petition) }
-    it { is_expected.to validate_uniqueness_of(:petition_id) }
-
     it { is_expected.to validate_length_of(:transcript_url).is_at_most(500) }
     it { is_expected.to validate_length_of(:video_url).is_at_most(500) }
   end


### PR DESCRIPTION
Rails 4.2 added built-in support for foreign keys and referential integrity so we should take advantage of this to ensure that our database remains consistent even under heavy load.