### PR TITLE
Email signatories with details of debate schedule

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -53,6 +53,7 @@ class Admin::PetitionsController < Admin::AdminController
   def update_scheduled_debate_date
     fetch_petition_for_scheduled_debate_date
     if @petition.update(update_scheduled_debate_date_params)
+      EmailDebateScheduledJob.run_later_tonight(@petition)
       redirect_to admin_petition_path(@petition), notice: "Scheduled debate date was successfully updated."
     else
       render :edit_scheduled_debate_date

--- a/app/jobs/email_debate_scheduled_job.rb
+++ b/app/jobs/email_debate_scheduled_job.rb
@@ -1,0 +1,19 @@
+class EmailDebateScheduledJob < EmailPetitionSignatories::Job
+  def self.run_later_tonight(petition)
+    petition.set_email_requested_at_for('debate_scheduled', to: Time.current)
+    super(petition, petition.get_email_requested_at_for('debate_scheduled'))
+  end
+
+  def perform(petition, requested_at_string, mailer = PetitionMailer.name, threshold_logger = nil)
+    @mailer = mailer.constantize
+    worker(petition, requested_at_string, threshold_logger).do_work!
+  end
+
+  def timestamp_name
+    'debate_scheduled'
+  end
+
+  def create_email(petition, signature)
+    @mailer.notify_signer_of_debate_scheduled(petition, signature)
+  end
+end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -72,6 +72,15 @@ class PetitionMailer < ApplicationMailer
     )
   end
 
+  def notify_signer_of_debate_scheduled(petition, signature)
+    @petition = petition
+    @signature = signature
+    mail(
+      subject: subject_for(:notify_signer_of_debate_scheduled),
+      to: @signature.email
+    )
+  end
+
   private
 
   def subject_for(key, options = {})

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -1,0 +1,12 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>
+  A petition you've supported will be debated by parliament. Please find a link to the debate on the petition
+  <%= link_to nil, petition_url(@signature.petition) %>
+</p>
+
+<p>Thanks,</p>
+
+<p><%= t("petitions.emails.signoff_prefix") %> <%= link_to nil, home_url %></p>
+
+<p>Don't want to receive any more emails regarding this petition? Unsubscribe by clicking <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -1,0 +1,10 @@
+Dear <%= @signature.name %>,
+
+A petition you've supported will be debated by parliament. Please find a link to the debate on the petition
+<%= petition_url(@signature.petition) %>
+
+Thanks,
+
+<%= t("petitions.emails.signoff_prefix") %> <%= home_url %>
+
+Don't want to receive any more emails regarding this petition? Unsubscribe by clicking <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -46,6 +46,8 @@ en-GB:
           Parliament petitions - It's time to get sponsors to support your petition
         notify_signer_of_debate_outcome: |-
           Parliament petitions - The petition '%{action}' has been debated
+        notify_signer_of_debate_scheduled: |-
+          HM Government & Parliament Petitions: A debate has been scheduled for the petition '%{action}' you've supported.
       signoff_prefix: "HM Government & Parliament Petitions"
 
     waiting_for_response_in_words:

--- a/db/migrate/20150619133502_add_debate_scheduled_to_email_requested_receipt.rb
+++ b/db/migrate/20150619133502_add_debate_scheduled_to_email_requested_receipt.rb
@@ -1,0 +1,5 @@
+class AddDebateScheduledToEmailRequestedReceipt < ActiveRecord::Migration
+  def change
+    add_column :email_requested_receipts, :debate_scheduled, :timestamp
+  end
+end

--- a/db/migrate/20150619134335_add_debate_scheduled_to_email_sent_receipt.rb
+++ b/db/migrate/20150619134335_add_debate_scheduled_to_email_sent_receipt.rb
@@ -1,0 +1,5 @@
+class AddDebateScheduledToEmailSentReceipt < ActiveRecord::Migration
+  def change
+    add_column :email_sent_receipts, :debate_scheduled, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -229,7 +229,8 @@ CREATE TABLE email_requested_receipts (
     government_response timestamp without time zone,
     debate_outcome timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    debate_scheduled timestamp without time zone
 );
 
 
@@ -946,4 +947,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150619075903');
 INSERT INTO schema_migrations (version) VALUES ('20150619090833');
 
 INSERT INTO schema_migrations (version) VALUES ('20150621200307');
+
+INSERT INTO schema_migrations (version) VALUES ('20150619133502');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -263,7 +263,8 @@ CREATE TABLE email_sent_receipts (
     government_response timestamp without time zone,
     debate_outcome timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    debate_scheduled timestamp without time zone
 );
 
 
@@ -949,4 +950,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150619090833');
 INSERT INTO schema_migrations (version) VALUES ('20150621200307');
 
 INSERT INTO schema_migrations (version) VALUES ('20150619133502');
+
+INSERT INTO schema_migrations (version) VALUES ('20150619134335');
 

--- a/features/admin/moderator_updates_petition_scheduled_debate_date.feature
+++ b/features/admin/moderator_updates_petition_scheduled_debate_date.feature
@@ -1,7 +1,7 @@
 Feature: Moderator updates petition scheduled debate date
 
   Scenario: Updating petition scheduled debate date
-    Given a petition "More money for charities" exists with a signature count of 150000
+    Given an open petition "More money for charities" with some signatures
     And I am logged in as a moderator
     When I view all petitions
     And I follow "More money for charities"
