### PR TITLE
Markup improvements

### DIFF
--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -18,12 +18,12 @@
 
 <div class="row">
   <label>Petition background:</label>
-  <p class="text_block"><%= raw auto_link(h(@petition.background), :html => { :target => '_blank' }) %></p>
+  <p class="text_block"><%= raw auto_link(h(@petition.background)) %></p>
 </div>
 
 <div class="row">
   <label>Petition additional details:</label>
-  <p class="text_block"><%= raw auto_link(h(@petition.additional_details), :html => { :target => '_blank' }) %></p>
+  <p class="text_block"><%= raw auto_link(h(@petition.additional_details)) %></p>
 </div>
 
 <div class="row">

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -18,12 +18,12 @@
 
 <div class="row">
   <label>Petition background:</label>
-  <p class="text_block"><%= raw auto_link(h(@petition.background)) %></p>
+  <p class="text_block"><%= auto_link(h(@petition.background)) %></p>
 </div>
 
 <div class="row">
   <label>Petition additional details:</label>
-  <p class="text_block"><%= raw auto_link(h(@petition.additional_details)) %></p>
+  <p class="text_block"><%= auto_link(h(@petition.additional_details)) %></p>
 </div>
 
 <div class="row">

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -12,19 +12,19 @@
 <div class="petition_view">
   <div class="content">
     <h1><%= @petition.title %></h1>
-    <div class="description"><%= raw auto_link(simple_format(h(@petition.description)), :html => { :target => '_blank' }) %></div>
+    <div class="description"><%= raw auto_link(simple_format(h(@petition.description))) %></div>
 
     <% if @petition.rejected? -%>
       <div class="petition_rejected">
         <h2>This petition has been rejected with the following reason given:</h2>
-        <div class"reason"><%= raw auto_link(simple_format(h(@petition.reason_for_rejection)), :html => { :target => '_blank' }) %></div>
+        <div class"reason"><%= raw auto_link(simple_format(h(@petition.reason_for_rejection))) %></div>
       </div>
     <% end -%>
 
     <% if @petition.response? -%>
       <div class="petition_response">
         <h2>This petition has received the following response:</h2>
-        <%= raw auto_link(simple_format(h(@petition.response), :class => 'response'), :html => { :target => '_blank' }) %>
+        <%= raw auto_link(simple_format(h(@petition.response), :class => 'response')) %>
       </div>
     <% end -%>
   </div>

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -12,19 +12,19 @@
 <div class="petition_view">
   <div class="content">
     <h1><%= @petition.title %></h1>
-    <div class="description"><%= auto_link(simple_format(h(@petition.description))) %></div>
+    <div class="description"><%= auto_link(simple_format(h(@petition.description)), html: { rel: 'nofollow' }) %></div>
 
     <% if @petition.rejected? -%>
       <div class="petition_rejected">
         <h2>This petition has been rejected with the following reason given:</h2>
-        <div class"reason"><%= auto_link(simple_format(h(@petition.reason_for_rejection))) %></div>
+        <div class"reason"><%= auto_link(simple_format(h(@petition.reason_for_rejection)), html: { rel: 'nofollow' }) %></div>
       </div>
     <% end -%>
 
     <% if @petition.response? -%>
       <div class="petition_response">
         <h2>This petition has received the following response:</h2>
-        <%= auto_link(simple_format(h(@petition.response), :class => 'response')) %>
+        <%= auto_link(simple_format(h(@petition.response), class: 'response'), html: { rel: 'nofollow' }) %>
       </div>
     <% end -%>
   </div>

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -12,19 +12,19 @@
 <div class="petition_view">
   <div class="content">
     <h1><%= @petition.title %></h1>
-    <div class="description"><%= raw auto_link(simple_format(h(@petition.description))) %></div>
+    <div class="description"><%= auto_link(simple_format(h(@petition.description))) %></div>
 
     <% if @petition.rejected? -%>
       <div class="petition_rejected">
         <h2>This petition has been rejected with the following reason given:</h2>
