### PR TITLE
[parameterise_puma_config_1] Add puma env params

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,4 +15,4 @@ test:
 production:
   <<: *default
   database: epets_production
-  pool: 16
+  pool: <%= ENV.fetch('WEB_CONCURRENCY_MAX_THREADS') { 32 }.to_i %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,16 @@ pidfile "/home/deploy/#{application_name}/shared/pids/puma.pid"
 bind "unix:///var/run/pumacorn/#{application_name}.sock"
 
 # Based on https://raw.githubusercontent.com/codetriage/codetriage/master/config/puma.rb
-workers ENV.fetch('WEB_CONCURRENCY') { 2 }.to_i
+concurrency = {
+  # Set to default of 4 workers - c4.xlarge has 4 CPUs
+  workers: ENV.fetch('WEB_CONCURRENCY') { 4 }.to_i,
+  # Some experimentation seems to indicate these are reasonable options:
+  min_threads: ENV.fetch('WEB_CONCURRENCY_MIN_THREADS') { 16 }.to_i,
+  max_threads: ENV.fetch('WEB_CONCURRENCY_MAX_THREADS') { 32 }.to_i
+}
+
+workers(concurrency[:workers])
+threads(concurrency[:min_threads], concurrency[:max_threads])
 
 preload_app!
 


### PR DESCRIPTION
- Added environment variable parameters for Puma with more useful defaults
- Set the number of database threads to vary based on ENV variables

Note that I've defaulted the thread count to 4. This correlates with the c4.xlarge in the comments. We're still doing performance testing, but c4.xlarge seems to do quite well.