### PR TITLE
Change closed to a real state

### DIFF
--- a/app/jobs/close_petitions_job.rb
+++ b/app/jobs/close_petitions_job.rb
@@ -1,0 +1,5 @@
+class ClosePetitionsJob < ActiveJob::Base
+  def perform
+    Petition.close_petitions!
+  end
+end

--- a/app/models/archived_petition.rb
+++ b/app/models/archived_petition.rb
@@ -2,70 +2,46 @@ require 'textacular/searchable'
 
 class ArchivedPetition < ActiveRecord::Base
   OPEN_STATE = 'open'
+  CLOSED_STATE = 'closed'
   REJECTED_STATE = 'rejected'
-  STATES = [OPEN_STATE, REJECTED_STATE]
+  STATES = [OPEN_STATE, CLOSED_STATE, REJECTED_STATE]
 
   alias_attribute :action, :title
 
   validates :title, presence: true, length: { maximum: 150 }
   validates :description, presence: true, length: { maximum: 1000 }
   validates :state, presence: true, inclusion: STATES
+  validates :closed_at, presence: true, unless: :rejected?
 
   extend Searchable(:title, :description)
   include Browseable
 
   facet :all, -> { by_created_at }
-  facet :open, -> { open.by_created_at }
-  facet :closed, -> { closed.by_created_at }
-  facet :rejected, -> { rejected.by_created_at }
+  facet :open, -> { for_state(OPEN_STATE).by_created_at }
+  facet :closed, -> { for_state(CLOSED_STATE).by_created_at }
+  facet :rejected, -> { for_state(REJECTED_STATE).by_created_at }
   facet :by_most_signatures, -> { by_most_signatures }
 
   class << self
-    def closed(time = Time.current)
-      where(open_state.and(closed_at_has_passed(time)))
-    end
-
-    def open(time = Time.current)
-      where(open_state.and(closed_at_has_not_passed(time)))
-    end
-
-    def rejected
-      where(rejected_state)
+    def for_state(state)
+      where(state: state)
     end
 
     def by_created_at
-      reorder(:created_at)
+      reorder(created_at: :asc)
     end
 
     def by_most_signatures
-      order("signature_count DESC")
-    end
-
-    private
-
-    def closed_at_has_not_passed(time)
-      arel_table[:closed_at].gteq(time)
-    end
-
-    def closed_at_has_passed(time)
-      arel_table[:closed_at].lt(time)
-    end
-
-    def open_state
-      arel_table[:state].eq(OPEN_STATE)
-    end
-
-    def rejected_state
-      arel_table[:state].eq(REJECTED_STATE)
+      reorder(signature_count: :desc)
     end
   end
 
   def open?
-    state == OPEN_STATE && closed_at.nil?
+    state == OPEN_STATE
   end
 
   def closed?(time = Time.current)
-    state == OPEN_STATE && !!closed_at && closed_at <= time
+    state.in?([OPEN_STATE, CLOSED_STATE]) && closed_at <= time
   end
 
   def rejected?

--- a/app/models/archived_petition.rb
+++ b/app/models/archived_petition.rb
@@ -40,8 +40,8 @@ class ArchivedPetition < ActiveRecord::Base
     state == OPEN_STATE
   end
 
-  def closed?(time = Time.current)
-    state.in?([OPEN_STATE, CLOSED_STATE]) && closed_at <= time
+  def closed?
+    state == CLOSED_STATE
   end
 
   def rejected?

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -113,6 +113,17 @@ module Browseable
       results.to_a
     end
 
+    def inspect
+      [].tap do |parts|
+        parts << "#<#{self.class.name}:#{object_id}"
+        parts << " class: #{klass.klass.to_s.inspect}"
+        parts << " scope: #{scope.to_s.inspect}" if scoped?
+        parts << " query: #{query.inspect}" if search?
+        parts << " size: #{total_entries}"
+        parts << ">"
+      end.join
+    end
+
     private
 
     def results

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -105,6 +105,18 @@ class Petition < ActiveRecord::Base
       limit(3)
     end
 
