### PR TITLE
Fix bug revalidating sponsor email

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -33,7 +33,11 @@ class SignaturesController < ApplicationController
 
     if @signature.validated?
       flash[:notice] = "Thank you. Your signature has already been added to the petition."
-      redirect_to signed_petition_signature_url(@petition, @signature.perishable_token) and return
+      if @signature.sponsor?
+        redirect_to sponsored_petition_sponsor_url(@petition, token: @petition.sponsor_token) and return
+      else
+        redirect_to signed_petition_signature_url(@petition, @signature.perishable_token) and return
+      end
     end
 
     @signature.validate!

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -95,4 +95,5 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     And I should have fully signed the petition as a sponsor
     When I confirm my email address
     Then I am taken to a landing page
-    And I should see that I have already signed the petition
+    And I should see "You have already sponsored this petition."
+    And I should see "This petition is waiting for more sponsors"


### PR DESCRIPTION
When revalidating a sponsors email address, it now redirects to the sponsors signed url with an appropriate flash message. Also refactored the signature controller verify method, as it was getting quite complex.

After the refactoring I was wondering if the verification/validation for the sponsor should happen in the sponsor controller rather than the signature controller? Curious to hear other opinions on this!