### PR TITLE
Remove character count when checking for existing petitions

### DIFF
--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -4,7 +4,7 @@
 <form method="get" action="/petitions/check_results">
   <div class="form-group">
     <label for="q" class="form-label">What do you want us to do?</label>
-    <textarea name="q" id="q" value="<%= @petitions.try(:query) %>" class="form-control" rows="3" data-max-length="80"></textarea>
+    <textarea name="q" id="q" value="<%= @petitions.try(:query) %>" class="form-control" rows="3"></textarea>
     <p class="character-count">80 characters max</p>
     <%= render 'petitions/action_help' %>
   </div>

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -18,5 +18,5 @@
   <p>If one of the petitions above matches yours, sign it and share it instead.</p>
   <p>You're more likely to get to 10,000 and 100,000 signatures that way.</p>
 <% end %>
-<%= link_to create_button_text, new_petition_path(:petition_action => @petitions.query.first(80)),
+<%= link_to create_button_text, new_petition_path(:petition_action => @petitions.query.first(255)),
     :class => 'button' %>


### PR DESCRIPTION
Drop the character counter (as it is a guide only) and truncate action
at 255 instead of 80