### PR TITLE
Use correct language attribute for <html> element

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="EN-GB">
+<html lang="en-GB">
   <head>
     <% @title = yield :page_title; @title = "Petition parliament" if @title.blank? -%>
     <title><%= @title %></title>


### PR DESCRIPTION
The [HTML5][1] specification states that the `lang` attribute should be a valid [BCP 47][2] language tag or an empty string. Typically this consists of the following:

```
<language>-<script>-<region>
```

where the components are the following:

*language:* a valid [ISO 639][3] code, e.g. 'en'
*script:* a valid [ISO 15924][4], e.g. 'Latn'
*region:* a valid [ISO 3166-1][5] or [UN M.49][6] code, e.g. 'GB'

The `script` and `region` components are often not specified, especially for english documents where it would normally be `lang="en"`. In our case since most english documents are in latin script we can leave this out but we still want to indicate our region.

[1]: http://www.w3.org/TR/html5/dom.html#the-lang-and-xml:lang-attributes
[2]: http://www.ietf.org/rfc/bcp/bcp47.txt
[3]: https://en.wikipedia.org/wiki/ISO_639
[4]: https://en.wikipedia.org/wiki/ISO_15924
[5]: https://en.wikipedia.org/wiki/ISO_3166-1
[6]: https://en.wikipedia.org/wiki/UN_M.49