### PR TITLE
Fix occasionally failing signature spec

### DIFF
--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Signature, type: :model do
       end
 
       it "returns only signatures for the given email address" do
-        expect(Signature.for_email("person3@example.com")).to eq(
+        expect(Signature.for_email("person3@example.com")).to match_array(
           [signature3, other_signature]
         )
       end


### PR DESCRIPTION
The spec matched the order of the signatures returned by a scope in
signature, altough there was no promise of the order.