### PR TITLE
Amending footer links to include all and start petitions

### DIFF
--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - Petitions" } %>
+<% content_for(:page_title) { "Start a petition - Petitions" } %>
 <h1 class="page-title">What action would you like the government to take?</h1>
 
 <form method="get" action="/petitions/check_results">

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - Petitions" } %>
+<% content_for(:page_title) { "Start a petition - Petitions" } %>
 
 <%= link_to check_petitions_path, class: "back-page" do %>
   &#9664; Back
@@ -6,8 +6,8 @@
 
 <% if @petitions.empty? %>
   <h1 class="page-title">We did not find any similar petitions</h1>
-  <p>We didn't find any existing petitions that match your subject, click the 'Create a new petition' button to continue.</p>
-  <% create_button_text = "Create a new petition" -%>
+  <p>We didn't find any existing petitions that match your subject, click the 'Start a petition' button to continue.</p>
+  <% create_button_text = "Start a petition" -%>
 <% else %>
   <h1 class="page-title">We found some similar petitions</h1>
   <p>If there's already a petition on the same topic, your petition is likely to be rejected</p>

--- a/app/views/petitions/create/_petition_details_ui.html.erb
+++ b/app/views/petitions/create/_petition_details_ui.html.erb
@@ -2,11 +2,9 @@
   &#9664; Back
 <% end %>
 
-<h1 class="page-title">Create petition</h1>
+<h1 class="page-title">Start a petition</h1>
 
 <%= render 'petitions/create/error_summary', f: f %>
-
-<p>Before you start - your petition must meet our <%= link_to 'guidelines', help_path(anchor: 'creating-a-petition') %></p>
 
 <%= form_row :for => [petition, :action] do %>
   <%= f.label :action, class: 'form-label' do %>

--- a/app/views/petitions/create/_replay_email_ui.html.erb
+++ b/app/views/petitions/create/_replay_email_ui.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - Petitions" } %>
+<% content_for(:page_title) { "Start a petition - Petitions" } %>
 
 <%= f.submit raw('&#9664; Back'), :name => 'move:back', :class => 'back-page' %>
 

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - Petitions" } %>
+<% content_for(:page_title) { "Start a petition - Petitions" } %>
 
 <%= f.submit raw('&#9664; Back'), :name => 'move:back', :class => 'back-page' %>
 

--- a/app/views/petitions/new.html.erb
+++ b/app/views/petitions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title) { "Create a new petition - Petitions" } %>
+<% content_for(:page_title) { "Start a petition - Petitions" } %>
 
 <%= form_for @stage_manager.stage_object, :url => create_petition_path do |f| %>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,8 +7,12 @@
         t.links_to home_path
       end
       n.add_tab do |t|
-        t.named 'Help'
-        t.links_to help_path
+        t.named 'All petitions'
+        t.links_to petitions_path
+      end
+      n.add_tab do |t|
+        t.named 'Start a petition'
+        t.links_to check_petitions_path
       end
       n.add_tab do |t|
         t.named 'Feedback'

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,6 +15,10 @@
         t.links_to check_petitions_path
       end
       n.add_tab do |t|
+        t.named 'Help'
+        t.links_to help_path
+      end
+      n.add_tab do |t|
         t.named 'Feedback'
         t.links_to feedback_path
       end

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -35,9 +35,9 @@
 </section>
 
 <section class="section-panel">
-  <h2>Start a new petition</h2>
+  <h2>Start a petition</h2>
   <p>Anyone can start a petition as long as they are a British citizen or UK resident</p>
-  <%= link_to "Start a new petition", check_petitions_path, :class => 'button' %>
+  <%= link_to "Start a petition", check_petitions_path, :class => 'button' %>
 </section>
 
 <form method="get" action="/search" class="search-form">

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -6,7 +6,7 @@ Feature: As Charlie
 Scenario: Charlie has to search for a petition before creating one
   Given a petition "Rioters should loose benefits"
   Given I am on the home page
-  When I follow "Start a petition"
+  When I follow "Start a petition" within ".//main"
   Then I should be asked to search for a new petition
   When I check for similar petitions
   Then I should see a list of existing petitions I can sign
@@ -17,7 +17,7 @@ Scenario: Charlie has to search for a petition before creating one
 @search
 Scenario: Charlie cannot craft an xss attack when searching for petitions
   Given I am on the home page
-  When I follow "Start a petition"
+  When I follow "Start a petition" within ".//main"
   Then I fill in "q" with "'onmouseover='alert(1)'"
   When I press "Check for similar petitions"
   Then the markup should be valid

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -6,7 +6,7 @@ Feature: As Charlie
 Scenario: Charlie has to search for a petition before creating one
   Given a petition "Rioters should loose benefits"
   Given I am on the home page
-  When I follow "Start a new petition"
+  When I follow "Start a petition"
   Then I should be asked to search for a new petition
   When I check for similar petitions
   Then I should see a list of existing petitions I can sign
@@ -17,7 +17,7 @@ Scenario: Charlie has to search for a petition before creating one
 @search
 Scenario: Charlie cannot craft an xss attack when searching for petitions
   Given I am on the home page
-  When I follow "Start a new petition"
+  When I follow "Start a petition"
   Then I fill in "q" with "'onmouseover='alert(1)'"
   When I press "Check for similar petitions"
   Then the markup should be valid

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -249,7 +249,7 @@ end
 When /^I start a new petition/ do
   steps %Q(
     Given I am on the new petition page
-    Then I should see "Create a new petition - Petitions" in the browser page title
+    Then I should see "Start a petition - Petitions" in the browser page title
     And I should be connected to the server via an ssl connection
   )
 end


### PR DESCRIPTION
Fixed the inconsistent labelling of create/start a/start a new petition etc

https://www.pivotaltracker.com/story/show/97506102