-        <div class"reason"><%= raw auto_link(simple_format(h(@petition.reason_for_rejection))) %></div>
+        <div class"reason"><%= auto_link(simple_format(h(@petition.reason_for_rejection))) %></div>
       </div>
     <% end -%>
 
     <% if @petition.response? -%>
       <div class="petition_response">
         <h2>This petition has received the following response:</h2>
-        <%= raw auto_link(simple_format(h(@petition.response), :class => 'response')) %>
+        <%= auto_link(simple_format(h(@petition.response), :class => 'response')) %>
       </div>
     <% end -%>
   </div>

--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -2,7 +2,7 @@
 <h1 class="page-title">Petitions in <%= @constituency.name %></h1>
 
 <% if @constituency.mp %>
-  <p>Your MP is <%= link_to @constituency.mp.name, @constituency.mp.url %></p>
+  <p>Your MP is <%= link_to @constituency.mp.name, @constituency.mp.url, rel: 'external' %></p>
 <% end %>
 
 <div class="section-panel local-petitions">

--- a/app/views/petition_mailer/petition_rejected.html.erb
+++ b/app/views/petition_mailer/petition_rejected.html.erb
@@ -3,7 +3,7 @@
 <%= @petition.rejection_description.html_safe %>
 
 <% if @petition.rejection_text.present? %>
-<p><%= raw auto_link(h(@petition.rejection_text)) %></p>
+<p><%= auto_link(h(@petition.rejection_text)) %></p>
 <% end %>
 
 <% if @petition.state != Petition::HIDDEN_STATE -%>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -5,10 +5,10 @@
     <section class="debate-outcome">
       <p>This topic was debated on <%= short_date_format petition.debate_outcome.debated_on %></p>
       <% if petition.debate_outcome.video_url? -%>
-        <p><%= link_to 'Watch the debate', petition.debate_outcome.video_url %></p>
+        <p><%= link_to 'Watch the debate', petition.debate_outcome.video_url, rel: 'external' %></p>
       <% end -%>
       <% if petition.debate_outcome.transcript_url? -%>
-        <p><%= link_to 'Read the transcript', petition.debate_outcome.transcript_url %></p>
+        <p><%= link_to 'Read the transcript', petition.debate_outcome.transcript_url, rel: 'external' %></p>
       <% end -%>
       <% if petition.debate_outcome.overview? -%>
         <%= raw auto_link(simple_format( h(petition.debate_outcome.overview) ), :html => { :target => '_blank' }) %>
@@ -17,7 +17,7 @@
   <% elsif petition.scheduled_debate_date.present? %>
     <p class="about-item-scheduled-debate-date">
       This petition is scheduled for debate on <%= short_date_format(petition.scheduled_debate_date) %>.
-      You'll be able to watch online at <%= link_to("parliamentlive.tv", "http://parliamentlive.tv") %>
+      You'll be able to watch online at <a href="http://parliamentlive.tv" rel="external">parliamentlive.tv</a>
     </p>
   <% else -%>
     <p>If a petition gets 100,000 signatures, it will be considered for debate in Parliament</p>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -11,7 +11,7 @@
         <p><%= link_to 'Read the transcript', petition.debate_outcome.transcript_url, rel: 'external' %></p>
       <% end -%>
       <% if petition.debate_outcome.overview? -%>
-        <%= raw auto_link(simple_format( h(petition.debate_outcome.overview) )) %>
+        <%= auto_link(simple_format( h(petition.debate_outcome.overview) )) %>
       <% end -%>
     </section>
   <% elsif petition.scheduled_debate_date.present? %>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -11,7 +11,7 @@
         <p><%= link_to 'Read the transcript', petition.debate_outcome.transcript_url, rel: 'external' %></p>
       <% end -%>
       <% if petition.debate_outcome.overview? -%>
-        <%= raw auto_link(simple_format( h(petition.debate_outcome.overview) ), :html => { :target => '_blank' }) %>
+        <%= raw auto_link(simple_format( h(petition.debate_outcome.overview) )) %>
       <% end -%>
     </section>
   <% elsif petition.scheduled_debate_date.present? %>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -11,7 +11,7 @@
         <p><%= link_to 'Read the transcript', petition.debate_outcome.transcript_url, rel: 'external' %></p>
       <% end -%>
       <% if petition.debate_outcome.overview? -%>
