### PR TITLE
Add background job to verify petition signature counts

### DIFF
--- a/app/jobs/petition_count_job.rb
+++ b/app/jobs/petition_count_job.rb
@@ -1,0 +1,22 @@
+class PetitionCountJob < ActiveJob::Base
+  def perform
+    petitions = Petition.with_invalid_signature_counts
+
+    unless petitions.empty?
+      petitions.each(&:update_signature_count!)
+      NewRelic::Agent.notice_error(error_message(petitions))
+    end
+  end
+
+  private
+
+  def error_message(petitions)
+    I18n.t(
+      :"invalid_signature_counts",
+        scope:  :"petitions.errors",
+        count:  petitions.size,
+        ids:    petitions.map(&:id).inspect,
+        id:     petitions.first.id.to_s
+    )
+  end
+end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -49,6 +49,13 @@ class Signature < ActiveRecord::Base
   end
   private_class_method :arel_join_onto_sent_receipts
 
+  def self.petition_ids_with_invalid_signature_counts
+    validated.joins(:petition).
+      group([arel_table[:petition_id], Petition.arel_table[:signature_count]]).
+      having(arel_table[Arel.star].count.not_eq(Petition.arel_table[:signature_count])).
+      pluck(:petition_id)
+  end
+
   scope :in_days, ->(number_of_days) { validated.where("updated_at > ?", number_of_days.day.ago) }
   scope :matching, ->(signature) { where(email: signature.email,
                                          name: signature.name,

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -1,5 +1,10 @@
 en-GB:
   petitions:
+    errors:
+      invalid_signature_counts:
+        one: "There was 1 petition with id: %{id} that had an invalid signature count"
+        other: "There were %{count} petitions with ids: %{ids} that had invalid signature counts"
+
     page_titles:
       all: "All petitions"
       open: "Open petitions"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,10 +19,14 @@
 
 # Learn more: http://github.com/javan/whenever
 
-every :weekday, :at => '7am' do # Use any day of the week or :weekend, :weekday
-  rake "epets:admin_email_reminder", :output => nil
+every :weekday, at: '7am' do
+  rake "epets:admin_email_reminder", output: nil
 end
 
-every :weekday, :at => '6.30am' do # Use any day of the week or :weekend, :weekday
-  rake "epets:threshold_email_reminder", :output => nil
+every :weekday, at: '6.30am' do
+  rake "epets:threshold_email_reminder", output: nil
+end
+
+every 30.minutes do
+  runner "PetitionCountJob.perform_later"
 end

--- a/spec/jobs/email_debate_outcomes_job_spec.rb
+++ b/spec/jobs/email_debate_outcomes_job_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include ActiveJob::TestHelper
 
 RSpec.describe EmailDebateOutcomesJob, type: :job do
   let(:email_requested_at) { Time.current }

--- a/spec/jobs/email_debate_scheduled_job_spec.rb
+++ b/spec/jobs/email_debate_scheduled_job_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include ActiveJob::TestHelper
 
 RSpec.describe EmailDebateScheduledJob, type: :job do
   let(:email_requested_at) { Time.current }

--- a/spec/jobs/email_petition_signatories_spec.rb
+++ b/spec/jobs/email_petition_signatories_spec.rb
@@ -1,11 +1,9 @@
 require 'net/smtp'
 require 'rails_helper'
 
-RSpec.describe EmailPetitionSignatories do
+RSpec.describe EmailPetitionSignatories, type: :job do
   describe EmailPetitionSignatories::Job do
     context '.run_later_tonight' do
-      include ActiveJob::TestHelper
-
       let(:petition) { FactoryGirl.create(:open_petition) }
       let(:requested_at) { Time.current }
       before do

--- a/spec/jobs/email_threshold_response_job_spec.rb
+++ b/spec/jobs/email_threshold_response_job_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include ActiveJob::TestHelper
 
 RSpec.describe EmailThresholdResponseJob, type: :job do
   let(:email_requested_at) { Time.current }

--- a/spec/jobs/petition_count_job_spec.rb
+++ b/spec/jobs/petition_count_job_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe PetitionCountJob, type: :job do
-  include ActiveJob::TestHelper
-
   context "when there are no petitions with invalid signature counts" do
     let!(:petition) { FactoryGirl.create(:open_petition) }
 

--- a/spec/jobs/petition_count_job_spec.rb
+++ b/spec/jobs/petition_count_job_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe PetitionCountJob, type: :job do
+  include ActiveJob::TestHelper
+
+  context "when there are no petitions with invalid signature counts" do
+    let!(:petition) { FactoryGirl.create(:open_petition) }
+
+    it "doesn't update the signature count" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.signature_count }
+    end
+
+    it "doesn't change the updated_at timestamp" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.updated_at }
+    end
+
+    it "doesn't notify NewRelic" do
+      expect(NewRelic::Agent).not_to receive(:notice_error)
+
+      perform_enqueued_jobs {
+        described_class.perform_later
+      }
+    end
+  end
+
+  context "when there are petitions with invalid signature counts" do
+    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 100) }
+
+    it "updates the signature count" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.to change{ petition.reload.signature_count }.from(100).to(1)
+    end
+
+    it "updates the updated_at timestamp" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.to change{ petition.reload.updated_at }.to(be_within(1.second).of(Time.current))
+    end
+
+    it "notifies NewRelic" do
+      expect(NewRelic::Agent).to receive(:notice_error).with <<-MSG.strip
+        There was 1 petition with id: #{petition.id} that had an invalid signature count
+      MSG
+
+      perform_enqueued_jobs {
+        described_class.perform_later
+      }
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -658,6 +658,46 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe ".with_invalid_signature_counts" do
+    let!(:petition) { FactoryGirl.create(:open_petition, attributes) }
+
+    context "when there are no petitions with invalid signature counts" do
+      let(:attributes) { { created_at: 2.days.ago, updated_at: 2.days.ago } }
+
+      it "doesn't return any petitions" do
+        expect(described_class.with_invalid_signature_counts).to eq([])
+      end
+    end
+
+    context "when there are petitions with invalid signature counts" do
+      let(:attributes) { { created_at: 2.days.ago, updated_at: 2.days.ago, signature_count: 100 } }
+
+      it "returns the petitions" do
+        expect(described_class.with_invalid_signature_counts).to eq([petition])
+      end
+    end
+  end
+
+  describe "#update_signature_count!" do
+    let!(:petition) { FactoryGirl.create(:open_petition, attributes) }
+
+    context "when there are petitions with invalid signature counts" do
+      let(:attributes) { { created_at: 2.days.ago, updated_at: 2.days.ago, signature_count: 100 } }
+
+      it "updates the signature count" do
+        expect{
+          petition.update_signature_count!
+        }.to change{ petition.reload.signature_count }.from(100).to(1)
+      end
+
+      it "updates the updated_at timestamp" do
+        expect{
+          petition.update_signature_count!
+        }.to change{ petition.reload.updated_at }.to(be_within(1.second).of(Time.current))
+      end
+    end
+  end
+
   describe "#increment_signature_count!" do
     let(:signature_count) { 8 }
     let(:petition) do

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -302,6 +302,28 @@ RSpec.describe Signature, type: :model do
     end
   end
 
+  describe ".petition_ids_with_invalid_signature_counts" do
+    subject do
+      described_class.petition_ids_with_invalid_signature_counts
+    end
+
+    context "when there are no petitions with invalid signature counts" do
+      let!(:petition) { FactoryGirl.create(:open_petition) }
+
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
+    context "when there are petitions with invalid signature counts" do
+      let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 100) }
+
+      it "returns an array of ids" do
+        expect(described_class.petition_ids_with_invalid_signature_counts).to eq([petition.id])
+      end
+    end
+  end
+
   describe "#number" do
     let(:attributes) { FactoryGirl.attributes_for(:petition) }
     let(:creator) { FactoryGirl.create(:pending_signature) }

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include(ActiveJob::TestHelper)
+end


### PR DESCRIPTION
Since we are now calculating the signature counts relatively rather than using a cron job we should be prudent and add a background job that regularly checks for invalid signature counts and then if it finds any to notify NewRelic of the ones that have occurred.

https://www.pivotaltracker.com/story/show/97710094