### PR TITLE
Add a page title locale key for awaiting response

### DIFF
--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -5,6 +5,7 @@ en-GB:
       open: "Open petitions"
       closed: "Closed petitions"
       rejected: "Rejected petitions"
+      awaiting_response: "Petitions awaiting a Government response"
       with_response: "Petitions with a Government response"
       with_debate_outcome: "Petitions debated in Parliament"
 


### PR DESCRIPTION
When the list of petitions awaiting a reponse was added in e5a2d1a it was missing a key in the config/locales/petitions.en-GB.yml file for the page title - this commit adds that missing key.