-        <%= auto_link(simple_format( h(petition.debate_outcome.overview) )) %>
+        <%= auto_link(simple_format(h(petition.debate_outcome.overview)), html: { rel: 'nofollow' }) %>
       <% end -%>
     </section>
   <% elsif petition.scheduled_debate_date.present? %>

--- a/app/views/petitions/_petition_show.html.erb
+++ b/app/views/petitions/_petition_show.html.erb
@@ -7,11 +7,11 @@
   <%= petition.action %>
 </h1>
 
-<div><%= auto_link(simple_format(h(petition.background))) %></div>
+<div><%= auto_link(simple_format(h(petition.background)), html: { rel: 'nofollow' }) %></div>
 <% unless petition.additional_details.blank? %>
   <details>
     <summary><span class="summary">More details</span></summary>
-    <div><%= auto_link(simple_format(h(petition.additional_details))) %></div>
+    <div><%= auto_link(simple_format(h(petition.additional_details)), html: { rel: 'nofollow' }) %></div>
   </details>
 <% end %>
 

--- a/app/views/petitions/_petition_show.html.erb
+++ b/app/views/petitions/_petition_show.html.erb
@@ -7,11 +7,11 @@
   <%= petition.action %>
 </h1>
 
-<div><%= raw auto_link(simple_format(h(petition.background))) %></div>
+<div><%= auto_link(simple_format(h(petition.background))) %></div>
 <% unless petition.additional_details.blank? %>
   <details>
     <summary><span class="summary">More details</span></summary>
-    <div><%= raw auto_link(simple_format(h(petition.additional_details))) %></div>
+    <div><%= auto_link(simple_format(h(petition.additional_details))) %></div>
   </details>
 <% end %>
 

--- a/app/views/petitions/_petition_show.html.erb
+++ b/app/views/petitions/_petition_show.html.erb
@@ -7,11 +7,11 @@
   <%= petition.action %>
 </h1>
 
-<div><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></div>
+<div><%= raw auto_link(simple_format(h(petition.background))) %></div>
 <% unless petition.additional_details.blank? %>
   <details>
     <summary><span class="summary">More details</span></summary>
-    <div><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></div>
+    <div><%= raw auto_link(simple_format(h(petition.additional_details))) %></div>
   </details>
 <% end %>
 

--- a/app/views/petitions/_rejected_petition_show.html.erb
+++ b/app/views/petitions/_rejected_petition_show.html.erb
@@ -3,11 +3,11 @@
   <%= petition.action %>
 </h1>
 
-<div><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></div>
+<div><%= raw auto_link(simple_format(h(petition.background))) %></div>
 <% unless petition.additional_details.blank? %>
   <details>
     <summary><span class="summary">More details</span></summary>
-    <div><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></div>
+    <div><%= raw auto_link(simple_format(h(petition.additional_details))) %></div>
   </details>
 <% end %>
 

--- a/app/views/petitions/_rejected_petition_show.html.erb
+++ b/app/views/petitions/_rejected_petition_show.html.erb
@@ -3,11 +3,11 @@
   <%= petition.action %>
 </h1>
 
-<div><%= auto_link(simple_format(h(petition.background))) %></div>
+<div><%= auto_link(simple_format(h(petition.background)), html: { rel: 'nofollow' }) %></div>
 <% unless petition.additional_details.blank? %>
   <details>
     <summary><span class="summary">More details</span></summary>
-    <div><%= auto_link(simple_format(h(petition.additional_details))) %></div>
+    <div><%= auto_link(simple_format(h(petition.additional_details)), html: { rel: 'nofollow' }) %></div>
   </details>
 <% end %>
 

--- a/app/views/petitions/_rejected_petition_show.html.erb
+++ b/app/views/petitions/_rejected_petition_show.html.erb
@@ -3,11 +3,11 @@
   <%= petition.action %>
 </h1>
 
-<div><%= raw auto_link(simple_format(h(petition.background))) %></div>
+<div><%= auto_link(simple_format(h(petition.background))) %></div>
 <% unless petition.additional_details.blank? %>
   <details>
     <summary><span class="summary">More details</span></summary>
