### PR TITLE
When showing a petition don't show no "more details" when there are none

### DIFF
--- a/app/views/petitions/_petition_show.html.erb
+++ b/app/views/petitions/_petition_show.html.erb
@@ -7,8 +7,13 @@
   <%= petition.action %>
 </h1>
 
-<p><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></p>
-<p><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></p>
+<div><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></div>
+<% unless petition.additional_details.blank? %>
+  <details>
+    <summary><span class="summary">More details</span></summary>
+    <div><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></div>
+  </details>
+<% end %>
 
 <%# Signable #%>
 <% if petition.can_be_signed? -%>

--- a/app/views/petitions/_rejected_petition_show.html.erb
+++ b/app/views/petitions/_rejected_petition_show.html.erb
@@ -3,8 +3,13 @@
   <%= petition.action %>
 </h1>
 
-<p><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></p>
-<p><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></p>
+<div><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></div>
+<% unless petition.additional_details.blank? %>
+  <details>
+    <summary><span class="summary">More details</span></summary>
+    <div><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></div>
+  </details>
+<% end %>
 
 <p class="flash-notice">This petition was rejected</p>
 

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -6,14 +6,13 @@
 
 <div class="panel-indent">
   <h1><%= petition.action %></h1>
-  <p><%= petition.background %></p>
-  <details>
-    <summary><span class="summary">More details</span></summary>
-    <div>
-      <p><%= petition.additional_details %></p>
-    </div>
-  </details>
-
+  <div><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></div>
+  <% unless petition.additional_details.blank? %>
+    <details>
+      <summary><span class="summary">More details</span></summary>
+      <div><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></div>
+    </details>
+  <% end %>
 </div>
 
 


### PR DESCRIPTION
We also standardise how we were showing the additional_details to always:

1. use the ``<details>/<summary>`` tags pattern
2. push the content through simple_format and autolink

For bug fix on: https://www.pivotaltracker.com/story/show/97178596