### PR TITLE
Use path_to_image helper for icon paths

### DIFF
--- a/app/views/shared/_os.html.erb
+++ b/app/views/shared/_os.html.erb
@@ -6,22 +6,22 @@
 
 <!-- Android: Chrome M31 and up, ignored if manifest is present-->
 <meta name="mobile-web-app-capable" content="yes">
-<link rel="icon" sizes="192x192" href="/images/os-social/android/icon-192x192.png">
+<link rel="icon" sizes="192x192" href="<%= path_to_image('os-social/android/icon-192x192.png') %>">
 
 <!-- iOS -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-title" content="Petitions">
 
-<link rel="apple-touch-icon" sizes="180x180" href="/images/os-social/apple/apple-touch-icon-180x180-precomposed.png">
-<link href="/images/os-social/apple/apple-touch-icon-152x152-precomposed.png" sizes="152x152" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-144x144-precomposed.png" sizes="144x144" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-120x120-precomposed.png" sizes="120x120" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-114x114-precomposed.png" sizes="114x114" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-76x76-precomposed.png" sizes="76x76" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-72x72-precomposed.png" sizes="72x72" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-60x60-precomposed.png" sizes="60x60" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-57x57-precomposed.png" sizes="57x57" rel="apple-touch-icon">
-<link href="/images/os-social/apple/apple-touch-icon-precomposed.png" rel="apple-touch-icon">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-180x180.png') %>" sizes="180x180" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-152x152.png') %>" sizes="152x152" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-144x144.png') %>" sizes="144x144" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-120x120.png') %>" sizes="120x120" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-114x114.png') %>" sizes="114x114" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-76x76.png') %>" sizes="76x76" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-72x72.png') %>" sizes="72x72" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-60x60.png') %>" sizes="60x60" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon-57x57.png') %>" sizes="57x57" rel="apple-touch-icon-precomposed">
+<link href="<%= path_to_image('os-social/apple/apple-touch-icon.png') %>" rel="apple-touch-icon-precomposed">
 
 <!-- Windows 8 and IE 11 -->
 <meta name="msapplication-config" content="browserconfig.xml" />

--- a/app/views/shared/_social_meta.html.erb
+++ b/app/views/shared/_social_meta.html.erb
@@ -11,7 +11,7 @@
 <!-- Open Graph -->
 <meta property="og:title" content="<%= @title %>" />
 <meta property="og:type" content="article" />
-<meta property="og:image" content="/images/os-social/opengraph-image.png" />
+<meta property="og:image" content="<%= path_to_image('os-social/opengraph-image.png') %>" />
 <meta property="og:url" content="<%= @path %>" />
 <meta property="og:site_name" content="Petitions" />
 <meta property="og:description" content="<%= @action %>" />
@@ -20,4 +20,4 @@
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="<%= @title %>">
 <meta name="twitter:description" content="<%= @action %>">
-<meta name="twitter:image" content="/images/os-social/opengraph-image.png">
+<meta name="twitter:image" content="<%= path_to_image('os-social/opengraph-image.png') %>">


### PR DESCRIPTION
The OS and Social icons were moved to app/assets/images in b009cb6, however the meta tags were still pointing to the original locations in public/images.

https://www.pivotaltracker.com/story/show/97523056