-    <div><%= raw auto_link(simple_format(h(petition.additional_details))) %></div>
+    <div><%= auto_link(simple_format(h(petition.additional_details))) %></div>
   </details>
 <% end %>
 

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -3,13 +3,13 @@
   <%# Has response #%>
   <% if petition.response_summary.present? -%>
     <h2>This petition has received the following response:</h2>
-    <%= raw auto_link(simple_format( h(petition.response_summary) )) %>
+    <%= auto_link(simple_format( h(petition.response_summary) )) %>
 
     <% if petition.response.present? -%>
       <details>
         <summary><span class="summary">Read the response in full</span></summary>
         <div class="panel-indent">
-          <%= raw auto_link(simple_format( h(petition.response) )) %>
+          <%= auto_link(simple_format( h(petition.response) )) %>
         </div>
       </details>
     <% end -%>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -3,13 +3,13 @@
   <%# Has response #%>
   <% if petition.response_summary.present? -%>
     <h2>This petition has received the following response:</h2>
-    <%= auto_link(simple_format( h(petition.response_summary) )) %>
+    <%= auto_link(simple_format(h(petition.response_summary)), html: { rel: 'nofollow' }) %>
 
     <% if petition.response.present? -%>
       <details>
         <summary><span class="summary">Read the response in full</span></summary>
         <div class="panel-indent">
-          <%= auto_link(simple_format( h(petition.response) )) %>
+          <%= auto_link(simple_format(h(petition.response)), html: { rel: 'nofollow' }) %>
         </div>
       </details>
     <% end -%>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -3,13 +3,13 @@
   <%# Has response #%>
   <% if petition.response_summary.present? -%>
     <h2>This petition has received the following response:</h2>
-    <%= raw auto_link(simple_format( h(petition.response_summary) ), :html => { :target => '_blank' }) %>
+    <%= raw auto_link(simple_format( h(petition.response_summary) )) %>
 
     <% if petition.response.present? -%>
       <details>
         <summary><span class="summary">Read the response in full</span></summary>
         <div class="panel-indent">
-          <%= raw auto_link(simple_format( h(petition.response) ), :html => { :target => '_blank' }) %>
+          <%= raw auto_link(simple_format( h(petition.response) )) %>
         </div>
       </details>
     <% end -%>

--- a/app/views/petitions/_threshold_details.html.erb
+++ b/app/views/petitions/_threshold_details.html.erb
@@ -1,4 +1,4 @@
-<article class="about-petitions <%= local_assigns[:variation] %>">
+<div class="about-petitions <%= local_assigns[:variation] %>">
   <%-
     order = ['response_threshold', 'debate_threshold']
     order.reverse! if petition.debate_outcome.present?
@@ -6,4 +6,4 @@
   <% order.each do |partial_name| -%>
     <%= render "petitions/#{partial_name}", petition: petition %>
   <% end -%>
-</article>
+</div>

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -6,16 +6,14 @@
 
 <div class="panel-indent">
   <h1><%= petition.action %></h1>
-  <div><%= auto_link(simple_format(h(petition.background))) %></div>
+  <div><%= auto_link(simple_format(h(petition.background)), html: { rel: 'nofollow' }) %></div>
   <% unless petition.additional_details.blank? %>
     <details>
       <summary><span class="summary">More details</span></summary>
-      <div><%= auto_link(simple_format(h(petition.additional_details))) %></div>
+      <div><%= auto_link(simple_format(h(petition.additional_details)), html: { rel: 'nofollow' }) %></div>
     </details>
   <% end %>
 </div>
 
-
 <%= f.submit 'This looks good', :name => 'move:next', :class => 'button', :tabindex => increment %>
 <%= f.submit 'Go back and make changes', :name => 'move:back', :class => 'button-secondary', :tabindex => increment %>
-

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -6,11 +6,11 @@
 
 <div class="panel-indent">
   <h1><%= petition.action %></h1>