+    def close_petitions!(time = Time.current)
+      in_need_of_closing(time).update_all(state: CLOSED_STATE, updated_at: time)
+    end
+
+    def in_need_of_closing(time = Time.current)
+      where(state: OPEN_STATE).where(arel_table[:closed_at].lt(time))
+    end
+
+    def with_invalid_signature_counts
+      where(id: Signature.petition_ids_with_invalid_signature_counts).to_a
+    end
+
     def with_invalid_signature_counts
       where(id: Signature.petition_ids_with_invalid_signature_counts).to_a
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -33,8 +33,8 @@ class Site < ActiveRecord::Base
       instance.host_with_port
     end
 
-    def petition_closed_at(time = Time.current)
-      instance.petition_closed_at(time)
+    def opened_at_for_closing(time = Time.current)
+      instance.opened_at_for_closing(time)
     end
 
     def port
@@ -189,8 +189,8 @@ class Site < ActiveRecord::Base
     end
   end
 
-  def petition_closed_at(time = Time.current)
-    time.end_of_day + petition_duration.months
+  def opened_at_for_closing(time = Time.current)
+    time.end_of_day - petition_duration.months
   end
 
   validates :title, presence: true, length: { maximum: 50 }

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,3 +30,7 @@ end
 every 30.minutes do
   runner "PetitionCountJob.perform_later"
 end
+
+every :weekday, at: '0.00am' do
+  runner "ClosePetitionsJob.perform_later"
+end

--- a/features/joe_searches_for_an_archived_petition.feature
+++ b/features/joe_searches_for_an_archived_petition.feature
@@ -7,9 +7,9 @@ Feature: Joe searches for an archived petition
   Background:
     Given the following archived petitions exist:
       | title                    | state    | signature_count| opened_at  | closed_at  | created_at |
-      | Wombles are great        | open     | 835            | 2012-01-01 | 2013-01-01 | 2012-01-01 |
-      | The Wombles of Wimbledon | open     | 243            | 2011-04-01 | 2012-04-01 | 2011-04-01 |
-      | Common People            | open     | 639            | 2014-10-01 | 2015-03-31 | 2014-10-01 |
+      | Wombles are great        | closed   | 835            | 2012-01-01 | 2013-01-01 | 2012-01-01 |
+      | The Wombles of Wimbledon | closed   | 243            | 2011-04-01 | 2012-04-01 | 2011-04-01 |
+      | Common People            | closed   | 639            | 2014-10-01 | 2015-03-31 | 2014-10-01 |
       | Eavis vs the Wombles     | rejected |                |            |            | 2011-01-01 |
 
   Scenario: Searching for petitions

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -110,7 +110,7 @@ And (/^the petition "([^"]*)" has (\d+) pending sponsors$/) do |petition_action,
 end
 
 Given /^a petition "([^"]*)" has been closed$/ do |petition_action|
-  @petition = FactoryGirl.create(:open_petition, :action => petition_action, :closed_at => 1.day.ago)
+  @petition = FactoryGirl.create(:closed_petition, :action => petition_action)
 end
 
 Given /^a petition "([^"]*)" has been rejected( with the reason "([^"]*)")?$/ do |petition_action, reason_or_not, reason|
@@ -330,7 +330,7 @@ Then /^I expand "([^"]*)"/ do |text|
 end
 
 Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |state, petition_action|
