### PR TITLE
Drop .field_with_errors wrapper from form field markup

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,8 @@ module Epets
 
     config.active_job.queue_adapter = :delayed_job
 
+    config.action_view.field_error_proc = -> (html_tag, instance) { html_tag }
+
     # Add 503 Service Unavailable to the rescue response
     config.action_dispatch.rescue_responses.merge!(
       'Site::ServiceUnavailable' => :service_unavailable


### PR DESCRIPTION
Drop the default `.field_with_errors` wrapper. This is unnecessary for our styling and stopped the character counter working it reordered the DOM