### PR TITLE
Remove Petition.states_by_count

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -110,15 +110,6 @@ class Petition < ActiveRecord::Base
     where(state: OPEN_STATE, response: nil, response_summary: nil).where.not(response_threshold_reached_at: nil)
   end
 
-  def self.counts_by_state
-    counts_by_state = {}
-    states = STATES + [CLOSED_STATE]
-    states.each do |key_name|
-      counts_by_state[key_name.to_sym] = for_state(key_name.to_s).count
-    end
-    counts_by_state
-  end
-
   def self.popular_in_constituency(constituency_id, how_many = 50)
     # NOTE: this query is complex, so we'll flatten it at the end
     # to prevent chaining things off the end that might break it.

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -658,28 +658,6 @@ RSpec.describe Petition, type: :model do
     end
   end
 
-  describe ".counts_by_state" do
-    it "returns a hash containing counts of petition states" do
-      1.times { FactoryGirl.create(:pending_petition) }
-      2.times { FactoryGirl.create(:validated_petition) }
-      3.times { FactoryGirl.create(:sponsored_petition) }
-      4.times { FactoryGirl.create(:open_petition) }
-      5.times { FactoryGirl.create(:closed_petition) }
-      6.times { FactoryGirl.create(:rejected_petition) }
-      7.times { FactoryGirl.create(:hidden_petition) }
-
-      # Petition.counts_by_state.class.should == Hash
-
-      expect(Petition.counts_by_state[:pending]).to   eq(1)
-      expect(Petition.counts_by_state[:validated]).to eq(2)
-      expect(Petition.counts_by_state[:sponsored]).to eq(3)
-      expect(Petition.counts_by_state[:open]).to      eq(4)
-      expect(Petition.counts_by_state[:closed]).to    eq(5)
-      expect(Petition.counts_by_state[:rejected]).to  eq(6)
-      expect(Petition.counts_by_state[:hidden]).to    eq(7)
-    end
-  end
-
   describe "#increment_signature_count!" do
     let(:signature_count) { 8 }
     let(:petition) do


### PR DESCRIPTION
The method Petition.states_by_count was used for the counts in tabs and is no longer used anywhere so remove it.