@@ -9,3 +9,5 @@ Feature: Moderator updates petition scheduled debate date
     And I fill in "Scheduled debate date" with "06/12/2015"
     And I press "Publish and Send Email"
     Then I should see "Scheduled debate date was successfully updated."
+    And the petition creator should have been emailed about the scheduled debate
+    And all the signatories of the petition should have been emailed about the scheduled debate

--- a/features/step_definitions/debate_scheduled_steps.rb
+++ b/features/step_definitions/debate_scheduled_steps.rb
@@ -1,0 +1,23 @@
+Then(/^the petition creator should have been emailed about the scheduled debate$/) do
+  @petition.reload
+  steps %Q(
+    Then "#{@petition.creator_signature.email}" should receive an email
+    When they open the email
+    Then they should see "A petition you've supported will be debated by parliament" in the email body
+    When they click the first link in the email
+    Then I should be on the petition page for "#{@petition.action}"
+  )
+end
+
+Then(/^all the signatories of the petition should have been emailed about the scheduled debate$/) do
+  @petition.reload
+  @petition.signatures.notify_by_email.validated.where.not(id: @petition.creator_signature.id).each do |signatory|
+    steps %Q(
+      Then "#{signatory.email}" should receive an email
+      When they open the email
+      Then they should see "A petition you've supported will be debated by parliament" in the email body
+      When they click the first link in the email
+      Then I should be on the petition page for "#{@petition.action}"
+    )
+  end
+end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -46,8 +46,8 @@ Given /^(\d+) petitions exist with a signature count of (\d+)$/ do |number, coun
 end
 
 Given /^a petition "([^"]*)" exists with a signature count of (\d+)$/ do |petition_action, count|
-    p = FactoryGirl.create(:open_petition, action: petition_action)
-    p.update_attribute(:signature_count, count)
+    @petition = FactoryGirl.create(:open_petition, action: petition_action)
+    @petition.update_attribute(:signature_count, count)
 end
 
 Given(/^an open petition "(.*?)" with response "(.*?)" and response summary "(.*?)"$/) do |petition_action, response, response_summary|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -139,6 +139,10 @@ FactoryGirl.define do
     end
   end
 
+  trait :scheduled_for_debate do
+    scheduled_debate_date 10.days.from_now
+  end
+
   factory :signature do
     sequence(:name) {|n| "Jo Public #{n}" }
     sequence(:email) {|n| "jo#{n}@public.com" }

--- a/spec/jobs/email_debate_scheduled_job_spec.rb
+++ b/spec/jobs/email_debate_scheduled_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+include ActiveJob::TestHelper
+
+RSpec.describe EmailDebateScheduledJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:open_petition) }
+  let(:signature) { FactoryGirl.create(:validated_signature, :petition => petition) }
+
+  let(:mailer) { double.as_null_object }
+  let(:logger) { double.as_null_object }
+
+  before do
+    petition.set_email_requested_at_for('debate_scheduled', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :count => 0)
+  end
+
+  def perform_job(requested_at = email_requested_at)
+    described_class.perform_now(petition, requested_at.getutc.iso8601, mailer, logger)
+  end
+
+  it "sends the notify_signer_of_debate_scheduled emails to each signatory of a petition" do
+    expect(mailer).to receive(:notify_signer_of_debate_scheduled).with(petition, signature).and_return(mailer)
+    perform_job
+  end
+
+  it "marks the signature with the 'debate_scheduled' last emailing time" do
+    expect(signature).to receive(:set_email_sent_at_for).with('debate_scheduled', to: email_requested_at)
+    perform_job
+  end
+
+  it 'uses a EmailPetitionSignatories::Worker to do the work' do
+    worker = double
+    expect(worker).to receive(:do_work!)
+    expect(EmailPetitionSignatories::Worker).to receive(:new).with(instance_of(described_class), petition, email_requested_at.getutc.iso8601, anything).and_return worker
+    perform_job
+  end
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -185,4 +185,32 @@ RSpec.describe PetitionMailer, type: :mailer do
       expect(mail.body.encoded).to match(%r[https://www.example.com/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
     end
   end
+
+  describe 'notifying signature of debate scheduled' do
+    let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, action: "Allow organic vegetable vans to use red diesel") }
+    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: 'Laura Palmer', email: 'laura@red-room.example.com') }
+    subject(:mail) { described_class.notify_signer_of_debate_scheduled(petition, signature) }
+
+    it "has the correct subject" do
+      expect(mail.subject).to eq("HM Government & Parliament Petitions: A debate has been scheduled for the petition '#{petition.action}' you've supported.")
+    end
+
+    it "addresses the signatory by name" do
+      expect(mail.body.encoded).to match(/Dear Laura Palmer\,/)
+    end
+
+    it "sends it only to the signatory" do
+      expect(mail.to).to eq(%w[laura@red-room.example.com])
+      expect(mail.cc).to be_blank
+      expect(mail.bcc).to be_blank
+    end
+
+    it "includes a link to the petition page" do
+      expect(mail.body.encoded).to match(%r[https://www.example.com/petitions/#{petition.id}])
+    end
+
+    it 'includes an unsubscribe link' do
+      expect(mail.body.encoded).to match(%r[https://www.example.com/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+    end
+  end
 end


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/96655906

Created the new job, mailer and updated the EmailSentReceipt and EmailRequestedReceipt models with the new 'debate_scheduled' fields. Using the same workflow as the previous debate_outcome implementation.