-  <div><%= raw auto_link(simple_format(h(petition.background)), :html => { :target => '_blank' }) %></div>
+  <div><%= raw auto_link(simple_format(h(petition.background))) %></div>
   <% unless petition.additional_details.blank? %>
     <details>
       <summary><span class="summary">More details</span></summary>
-      <div><%= raw auto_link(simple_format(h(petition.additional_details)), :html => { :target => '_blank' }) %></div>
+      <div><%= raw auto_link(simple_format(h(petition.additional_details))) %></div>
     </details>
   <% end %>
 </div>

--- a/app/views/petitions/create/_replay_petition_ui.html.erb
+++ b/app/views/petitions/create/_replay_petition_ui.html.erb
@@ -6,11 +6,11 @@
 
 <div class="panel-indent">
   <h1><%= petition.action %></h1>
-  <div><%= raw auto_link(simple_format(h(petition.background))) %></div>
+  <div><%= auto_link(simple_format(h(petition.background))) %></div>
   <% unless petition.additional_details.blank? %>
     <details>
       <summary><span class="summary">More details</span></summary>
-      <div><%= raw auto_link(simple_format(h(petition.additional_details))) %></div>
+      <div><%= auto_link(simple_format(h(petition.additional_details))) %></div>
     </details>
   <% end %>
 </div>

--- a/app/views/search/_filter_nav.html.erb
+++ b/app/views/search/_filter_nav.html.erb
@@ -1,5 +1,5 @@
 <nav id="other-search-lists">
-  <h1>Other lists of petitions</h1>
+  <h2>Other lists of petitions</h2>
   <ul>
   <% @petitions.facets.each do |facet, count| %>
     <li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -17,14 +17,14 @@
     end %>
 
     <div class="open-government-licence">
-      <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-      <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+      <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="external license">Open Government Licence</a></p>
+      <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="external license">Open Government Licence v3.0</a>, except where otherwise stated</p>
     </div>
 
     <div class="copyright">
       <span class="graphic graphic-portcullis-large-grey" aria-hidden="true"></span>
       <span class="graphic graphic-crest-large-grey" aria-hidden="true"></span>
-      <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright</a>
+      <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" rel="external">&copy; Crown copyright</a>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_share_petition.html.erb
+++ b/app/views/shared/_share_petition.html.erb
@@ -2,25 +2,25 @@
 <% share_title = petition.action + " - Petitions" -%>
 <ul class="petition-share">
   <li>
-    <%= link_to "http://www.facebook.com/sharer.php?t=#{URI.escape(share_title)}&u=#{URI.escape(petition_url(petition))}" do %>
+    <%= link_to "http://www.facebook.com/sharer.php?t=#{URI.escape(share_title)}&u=#{URI.escape(petition_url(petition))}", rel: 'external' do %>
       <span class="icon icon-share-facebook" aria-hidden="true"></span>
       Facebook
     <% end %>
   </li>
   <li>
-    <%= link_to "mailto:?subject=#{URI.escape(share_title)}&body=#{URI.escape(petition_url(petition))}" do %>
+    <%= link_to "mailto:?subject=#{URI.escape(share_title)}&body=#{URI.escape(petition_url(petition))}", rel: 'external' do %>
       <span class="icon icon-share-email" aria-hidden="true"></span>
       Email
     <% end %>
   </li>
   <li>
-    <%= link_to "http://twitter.com/share?text=#{URI.escape(share_title)}&url=#{URI.escape(petition_url(petition))}" do %>
+    <%= link_to "http://twitter.com/share?text=#{URI.escape(share_title)}&url=#{URI.escape(petition_url(petition))}", rel: 'external' do %>
       <span class="icon icon-share-twitter" aria-hidden="true"></span>
       Twitter
     <% end %>
   </li>
   <li class="petition-share-whatsapp">
-    <%= link_to "whatsapp://send?text=#{URI.escape(share_title + "\n" + petition_url(petition))}" do %>
+    <%= link_to "whatsapp://send?text=#{URI.escape(share_title + "\n" + petition_url(petition))}", rel: 'external' do %>
       <span class="icon icon-share-whatsapp" aria-hidden="true"></span>
       Whatsapp
     <% end %>

