### PR TITLE
Whitelist facets exposed on search pages

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -3,5 +3,12 @@ class Admin::AdminController < ApplicationController
 
   before_filter :require_admin_and_check_for_password_change
   layout 'admin'
+  helper_method :admin_petition_facets
+
+  protected
+
+  def admin_petition_facets
+    I18n.t('admin', scope: :"petitions.facets")
+  end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   before_filter :authenticate, if: :site_protected?
 
   before_action :set_seen_cookie_message, if: :show_cookie_message?
-  helper_method :show_cookie_message?
+  helper_method :show_cookie_message?, :public_petition_facets
 
   protected
 
@@ -38,5 +38,9 @@ class ApplicationController < ActionController::Base
 
   def show_cookie_message?
     @show_cookie_message ||= cookies[:seen_cookie_message] != 'yes'
+  end
+
+  def public_petition_facets
+    I18n.t('public', scope: :"petitions.facets")
   end
 end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,5 +1,6 @@
 class PetitionsController < ApplicationController
   include ManagingMoveParameter
+  before_action :avoid_unknown_state_filters, only: :index
 
   respond_to :html
 
@@ -56,6 +57,11 @@ class PetitionsController < ApplicationController
   end
 
   protected
+
+  def avoid_unknown_state_filters
+    return if params[:state].blank?
+    redirect_to url_for(params.merge(state: 'all')) unless public_petition_facets.include? params[:state]
+  end
 
   def parse_emails(emails)
     emails.strip.split(/\r?\n/).map { |e| e.strip }

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -60,7 +60,7 @@ class PetitionsController < ApplicationController
 
   def avoid_unknown_state_filters
     return if params[:state].blank?
-    redirect_to url_for(params.merge(state: 'all')) unless public_petition_facets.include? params[:state]
+    redirect_to url_for(params.merge(state: 'all')) unless public_petition_facets.include? params[:state].to_sym
   end
 
   def parse_emails(emails)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -20,7 +20,7 @@ module AdminHelper
   def admin_petition_facets_for_select(selected)
     options_for_select(
       admin_petition_facets.map do |facet|
-        [I18n.t(facet,  scope: :"petitions.facets.names.admin", default: facet.humanize), facet]
+        [I18n.t(facet,  scope: :"petitions.facets.names.admin", default: facet.to_s.humanize), facet]
       end,
       selected
     )

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -16,4 +16,13 @@ module AdminHelper
                         :method => :delete
                       }
   end
+
+  def admin_petition_facets_for_select(selected)
+    options_for_select(
+      admin_petition_facets.map do |facet|
+        [I18n.t(facet,  scope: :"petitions.facets.names.admin", default: facet.humanize), facet]
+      end,
+      selected
+    )
+  end
 end

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -21,15 +21,7 @@ module PetitionHelper
   end
 
   def public_petition_facets_with_counts(petition_search)
