### PR TITLE
Don't show petition creator on closed petitions

### DIFF
--- a/app/views/petitions/_petition_show.html.erb
+++ b/app/views/petitions/_petition_show.html.erb
@@ -41,7 +41,9 @@
   <li class="meta-deadline">
     <span class="label">Deadline</span> <%= short_date_format petition.closed_at %>
   </li>
-  <li class="meta-created-by">
-    <span class="label">Created by</span> <%= petition.creator_signature.name %>
-  </li>
+  <% unless petition.closed? %>
+    <li class="meta-created-by">
+      <span class="label">Created by</span> <%= petition.creator_signature.name %>
+    </li>
+  <% end %>
 </ul>

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -185,6 +185,10 @@ Then /^I should see submitted date$/ do
   expect(page).to have_css("li", :text =>  "Date submitted " + @petition.created_at.strftime("%e %B %Y").squish)
 end
 
+Then(/^I should not see the petition creator$/) do
+  expect(page).not_to have_css("li.meta-created-by", :text => "Created by " + @petition.creator_signature.name)
+end
+
 Then /^I should see the reason for rejection$/ do
   @petition.reload
 

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -56,6 +56,11 @@ Feature: Suzie views a petition
     When I view the petition
     Then I should see "This petition is now closed"
 
+  Scenario: Suzie does not see the creator when viewing a closed petition
+    Given a petition "Spend more money on Defence" has been closed
+    When I view the petition
+    Then I should not see the petition creator
+
   Scenario: Suzie sees information about the outcomes when viewing a debated petition
     Given a petition "Ban Badger Baiting" has been debated 2 days ago
     When I view the petition


### PR DESCRIPTION
To prevent future embarrassment for petition creators, once a petition has closed then no longer show their name. An example of this would be am employer searching on a potential employee's name and getting back a petition they created 2-3 years ago as one of the top results.

https://www.pivotaltracker.com/story/show/97192450