### PR TITLE
Change font-stack to use Helvetica/Arial, remove Roboto

### DIFF
--- a/app/assets/stylesheets/govuk_frontend_toolkit/_font_stack.scss
+++ b/app/assets/stylesheets/govuk_frontend_toolkit/_font_stack.scss
@@ -1,7 +1,7 @@
 //  Petitions font stacks, referred to in typography.scss
 
 // Petitions font stack
-$petitions-font: "Roboto", Arial, sans-serif;
+$petitions-font: "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 // No tabular font stack yet
 $petitions-font-tabular: $petitions-font;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <title><%= page_title %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <link href='//fonts.googleapis.com/css?family=Roboto:400,700' rel='stylesheet' type='text/css'>
 
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag 'application' %><!--<![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag 'application-ie7' %><![endif]-->


### PR DESCRIPTION
At the request of @benterrett – for now, until we can talk to the Parliament lot about webfonts