-  petition_closed_at = state == 'closed' ? 1.day.ago : 1.day.from_now
+  petition_closed_at = state == 'closed' ? 1.day.ago : nil
   petition_state = state == 'closed' ? 'open' : state
   petition_args = {
     action: petition_action,

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -60,7 +60,7 @@ Given /^the petition I want to sign is (validated|sponsored|open|hidden|rejected
 end
 
 Given /^the petition I want to sign has been closed$/ do
-  @sponsor_petition = FactoryGirl.create(:open_petition, closed_at: 1.day.ago)
+  @sponsor_petition = FactoryGirl.create(:closed_petition, closed_at: 1.day.ago)
 end
 
 Then(/^I am redirected to the petition closed page$/) do

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -35,7 +35,7 @@ namespace :import do
         petition.title              = row['title']
         petition.description        = row['description']
         petition.response           = row['response']
-        petition.state              = row['state']
+        petition.state              = row['state'] == 'open' ? 'closed' : row['state']
         petition.opened_at          = row['open_at']
         petition.closed_at          = row['closed_at']
         petition.signature_count    = row['signature_count']

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -42,10 +42,6 @@ RSpec.describe Admin::ModerationController, type: :controller do
           expect(petition.open_at).to be_within(1.second).of(now)
         end
 
-        it "sets the closed date to the end of the day on the date #{Site.petition_duration} months from now" do
-          expect(petition.closed_at).to be_within(1.second).of(closing_date)
-        end
-
         it "redirects to the admin show page for the petition page" do
           expect(response).to redirect_to("https://petition.parliament.uk/admin/petitions/#{petition.id}")
         end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,9 +20,11 @@ FactoryGirl.define do
 
   factory :archived_petition do
     sequence(:title) { |n| "Petition #{n}" }
+    state "closed"
     description "Petition description"
     signature_count 0
     opened_at { 2.years.ago }
+    closed_at { 1.year.ago }
 
     trait :response do
       response "Petition response"
@@ -35,12 +37,13 @@ FactoryGirl.define do
     trait :open do
       state "open"
       signature_count 100
+      closed_at { 6.month.from_now }
     end
 
     trait :closed do
-      state "open"
+      state "closed"
       signature_count 100
-      closed_at { 1.year.ago }
+      closed_at { 6.months.ago }
     end
 
     trait :rejected do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -102,7 +102,6 @@ FactoryGirl.define do
   factory :open_petition, :parent => :petition do
     state      Petition::OPEN_STATE
     open_at    { Time.current }
-    closed_at  { open_at + 1.day }
   end
 
   factory :closed_petition, :parent => :petition do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -106,7 +106,7 @@ FactoryGirl.define do
   end
 
   factory :closed_petition, :parent => :petition do
-    state      Petition::OPEN_STATE
+    state      Petition::CLOSED_STATE
     open_at    { 10.days.ago }
     closed_at  { 1.day.ago }
   end

--- a/spec/jobs/close_petitions_job_spec.rb
+++ b/spec/jobs/close_petitions_job_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ClosePetitionsJob, type: :job do
-  context "when a petition is in the open state and closed_at has not passed" do
-    let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.from_now) }
+  let!(:petition) { FactoryGirl.create(:open_petition, open_at: open_at) }
+
+  context "when a petition is in the open state and closing date has not passed" do
+    let(:open_at) { Site.opened_at_for_closing(1.day.from_now) }
 
     it "does not close the petition" do
       expect{
@@ -14,7 +16,7 @@ RSpec.describe ClosePetitionsJob, type: :job do
   end
 
   context "when a petition is in the open state and closed_at has passed" do
-    let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.ago) }
+    let(:open_at) { Site.opened_at_for_closing(1.day.ago) }
 
     it "does close the petition" do
       expect{

--- a/spec/jobs/close_petitions_job_spec.rb
+++ b/spec/jobs/close_petitions_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ClosePetitionsJob, type: :job do
+  context "when a petition is in the open state and closed_at has not passed" do
+    let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.from_now) }
+
+    it "does not close the petition" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.state }
+    end
+  end
+
+  context "when a petition is in the open state and closed_at has passed" do
+    let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.ago) }
+
+    it "does close the petition" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.to change{ petition.reload.state }.from('open').to('closed')
+    end
+  end
+end

--- a/spec/models/archived_petition_spec.rb
+++ b/spec/models/archived_petition_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ArchivedPetition, type: :model do
     end
 
     it { is_expected.to validate_presence_of(:state) }