--- a/app/views/signatures/signed.html.erb
+++ b/app/views/signatures/signed.html.erb
@@ -19,7 +19,7 @@
     <p>Your constituency is <%= @signature.constituency.name %></p>
     <% if @signature.constituency.mp %>
       <p>Your local MP is <%= @signature.constituency.mp.name %></p>
-      <p><%= link_to "Contact your MP", @signature.constituency.mp.url %></p>
+      <p><%= link_to "Contact your MP", @signature.constituency.mp.url, rel: "external" %></p>
     <% end %>
   </div>
 <% end %>
@@ -27,5 +27,4 @@
 <h2>Register to vote</h2>
 <p>To vote in local, national and EU elections, you must be registered to vote.</p>
 <p>It takes less than 5 minutes.</p>
-<%= link_to "Register to vote", "https://www.gov.uk/register-to-vote" %>
-
+<a href="https://www.gov.uk/register-to-vote" rel="external">Register to vote</a>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -44,7 +44,7 @@
   <details>
     <summary><span class="summary">Data protection</span></summary>
     <div class="panel-indent">
-      <p>If you wish to see the personal data that we hold about you, send a <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/subject-access-request/">Subject Access Request</a> to <a href="mailto:foiteam@cabinet-office.x.gsi.gov.uk">foiteam@cabinet-office.x.gsi.gov.uk</a>.</p>
+      <p>If you wish to see the personal data that we hold about you, send a <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/subject-access-request/" rel="external">Subject Access Request</a> to <a href="mailto:foiteam@cabinet-office.x.gsi.gov.uk">foiteam@cabinet-office.x.gsi.gov.uk</a>.</p>
       <p>You must include the email address you used to create or sign a petition. Our response will be sent to this email address to protect your privacy.</p>
       <p>We reserve the right to charge a fee for providing your data.</p>
     </div>
@@ -83,7 +83,7 @@
     <li>In violation of any intellectual property rights</li>
     <li>In violation of any law or regulation</li>
     <li>Advertising or spam</li>
-    <li>About honours or appointments &ndash; find out how to submit nominations for honours at: <a href="https://www.gov.uk/honours/">www.gov.uk/honours</a></li>
+    <li>About honours or appointments &ndash; find out how to submit nominations for honours at: <a href="https://www.gov.uk/honours/" rel="external">www.gov.uk/honours</a></li>
   </ul>
 
   <details>
@@ -117,7 +117,7 @@
 
   <h3>Paper based Parliamentary Petitions</h3>
 
-  <p>The petitions system is not intended to replace the <a href="http://www.parliament.uk/get-involved/have-your-say/petitioning/">paper-based system of public petitions</a> in the House of Commons</p>
+  <p>The petitions system is not intended to replace the <a href="http://www.parliament.uk/get-involved/have-your-say/petitioning/" rel="external">paper-based system of public petitions</a> in the House of Commons</p>
 
 </section>
 
@@ -136,7 +136,7 @@
 
   <p>These cookies aren&apos;t used to identify you personally.</p>
 
-  <p>Find out more about <a rel="external" href="http://www.aboutcookies.org/">how to manage cookies.</a></p>
+  <p>Find out more about <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies.</a></p>
 
   <h3>Google Analytics cookies</h3>
 

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -112,4 +112,4 @@ en-GB:
           <p>Petitions cannot be used for freedom of information requests.</p>
         honours: |
           <p>Petitions cannot include information about honours or appointments.</p>
-          <p>Find information about nominations for honours at: <a href='https://www.gov.uk/honours'>https://www.gov.uk/honours</a></p>
+          <p>Find information about nominations for honours at: <a href='https://www.gov.uk/honours' rel='external'>https://www.gov.uk/honours</a></p>


### PR DESCRIPTION
Fix the markup concerns raised by the meeting with GDS:

- changed article.about-petitions to div.about-petitions
- changed `<h1>Other lists of petitions</h1>` to `<h2>Other lists of petitions</h2>`
- added `rel="external"` for all external links
- added `rel="nofollow"` to user generated links
- removed the target="_blank" on user generated links because of the bad UX