### PR TITLE
Admin search by keyword

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -2,9 +2,7 @@ class Admin::PetitionsController < Admin::AdminController
   respond_to :html
 
   def index
-    @petitions = Petition.selectable.order(:signature_count)
-    @petitions = @petitions.for_state(params[:state]) unless params[:state].blank?
-    @petitions = @petitions.paginate(:page => params[:page], :per_page => params[:per_page] || 20)
+    @petitions = Petition.selectable.search(params.merge(count: params[:per_page] || 20))
   end
 
   def show

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -6,15 +6,17 @@ class Admin::SearchesController < Admin::AdminController
 
   def result
     @query = params[:search][:query]
-    if (/^\d+$/ =~ @query)
-      find_by_id(@query)
+    if is_number?(@query)
+      find_petition_by_id(@query)
+    elsif is_email?(@query)
+      find_signatures_by_email(@query)
     else
-      @signatures = Signature.for_email(@query).paginate(:page => params[:page], :per_page => 20)
+      find_petitions_by_keyword(@query)
     end
   end
 
   private
-  def find_by_id(query)
+  def find_petition_by_id(query)
     begin
       petition = Petition.find(query.to_i)
       redirect_to url_for_petition_state(petition)
@@ -24,6 +26,14 @@ class Admin::SearchesController < Admin::AdminController
     end
   end
 
+  def find_signatures_by_email(query)
+    @signatures = Signature.for_email(query).paginate(:page => params[:page], :per_page => 20)
+  end
+
+  def find_petitions_by_keyword(query)
+    redirect_to(controller: 'admin/petitions', action: 'index', q: query)
+  end
+  
   def url_for_petition_state(petition)
     return admin_petition_url(petition) unless petition.editable_by?(current_user)
     return admin_petition_url(petition) if petition.awaiting_moderation?
@@ -31,5 +41,13 @@ class Admin::SearchesController < Admin::AdminController
     if (petition.response_editable_by?(current_user))
       edit_response_admin_petition_url(petition)
     end
+  end
+
+  def is_number?(query)
+    /^\d+$/ =~ query
+  end
+
+  def is_email?(query)
+    query.include?('@')
   end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -40,6 +40,7 @@ class Petition < ActiveRecord::Base
   facet :awaiting_response, -> { awaiting_response.reorder(response_threshold_reached_at: :asc) }
   facet :closed, -> { for_state(CLOSED_STATE).reorder(signature_count: :desc) }
   facet :rejected, -> { for_state(REJECTED_STATE).reorder(created_at: :desc) }
+  facet :hidden, -> { for_state(HIDDEN_STATE).reorder(created_at: :desc) }
   facet :all, -> { reorder(signature_count: :desc) }
 
   facet :awaiting_debate_date, -> { where(state: OPEN_STATE).awaiting_debate_date.without_debate_outcome.reorder(debate_threshold_reached_at: :asc) }

--- a/app/views/admin/searches/new.html.erb
+++ b/app/views/admin/searches/new.html.erb
@@ -4,8 +4,9 @@
 <br/>
 
 <ul>
-  <li>an id to find a petition with that id;
-  <li>an email address to see all petitions that that email address has signed.
+  <li>an id to find a petition with that id;</li>
+  <li>an email address to see all petitions that that email address has signed;</li>
+  <li>a keyword to find all petitions that contain the keyword in their Action, Background or Additional details fields.</li>
 </ul>
 <br/>
 

--- a/features/admin/search_for_petitions_by_keyword.feature
+++ b/features/admin/search_for_petitions_by_keyword.feature
@@ -1,0 +1,31 @@
+Feature: Maggie searches for petitions by keyword
+  In order to find petitions containing a certain keyword
+  As Maggie
+  I would like to be able to enter a keyword, and see all petitions that have the word in their action, background or supporting details
+
+  Scenario: When searching for keyword, it returns all petitions with keyword in action OR background OR additional_details
+    Given a petition "p1" exists with action: "Raise benefits", state: "open", open_at: "1 day ago", closed_at: "1 day from now"
+    And a petition "p2" exists with action: "Help the poor", background: "Need higher benefits", state: "open", open_at: "1 day ago", closed_at: "1 day from now"
+    And a petition "p3" exists with action: "Help the homeless", additional_details: "Could raise benefits", state: "open", open_at: "1 day ago", closed_at: "1 day from now"
+    Given a petition "p4" exists with action: "Petition about something else", state: "open", open_at: "1 day ago", closed_at: "1 day from now"
+    And I am logged in as a moderator
+    When I search for petitions with keyword "benefits" in the admin section
+    Then I should see the following list of petitions:
+          | Raise benefits    |
+          | Help the poor     |
+          | Help the homeless |
+
+  Scenario: When searching for keyword, it returns all petitions no matter what petition state
+    Given an open petition exists with action: "My open petition about benefits"
+    And a closed petition exists with action: "My closed petition about benefits"
+    And a rejected petition exists with action: "My rejected petition about benefits"
+    And a hidden petition exists with action: "My hidden petition about benefits"
+    And an open petition exists with action: "My open petition about something else"
+    And I am logged in as a moderator
+    When I search for petitions with keyword "benefits" in the admin section
+    Then I should see the following list of petitions:
+          | My open petition about benefits     |
+          | My closed petition about benefits   |
+          | My rejected petition about benefits |
+          | My hidden petition about benefits   |
+          

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -17,6 +17,12 @@ When /^I search for a petition by id$/ do
   click_button 'Search'
 end
 
+When /^I search for petitions with keyword "([^"]*)" in the admin section$/ do |keyword|
+  visit new_admin_search_path
+  fill_in "Search", :with => keyword
+  click_button 'Search'
+end
+
 When /^I view the petition through the admin interface$/ do
   visit new_admin_search_path
   fill_in "Search", :with => @petition.id

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -302,11 +302,6 @@ RSpec.describe Admin::PetitionsController, type: :controller do
         expect(Petition).to receive(:selectable).and_return(petitions)
         get :index
       end
-
-      it "optionally filters by state" do
-        expect(petitions).to receive(:for_state).with('open').and_return(petitions)
-        get :index, :state => 'open'
-      end
     end
 
     context "show" do

--- a/spec/controllers/admin/searches_controller_spec.rb
+++ b/spec/controllers/admin/searches_controller_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe Admin::SearchesController, type: :controller do
           end
         end
       end
+
+      context "searching by keyword" do
+        it "redirects to the all petitions page for a keyword" do
+          get :result, :search => { :query => 'example_keyword' }
+          expect(response).to redirect_to("https://petition.parliament.uk/admin/petitions?q=example_keyword")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Admin search supports search by keywords which is the default choice if search string is not a number or an email). Admin petitions index uses the new search functionality.