-    it { is_expected.to validate_inclusion_of(:state).in_array(%w[open rejected]) }
+    it { is_expected.to validate_inclusion_of(:state).in_array(%w[open closed rejected]) }
   end
 
   describe "#reason_for_rejection" do
@@ -85,6 +85,8 @@ RSpec.describe ArchivedPetition, type: :model do
     it "defaults to nil" do
       expect(petition.closed_at).to be_nil
     end
+
+    it { is_expected.to validate_presence_of(:closed_at) }
   end
 
   describe "#signature_count" do

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -723,6 +723,62 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe ".close_petitions!" do
+    context "when a petition is in the open state and closed_at has not passed" do
+      let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.from_now) }
+
+      it "does not close the petition" do
+        expect{
+          described_class.close_petitions!
+        }.not_to change{ petition.reload.state }
+      end
+    end
+
+    context "when a petition is in the open state and closed_at has passed" do
+      let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.ago) }
+
+      it "does close the petition" do
+        expect{
+          described_class.close_petitions!
+        }.to change{ petition.reload.state }.from('open').to('closed')
+      end
+    end
+  end
+
+  describe ".in_need_of_closing" do
+    context "when a petition is in the closed state and closed_at has not passed" do
+      let!(:petition) { FactoryGirl.create(:closed_petition, closed_at: 3.days.from_now) }
+
+      it "does not find the petition" do
+        expect(described_class.in_need_of_closing.to_a).not_to include(petition)
+      end
+    end
+
+    context "when a petition is in the closed state and closed_at has passed" do
+      let!(:petition) { FactoryGirl.create(:closed_petition, closed_at: 3.days.ago) }
+
+      it "does not find the petition" do
+        expect(described_class.in_need_of_closing.to_a).not_to include(petition)
+      end
+    end
+
+    context "when a petition is in the open state and closed_at has not passed" do
+      let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.from_now) }
+
+      it "does not find the petition" do
+        expect(described_class.in_need_of_closing.to_a).not_to include(petition)
+      end
+    end
+
+    context "when a petition is in the open state and closed_at has passed" do
+      let!(:petition) { FactoryGirl.create(:open_petition, closed_at: 3.days.ago) }
+
+      it "does not find the petition" do
+        expect(described_class.in_need_of_closing.to_a).to include(petition)
+      end
+    end
+  end
+
   describe ".with_invalid_signature_counts" do
     let!(:petition) { FactoryGirl.create(:open_petition, attributes) }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -397,17 +397,17 @@ RSpec.describe Site, type: :model do
     end
   end
 
-  describe ".petition_closed_at" do
+  describe ".opened_at_for_closing" do
     let(:site) { double(:site) }
-    let(:closed_at) { 3.months.from_now.end_of_day }
+    let(:opened_at) { 3.months.ago.end_of_day }
 
     before do
       expect(Site).to receive(:first_or_create).and_return(site)
     end
 
-    it "delegates petition_closed_at to the instance" do
-      expect(site).to receive(:petition_closed_at).and_return(closed_at)
-      expect(Site.petition_closed_at).to eq(closed_at)
+    it "delegates opened_at_for_closing to the instance" do
+      expect(site).to receive(:opened_at_for_closing).and_return(opened_at)
+      expect(Site.opened_at_for_closing).to eq(opened_at)
     end
   end
 
@@ -562,13 +562,13 @@ RSpec.describe Site, type: :model do
     end
   end
 
-  describe "#petition_closed_at" do
+  describe "#opened_at_for_closing" do
     subject :site do
       described_class.create!(petition_duration: 3)
     end
 
-    it "returns the closing date in petition_duration months" do
-      expect(site.petition_closed_at).to eq(3.months.from_now.end_of_day)
+    it "returns the opening date at petition_duration months ago" do
+      expect(site.opened_at_for_closing).to eq(3.months.ago.end_of_day)
     end
   end
 end


### PR DESCRIPTION
As part of a series of steps to simplify our list queries make the closed state a real state and not based on it being open and the closed_at time being in the past.
