### PR TITLE
Restyle threshold details without indent

### DIFF
--- a/app/assets/stylesheets/petitions/views/_petition-show.scss
+++ b/app/assets/stylesheets/petitions/views/_petition-show.scss
@@ -10,6 +10,10 @@
 
 .signature-count {
   @include bold-48;
+  margin: em(10, 32) 0;
+  @include media(tablet) {
+    margin: em(15, 48) 0;
+  }
 
   span {
     @include bold-36;

--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -145,22 +145,30 @@ input.back-page {
 }
 
 .about-item {
-  padding: 0 0 0 50px;
+  padding: $gutter-two-thirds 0 0 0;
+
+  p {
+    margin: em(5, 16) 0;
+
+    @include media(tablet) {
+      margin: em(10, 19) 0;
+    }
+  }
+
   h2 {
     @include bold-36;
     span { @include bold-19; }
-    margin-top: em(10, 24);
-    margin-bottom: em(5, 24);
+    margin: em(5, 24) 0;
 
     @include media(tablet) {
-      margin-top: em(15, 36);
+      margin: em(10, 36) 0;
     }
   }
   h3 {
     margin-top: em(10, 16);
 
     @include media(tablet) {
-      margin-top: em(15, 19);
+      margin: em(5, 19) 0;
     }
   }
   blockquote {
@@ -177,35 +185,6 @@ input.back-page {
   }
 }
 
-.about-item-sign {
-  @include background-image("graphics/graphic_pen", 25px, 35px);
-  background-repeat: no-repeat;
-  background-position: 10px 0px;
-}
-.about-item-count-10000 {
-  @include background-image("graphics/graphic_crown", 36px, 25px);
-  background-repeat: no-repeat;
-  background-position: 0px 0px;
-}
-.about-item-count-100000 {
-  @include background-image("graphics/graphic_portcullis", 26px, 32px);
-  background-repeat: no-repeat;
-  background-position: 3px 0px;
-}
-
 .about-item-scheduled-debate-date {
   @include bold-19;
-}
-
-// Light variation
-.about-petitions-light {
-  .about-item {
-    color: $secondary-text-colour;
-  }
-  .about-item-count-10000 {
-    @include background-image("graphics/graphic_crown-grey", 35px, 25px);
-  }
-  .about-item-count-100000 {
-    @include background-image("graphics/graphic_portcullis-grey", 26px, 32px);
-  }
 }

--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -18,7 +18,7 @@
 
 <p class="signature-count"><%= signature_count(:default, petition.signature_count) %></p>
 
-<%= render 'threshold_details', variation: (petition.response.present? || petition.debate_outcome.present? ? '' : 'about-petitions-light'), petition: petition %>
+<%= render 'threshold_details', petition: petition %>
 
 <ul class="petition-meta">
   <li>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -1,4 +1,5 @@
-<section class="about-item  about-item-count-100000" aria-labelledby="debate-threshold-heading">
+<section class="about-item about-item-count-100000" aria-labelledby="debate-threshold-heading">
+  <span class="graphic graphic-portcullis"></span>
   <h2 id="debate-threshold-heading">100,000 <span>signatures</span></h2>
   <%# Has debate outcome details #%>
   <% if petition.debate_outcome.present? -%>

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -15,7 +15,7 @@
 
 <p class="signature-count"><%= signature_count(:default, petition.signature_count) %></p>
 
-<%= render 'threshold_details', variation: (petition.response.present? || petition.debate_outcome.present? ? '' : 'about-petitions-light'), petition: petition %>
+<%= render 'threshold_details', petition: petition %>
 
 <%= render 'shared/share_petition', petition: petition %>
 

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -1,4 +1,5 @@
 <section class="about-item about-item-count-10000" aria-labelledby="response-threshold-heading">
+  <span class="graphic graphic-crown"></span>
   <h2 id="response-threshold-heading">10,000 <span>signatures</span></h2>
   <%# Has response #%>
   <% if petition.response_summary.present? -%>

--- a/app/views/petitions/_threshold_details.html.erb
+++ b/app/views/petitions/_threshold_details.html.erb
@@ -1,4 +1,4 @@
-<div class="about-petitions <%= local_assigns[:variation] %>">
+<div class="about-petitions">
   <%-
     order = ['response_threshold', 'debate_threshold']
     order.reverse! if petition.debate_outcome.present? or petition.scheduled_debate_date.present?


### PR DESCRIPTION
Remove about-petitions light variation and associated code, because the grey
text version makes less sense alongside the government response and debate
states