### PR TITLE
Fix signature number after signing

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -57,8 +57,8 @@ class Signature < ActiveRecord::Base
   # = Methods =
   attr_accessor :uk_citizenship
 
-  def self.signature_number(validated_at)
-    where(arel_table[:validated_at].lt(validated_at)).count + 1
+  def self.signature_number(petition_id, validated_at)
+    where('petition_id = ? AND validated_at < ?', petition_id, validated_at).count + 1
   end
 
   def email=(value)
@@ -67,7 +67,7 @@ class Signature < ActiveRecord::Base
 
   def number
     if validated_at?
-      @number ||= self.class.signature_number(validated_at)
+      @number ||= self.class.signature_number(petition_id, validated_at)
     end
   end
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -318,17 +318,43 @@ RSpec.describe Signature, type: :model do
       end
     end
 
-    before do
-      petition.signatures.each do |signature|
-        signature.validate!
-      end
+    let(:other_attributes) { FactoryGirl.attributes_for(:petition) }
+    let(:other_creator) { FactoryGirl.create(:pending_signature) }
+    let(:other_petition) do
+      Petition.create(other_attributes) do |petition|
+        petition.creator_signature = other_creator
 
+        5.times do
+          petition.signatures << FactoryGirl.create(:pending_signature)
+        end
+      end
+    end
+
+    before do
+      petition.signatures.each { |s| s.validate! }
       petition.publish!
+
+      other_petition.signatures.each { |s| s.validate! }
+      other_petition.publish!
     end
 
     it "returns the signature number" do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
+
+      expect(petition.signature_count).to eq(7)
+      expect(signature.number).to eq(7)
+    end
+
+    it "is scoped to the petition" do
+      other_signature = FactoryGirl.create(:pending_signature, petition: other_petition)
+      other_signature.validate!
+
+      signature = FactoryGirl.create(:pending_signature, petition: petition)
+      signature.validate!
+
+      expect(other_petition.signature_count).to eq(7)
+      expect(other_signature.number).to eq(7)
 
       expect(petition.signature_count).to eq(7)
       expect(signature.number).to eq(7)


### PR DESCRIPTION
Commit 6a5849d added a class method that should've been scoped to a petition when calculating the number of signature. This adds that scope and a regression test to ensure that it doesn't reoccur.

https://www.pivotaltracker.com/story/show/96865510