### PR TITLE
Make controls on admin all petitions autosubmit filter form

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,0 +1,1 @@
+//= require autosubmit_selects.js

--- a/app/assets/javascripts/autosubmit_selects.js
+++ b/app/assets/javascripts/autosubmit_selects.js
@@ -1,0 +1,5 @@
+$().ready(function() {
+  $('select[data-autosubmit]').change(function() {
+    $(this).closest('form').submit();
+  });
+});

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -1,8 +1,8 @@
 <%= form_tag admin_petitions_path, :method => :get, :class => "filter" do -%>
   <%= label_tag :state, "Filter by status:" %>
-  <%= select_tag :state, options_for_select(Petition::SELECTABLE_STATES, params[:state]), :include_blank => "-- all moderated petitions --" %>
+  <%= select_tag :state, options_for_select(Petition::SELECTABLE_STATES, params[:state]), :include_blank => "-- all moderated petitions --", data: {autosubmit: true} %>
   <%= label_tag :per_page, "Results per page:" %>
-  <%= select_tag :per_page, options_for_select(%w(20 50 100), params[:per_page]) %>
+  <%= select_tag :per_page, options_for_select(%w(20 50 100), params[:per_page]), data: {autosubmit: true} %>
   <%= submit_tag "Go" %>
 <% end -%>
 <table class="admin_index">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>Petitions</title>
   <%= stylesheet_link_tag 'admin' %>
-  <%= javascript_include_tag "vendor/jquery.js", "rails", "edit_response_controller" %>
+  <%= javascript_include_tag "vendor/jquery.js", "rails", "edit_response_controller", "admin" %>
   <%= csrf_meta_tag %>
   <%= yield :js %>
 </head>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,7 +8,7 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( application-ie7.css application-ie8.css admin.css ie.js )
+Rails.application.config.assets.precompile += %w( application-ie7.css application-ie8.css admin.css ie.js admin.js )
 
 # Compress JavaScript assets.
 Rails.application.config.assets.js_compressor = :uglifier

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: A moderator user views all petitions
   In order to see a full list of all the petitions
   As any moderator user
@@ -60,7 +61,6 @@ Feature: A moderator user views all petitions
     When I view all petitions
     Then I should see a list of 20 petitions
     When I change the number viewed per page to 50
-    And I press "Go"
     Then I should see a list of 25 petitions
 
   Scenario: A sysadmin can view all petitions

--- a/features/step_definitions/inspection_steps.rb
+++ b/features/step_definitions/inspection_steps.rb
@@ -87,9 +87,12 @@ Then(/^I should see the following ordered list of petitions:$/) do |table|
 end
 
 Then(/^I should see the following list of petitions:$/) do |table|
-  actual_petitions = page.all(:css, '.petition-action').map(&:text)
   expected_petitions = table.raw.flatten
-  expect(actual_petitions).to match_array(expected_petitions)
+  expect(page).to have_selector(:css, '.petition-action', count: expected_petitions.size)
+
+  expected_petitions.each.with_index do |expected_petition, idx|
+    expect(page).to have_selector(:css, "tr:nth-child(#{idx+1}) .petition-action", text: expected_petition)
+  end
 end
 
 Then /^I should see the creation date of the petition$/ do

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -99,9 +99,8 @@ Then /^I should not see the petition "([^"]*)"$/ do |petition_action|
   expect(page).not_to have_link(petition_action)
 end
 
-When /^I filter the list to show "([^"]*)" petitions$/ do |option|
+When(/^I filter the list to show "([^"]*)" petitions$/) do |option|
   select option
-  click_button "Go"
 end
 
 When /^I select the option to view "([^"]*)" petitions$/ do |option|


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/97713774

When you choose a new state to filter the all petitions list by, or a new number of petitions to see per page, we want the user to not have to press go.  We do this with a simple jquery enhancement that attaches to any select element with a data-autosubmit attribute and adds a onchange handler to submit the form the select lives in.

We leave the 'Go' button just in case (but perhaps we should hide it?).

Notes of interest:

1. We test this only via cucumber but this means we had to change some of our inspection steps to use capybara matchers instead of rspec matchers.  Without using the capybara matcher we don't neccessarily wait for the page refresh so might assert on the previous page contents.

2. We have an old version of jquery so we need to do `$(this).closest('form').submit();` - a newer jquery would let us do `$(this).form().submit();`.