-    Hash[
-      public_petition_facets.map do |key|
-        if petition_search.facets.key? key.to_sym
-          [key, petition_search.facets[key.to_sym]]
-        else
-          nil
-        end
-      end.compact
-    ]
+    petition_search.facets.slice(*public_petition_facets).stringify_keys
   end
 
   private

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -22,7 +22,7 @@ module PetitionHelper
 
   def public_petition_facets_with_counts(petition_search)
     Hash[
-      I18n.t('public', scope: :"petitions.facets").map do |key|
+      public_petition_facets.map do |key|
         if petition_search.facets.key? key.to_sym
           [key, petition_search.facets[key.to_sym]]
         else

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -20,6 +20,18 @@ module PetitionHelper
     t(:"petitions.rejection_reasons.descriptions")
   end
 
+  def public_petition_facets_with_counts(petition_search)
+    Hash[
+      I18n.t('public', scope: :"petitions.facets").map do |key|
+        if petition_search.facets.key? key.to_sym
+          [key, petition_search.facets[key.to_sym]]
+        else
+          nil
+        end
+      end.compact
+    ]
+  end
+
   private
 
   def render_petition_hidden_details(stage_manager, form)

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -21,7 +21,7 @@ module PetitionHelper
   end
 
   def public_petition_facets_with_counts(petition_search)
-    petition_search.facets.slice(*public_petition_facets).stringify_keys
+    petition_search.facets.slice(*public_petition_facets)
   end
 
   private

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -28,6 +28,14 @@ module Browseable
       end
     end
 
+    def slice(*only_these_keys)
+      only_these_keys = only_these_keys.map(&:to_sym)
+
+      only_these_keys.each_with_object({}) do |key, hash|
+        hash[key] = self[key] if has_key?(key)
+      end
+    end
+
     private
 
     def facet_counts

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -29,8 +29,6 @@ module Browseable
     end
 
     def slice(*only_these_keys)
-      only_these_keys = only_these_keys.map(&:to_sym)
-
       only_these_keys.each_with_object({}) do |key, hash|
         hash[key] = self[key] if has_key?(key)
       end

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag admin_petitions_path, :method => :get, :class => "filter" do -%>
   <%= label_tag :state, "Filter by status:" %>
-  <%= select_tag :state, options_for_select(Petition::SELECTABLE_STATES, params[:state]), :include_blank => "-- all moderated petitions --", data: {autosubmit: true} %>
+  <%= select_tag :state, admin_petition_facets_for_select(params[:state]), data: {autosubmit: true} %>
   <%= label_tag :per_page, "Results per page:" %>
   <%= select_tag :per_page, options_for_select(%w(20 50 100), params[:per_page]), data: {autosubmit: true} %>
   <%= submit_tag "Go" %>

--- a/app/views/petitions/search/_filter_nav.html.erb
+++ b/app/views/petitions/search/_filter_nav.html.erb
@@ -2,7 +2,7 @@
   <h2 id="other-lists-heading">Other lists of petitions</h2>
   <div class="section-panel">
     <ul>
-    <% @petitions.facets.each do |facet, count| %>
+    <% public_petition_facets_with_counts(@petitions).each do |facet, count| %>
       <li>
         <%= link_to petitions_url(state: facet) do %>
           <%= t(facet, scope: :"petitions.lists", quantity: number_with_delimiter(count)) %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -35,6 +35,23 @@ en-GB:
         - 'with_response'
         - 'awaiting_debate_date'
         - 'with_debate_outcome'
+      admin:
+        - 'all'
+        - 'open'
+        - 'closed'
+        - 'rejected'
+        - 'hidden'
+        - 'awaiting_response'
+        - 'with_response'
+        - 'awaiting_debate_date'
+        - 'with_debate_outcome'
+      names:
+        admin:
+          all: "All moderated petitions"
+          awaiting_response: "Awaiting a government response"
+          with_response: "With a government response"
+          awaiting_debate_date: "Awaiting a debate in parliament"
+          with_debate_outcome: "Has been debated in parliament"
 
     emails:
       subjects:

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -25,6 +25,17 @@ en-GB:
       with_debate_outcome: "Petitions debated in Parliament (%{quantity})"
       awaiting_debate_date: "Petitions waiting for a debate in Parliament (%{quantity})"
 
+    facets:
+      public:
+        - 'all'
+        - 'open'
+        - 'closed'
+        - 'rejected'
+        - 'awaiting_response'
+        - 'with_response'
+        - 'awaiting_debate_date'
+        - 'with_debate_outcome'
+
     emails:
       subjects:
         email_confirmation_for_signer: |-

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -27,24 +27,24 @@ en-GB:
 
     facets:
       public:
-        - 'all'
-        - 'open'
-        - 'closed'
-        - 'rejected'
-        - 'awaiting_response'
-        - 'with_response'
-        - 'awaiting_debate_date'
-        - 'with_debate_outcome'
+        - :all
+        - :open
+        - :closed
+        - :rejected
+        - :awaiting_response
+        - :with_response
+        - :awaiting_debate_date
+        - :with_debate_outcome
       admin:
-        - 'all'
-        - 'open'
-        - 'closed'
-        - 'rejected'
-        - 'hidden'
-        - 'awaiting_response'
-        - 'with_response'
-        - 'awaiting_debate_date'
-        - 'with_debate_outcome'
+        - :all
+        - :open
+        - :closed
+        - :rejected
+        - :hidden
+        - :awaiting_response
+        - :with_response
+        - :awaiting_debate_date
+        - :with_debate_outcome
       names:
         admin:
           all: "All moderated petitions"

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -38,19 +38,19 @@ Feature: A moderator user views all petitions
      | My rejected petition |
      | My hidden petition   |
 
-    And I filter the list to show "open" petitions
+    And I filter the list to show "Open" petitions
     Then I should see the following list of petitions:
      | My open petition     |
 
-    And I filter the list to show "closed" petitions
+    And I filter the list to show "Closed" petitions
     Then I should see the following list of petitions:
      | My closed petition   |
 
-    And I filter the list to show "rejected" petitions
+    And I filter the list to show "Rejected" petitions
     Then I should see the following list of petitions:
      | My rejected petition |
 
-    And I filter the list to show "hidden" petitions
+    And I filter the list to show "Hidden" petitions
     Then I should see the following list of petitions:
      | My hidden petition   |
 

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -9,8 +9,13 @@ Then /^I should not be able to search via free text$/ do
   expect(page).to have_no_css("form[action=search]")
 end
 
-Then /^I should see an? "([^"]*)" petition count of (\d+)$/ do |state, count|
-  expect(page).to have_css(%{#other-search-lists a:contains("#{state.capitalize}")}, :text => count.to_s)
+Then(/^I should( not)? see an? "([^"]*)" petition count of (\d+)$/) do |see_or_not, state, count|
+  have_petition_count_for_state = have_css(%{#other-search-lists a:contains("#{state.capitalize}")}, :text => count.to_s)
+  if see_or_not.blank?
+    expect(page).to have_petition_count_for_state
+  else
+    expect(page).not_to have_petition_count_for_state
+  end
 end
 
 When(/^I fill in "(.*?)" as my search term$/) do |search_term|

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -49,8 +49,9 @@ Feature: Suzy Singer searches by free text
     And I fill in "Wombles" as my search term
     And I press "Search"
     Then I should see an "open" petition count of 12
-    Then I should see a "closed" petition count of 1
-    Then I should see a "rejected" petition count of 1
+    And I should see a "closed" petition count of 1
+    And I should see a "rejected" petition count of 1
+    But I should not see a "hidden" petition count of 1
 
   Scenario: Search for open petitions using multiple search terms
     When I search for "Open petitions" with "overthrow the"

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::AdminController, type: :controller do
+  context '#admin_petition_facets' do
+    it 'extracts the list of admin facets from the locale file' do
+      expect(controller.send(:admin_petition_facets)).to eq I18n.t(:"petitions.facets.admin")
+    end
+
+    it 'is a helper method' do
+      expect(controller.class.helpers).to respond_to :admin_petition_facets
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -62,4 +62,14 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
   end
+
+  context '#public_petition_facets' do
+    it 'extracts the list of public facets from the locale file' do
+      expect(controller.send(:public_petition_facets)).to eq I18n.t(:"petitions.facets.public")
+    end
+
+    it 'is a helper method' do
+      expect(controller.class.helpers).to respond_to :public_petition_facets
+    end
+  end
 end

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -236,9 +236,42 @@ RSpec.describe PetitionsController, type: :controller do
   end
 
   describe "GET #index" do
-    it "is successful" do
-      get :index
-      expect(response).to be_success
+    context 'when no state param is provided' do
+      it "is successful" do
+        get :index
+        expect(response).to be_success
+      end
+
+      it "exposes a search scoped to the all facet" do
+        get :index
+        expect(assigns(:petitions).scope).to eq :all
+      end
+    end
+
+    context 'when a state param is provided' do
+      context 'but it is not a public facet from the locale file' do
+        it 'redirects to itself with state=all' do
+          get :index, state: 'awaiting_monkey'
+          expect(response).to redirect_to 'https://petition.parliament.uk/petitions?state=all'
+        end
+
+        it 'preserves other params when it redirects' do
+          get :index, q: 'what is clocks', state: 'awaiting_monkey'
+          expect(response).to redirect_to 'https://petition.parliament.uk/petitions?q=what+is+clocks&state=all'
+        end
+      end
+
+      context 'and it is a public facet from the locale file' do
+        it 'is successful' do
+          get :index, state: 'open'
+          expect(response).to be_success
+        end
+
+        it "exposes a search scoped to the state param" do
+          get :index, state: 'open'
+          expect(assigns(:petitions).scope).to eq :open
+        end
+      end
     end
   end
 

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe AdminHelper, type: :helper do
+  describe '#admin_petition_facets_for_select' do
+    let(:admin_petition_facets) { ['all', 'open', 'awaiting_monkey'] }
+    before do
+      def helper.admin_petition_facets; end
+      allow(helper).to receive(:admin_petition_facets).and_return admin_petition_facets
+    end
+
+    let(:selected) { 'open' }
+    subject { helper.admin_petition_facets_for_select(selected) }
+    before { render text: subject }
+
+    it 'provides an option tag for each facet in admin_petition_facets' do
+      expect(rendered).to have_css('option', count: admin_petition_facets.size)
+      admin_petition_facets.each.with_index do |facet, idx|
+        expect(rendered).to have_css("option:nth-of-type(#{idx+1})[value='#{facet}']")
+      end
+    end
+
+    it 'sets the text of the option to the value from the locale file if present' do
+      expect(rendered).to have_css("option[value='all']", text: I18n.t(:"petitions.facets.names.admin.all"))
+    end
+
+    it 'sets the text of the option to the humanized version of the facet name if not present in the locale file if present' do
+      expect(rendered).to have_css("option[value='awaiting_monkey']", text: 'Awaiting monkey')
+    end
+
+    it 'marks the option whose value matches the supplied argument as selected' do
+      expect(rendered).to have_css("option[value='open'][selected]")
+    end
+  end
+end

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe PetitionHelper, type: :helper do
+  describe '#public_petition_facets_with_counts' do
+    let(:facets) do
+      {
+        all: 100,
+        open: 10,
+        closed: 20,
+        rejected: 30,
+        awaiting_response: 40,
+        with_response: 50,
+        awaiting_debate_date: 60,
+        with_debate_outcome: 70,
+        hidden: 80
+      }
+    end
+    let(:petition_search) { double(facets: facets) }
+
+    subject { helper.public_petition_facets_with_counts(petition_search) }
+
+    it 'returns each facet from the public facet' do
+      expect(subject.keys).to eq I18n.t(:'petitions.facets.public')
+    end
+
+    it 'returns each facet with its count from the search object' do
+      I18n.t(:'petitions.facets.public').each do |public_facet|
+        expect(subject[public_facet]).to eq facets[public_facet.to_sym]
+      end
+    end
+
+    it 'swallows the error and does not expose the facet if the search does not support it' do
+      facets.default_proc = ->(_, failed_key) { raise ArgumentError, "Unsupported facet: #{failed_key.inspect}" }
+      facets.delete(:with_response)
+      expect {
+        subject
+      }.not_to raise_error
+      expect(subject).not_to have_key('with_response')
+    end
+  end
+end

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -2,29 +2,30 @@ require 'rails_helper'
 
 RSpec.describe PetitionHelper, type: :helper do
   describe '#public_petition_facets_with_counts' do
+    let(:public_petition_facets) { ['all', 'open', 'with_response'] }
+    before do
+      def helper.public_petition_facets; end
+      allow(helper).to receive(:public_petition_facets).and_return public_petition_facets
+    end
+
     let(:facets) do
       {
         all: 100,
         open: 10,
-        closed: 20,
-        rejected: 30,
-        awaiting_response: 40,
-        with_response: 50,
-        awaiting_debate_date: 60,
-        with_debate_outcome: 70,
-        hidden: 80
+        with_response: 20,
+        hidden: 30
       }
     end
     let(:petition_search) { double(facets: facets) }
 
     subject { helper.public_petition_facets_with_counts(petition_search) }
 
-    it 'returns each facet from the public facet' do
-      expect(subject.keys).to eq I18n.t(:'petitions.facets.public')
+    it 'returns each facet from the public facet list' do
+      expect(subject.keys).to eq public_petition_facets
     end
 
     it 'returns each facet with its count from the search object' do
-      I18n.t(:'petitions.facets.public').each do |public_facet|
+      public_petition_facets.each do |public_facet|
         expect(subject[public_facet]).to eq facets[public_facet.to_sym]
       end
     end

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PetitionHelper, type: :helper do
         open: 10,
         with_response: 20,
         hidden: 30
-      }
+      }.with_indifferent_access
     end
     let(:petition_search) { double(facets: facets) }
 

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PetitionHelper, type: :helper do
   describe '#public_petition_facets_with_counts' do
-    let(:public_petition_facets) { ['all', 'open', 'with_response'] }
+    let(:public_petition_facets) { [:all, :open, :with_response] }
     before do
       def helper.public_petition_facets; end
       allow(helper).to receive(:public_petition_facets).and_return public_petition_facets
@@ -14,7 +14,7 @@ RSpec.describe PetitionHelper, type: :helper do
         open: 10,
         with_response: 20,
         hidden: 30
-      }.with_indifferent_access
+      }
     end
     let(:petition_search) { double(facets: facets) }
 

--- a/spec/models/concerns/browseable_spec.rb
+++ b/spec/models/concerns/browseable_spec.rb
@@ -373,10 +373,6 @@ RSpec.describe Browseable, type: :model do
         expect(facets.slice(:open)).to eq({open: 999})
       end
 
-      it 'accepts keys as strings' do
-        expect(facets.slice('pending')).to eq({pending: 20})
-      end
-
       it 'returns a hash with keys ordered by the supplied keys' do
         expect(facets.slice(:pending, :open).keys).to eq([:pending, :open])
       end


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/97724776

To give us control over what search facets are accessible on the frontend vs backend we define a list of facets in the locale file under `petitions.facets.public` and `petitions.facets.admin`.  The public frontend only shows these facets in the filter list so a user shouldn't be invited to click on a facet that isn't public.  We also make the public backend reject any facet that is not in the public list so they can't just hack the url to see, for example, a list of hidden petitions.

The admin isn't so constrained as it's not a problem if an admin can see a petition via a non-public scope.  However, so we don't baffle them with too many options we use the locale list to populate the filter dropdown on the all petitions page.