### PR TITLE
Public homepage changes

### DIFF
--- a/app/assets/stylesheets/petitions/views/_home.scss
+++ b/app/assets/stylesheets/petitions/views/_home.scss
@@ -1,6 +1,6 @@
 .trending {
   h2 {
-    margin-top: $gutter-half; 
+    margin-top: $gutter-half;
     margin-bottom: $gutter-half;
   }
 }
@@ -21,6 +21,19 @@
   .count {
     @include bold-48();
     display: block;
+  }
+}
+
+.threshold-panel {
+  .threshold-panel-header {
+    @extend .section-panel;
+    background-color: $petitions-header-colour;
+    color: $white;
+    border-bottom: none;
+    padding-top: $gutter-half;
+  }
+  .threshold-panel-body {
+    @extend .section-panel;
   }
 }
 

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -14,8 +14,8 @@
 
   <ol class="list-number">
     <li>Anyone can <%= link_to "create a petition", check_petitions_path %> (as long as they are a British citizen or UK resident)</li>
-    <li>If the petition gets 10,000 signatures, the government will reply</li>
-    <li>If the petition gets 100,000 signatures, the petition will be considered for debate in Parliament</li>
+    <li>If the petition gets <%= number_with_delimiter Site.threshold_for_response %> signatures, the government will reply</li>
+    <li>If the petition gets <%= number_with_delimiter Site.threshold_for_debate %> signatures, the petition will be considered for debate in Parliament</li>
   </ol>
 
   <!-- <p>You can see the debates and government responses that petitions have caused</p> -->

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -31,7 +31,7 @@
     <div class="threshold-panel-header">
       <span class="graphic graphic-crown-white"></span>
       <h2 id="response-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
-      <p>If a petition gets 10,000 signatures, the government will respond</p>
+      <p>If a petition gets <%= number_with_delimiter Site.threshold_for_response %>, the government will respond</p>
     </div>
     <div class="threshold-panel-body">
       <p><%= link_to_unless counts[:with_response].zero?, petition_count(:with_response_explanation, counts[:with_response]), petitions_path(state: :with_response) %></p>
@@ -41,8 +41,8 @@
   <section class="threshold-panel"  aria-labelledby="debate-threshold-heading">
     <div class="threshold-panel-header">
       <span class="graphic graphic-portcullis-white"></span>
-      <h2 id="debate-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
-      <p>If a petition gets 100,000 signatures, it will be considered for debate in Parliament</p>
+      <h2 id="debate-threshold-heading"><%= number_with_delimiter Site.threshold_for_debate %> <span>signatures</span></h2>
+      <p>If a petition gets <%= number_with_delimiter Site.threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
     </div>
     <div class="threshold-panel-body">
       <p><%= link_to_unless counts[:with_debate_outcome].zero?, petition_count(:with_debate_outcome_explanation, counts[:with_debate_outcome]), petitions_path(state: :with_debate_outcome) %></p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="visuallyhidden">Petitions - tell the government what you think</h1>
 
-<% petition_counts do |counts| %>
+<% actioned_petition_counts do |counts| %>
   <div class="section-panel actioned-petitions">
     <ul>
       <% counts.each do |state, count| %>
@@ -25,6 +25,30 @@
   <% end %>
   <%= link_to 'View all open petitions', petitions_path(state: 'open'), :class => 'view-all' %>
 </div>
+
+<% explanation_petition_counts do |counts| %>
+  <section class="threshold-panel" aria-labelledby="response-threshold-heading">
+    <div class="threshold-panel-header">
+      <span class="graphic graphic-crown-white"></span>
+      <h2 id="response-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
+      <p>If a petition gets 10,000 signatures, the government will respond</p>
+    </div>
+    <div class="threshold-panel-body">
+      <p><%= link_to_unless counts[:with_response].zero?, petition_count(:with_response_explanation, counts[:with_response]), petitions_path(state: :with_response) %></p>
+    </div>
+  </section>
+
+  <section class="threshold-panel"  aria-labelledby="debate-threshold-heading">
+    <div class="threshold-panel-header">
+      <span class="graphic graphic-portcullis-white"></span>
+      <h2 id="debate-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
+      <p>If a petition gets 100,000 signatures, it will be considered for debate in Parliament</p>
+    </div>
+    <div class="threshold-panel-body">
+      <p><%= link_to_unless counts[:with_debate_outcome].zero?, petition_count(:with_debate_outcome_explanation, counts[:with_debate_outcome]), petitions_path(state: :with_debate_outcome) %></p>
+    </div>
+  </section>
+<% end %>
 
 <section class="section-panel local-to-you" aria-labelledby="local-to-you-heading">
   <h2 id="local-to-you-heading">Local to you</h2>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -23,7 +23,7 @@
       </ul>
     </section>
   <% end %>
-  <%= link_to 'View all petitions', petitions_path, :class => 'view-all' %>
+  <%= link_to 'View all open petitions', petitions_path(state: 'open'), :class => 'view-all' %>
 </div>
 
 <section class="section-panel local-to-you" aria-labelledby="local-to-you-heading">

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -1,6 +1,6 @@
-<section class="about-item about-item-count-100000" aria-labelledby="debate-threshold-heading">
+<section class="about-item about-item-count-debate" aria-labelledby="debate-threshold-heading">
   <span class="graphic graphic-portcullis"></span>
-  <h2 id="debate-threshold-heading">100,000 <span>signatures</span></h2>
+  <h2 id="debate-threshold-heading"><%= number_with_delimiter Site.threshold_for_debate %> <span>signatures</span></h2>
   <%# Has debate outcome details #%>
   <% if petition.debate_outcome.present? -%>
     <section class="debate-outcome">
@@ -23,6 +23,6 @@
       You'll be able to watch online at <a href="http://parliamentlive.tv" rel="external">parliamentlive.tv</a>
     </p>
   <% else -%>
-    <p>If a petition gets 100,000 signatures, it will be considered for debate in Parliament</p>
+    <p>If a petition gets <%= number_with_delimiter Site.threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
   <% end -%>
 </section>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -1,6 +1,6 @@
-<section class="about-item about-item-count-10000" aria-labelledby="response-threshold-heading">
+<section class="about-item about-item-count-response" aria-labelledby="response-threshold-heading">
   <span class="graphic graphic-crown"></span>
-  <h2 id="response-threshold-heading">10,000 <span>signatures</span></h2>
+  <h2 id="response-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
   <%# Has response #%>
   <% if petition.response_summary.present? -%>
     <h3>The government responded</h3>
@@ -17,6 +17,6 @@
       </details>
     <% end -%>
   <% else -%>
-    <p>If a petition gets 10,000 signatures, the government will respond</p>
+    <p>If a petition gets <%= number_with_delimiter Site.threshold_for_response %> signatures, the government will respond</p>
   <% end -%>
 </section>

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -14,7 +14,7 @@
   <%= render 'notification', text: 'If there\'s already a petition on the same topic, your petition is likely to be rejected' %>
 
   <p>If one of the petitions above matches yours, sign it and share it instead.</p>
-  <p>You're more likely to get to 10,000 and 100,000 signatures that way.</p>
+  <p>You're more likely to get to <%= number_with_delimiter Site.threshold_for_response %> and <%= number_with_delimiter Site.threshold_for_debate %> signatures that way.</p>
 <% end %>
 <%= link_to create_button_text, new_petition_path(:petition_action => @petitions.query.first(255)),
     :class => 'button' %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -120,12 +120,20 @@ en-GB:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition was debated in parliament"
           other: "<span class=\"count\">%{formatted_count}</span> petitions were debated in parliament"
+      with_response_explanation:
+        html:
+          zero: "There aren't any petitions with a government response yet"
+          other: "Petitions with a government response (%{formatted_count})"
+      with_debate_outcome_explanation:
+        html:
+          zero: There aren't any petitions that have been debated in parliament yet
+          other: "Petitions debated in parliament (%{formatted_count})"
 
     action_counts:
-      in_moderation: 
+      in_moderation:
         html:
           "<span class=\"count\">%{formatted_count}</span> Moderation queue"
-      awaiting_response: 
+      awaiting_response:
         html:
           "<span class=\"count\">%{formatted_count}</span> Government response queue"
       all:

--- a/features/step_definitions/actioned_steps.rb
+++ b/features/step_definitions/actioned_steps.rb
@@ -1,23 +1,49 @@
-Given /^There are (\d+) petitions debated in parliament$/ do |debated_count|
+Given(/^there are (\d+) petitions debated in parliament$/) do |debated_count|
   debated_count.times do |count|
     petition = FactoryGirl.create(:debated_petition, :action => "Petition #{count}")
   end
 end
 
-Given /^There are (\d+) petitions with a government response$/ do |response_count|
+Given(/^there are (\d+) petitions with a government response$/) do |response_count|
   response_count.times do |count|
     petition = FactoryGirl.create(:responded_petition, :action => "Petition #{count}")
   end
 end
 
-Then /^I should not see the actioned petitions section$/ do
+Then(/^I should not see the actioned petitions section$/) do
   expect(page).to_not have_css(".actioned-petitions")
 end
 
-Then /^I should see there are (.*?) petitions with a government response$/ do |response_count|
+Then(/^I should see there are (.*?) petitions with a government response$/) do |response_count|
   expect(page).to have_css(".actioned-petitions ul li:first-child .count", :text => response_count)
 end
 
-Then /^I should see there are (.*?) petitions debated in parliament$/ do |debated_count|
+Then(/^I should see there are (.*?) petitions debated in parliament$/) do |debated_count|
   expect(page).to have_css(".actioned-petitions ul li:last-child .count", :text => debated_count)
+end
+
+Then(/^I should see an empty government response threshold section$/) do
+  within(:css, ".threshold-panel[aria-labelledby=response-threshold-heading]") do
+    expect(page).to have_no_css("a[href='#{petitions_path(state: :with_response)}']")
+  end
+end
+
+Then(/^I should see an empty debate threshold section$/) do
+  within(:css, ".threshold-panel[aria-labelledby=debate-threshold-heading]") do
+    expect(page).to have_no_css("a[href='#{petitions_path(state: :with_debate_outcome)}']")
+  end
+end
+
+Then(/^I should see the government response threshold section with a count of (\d+)$/) do |response_petitions_count|
+  within(:css, ".threshold-panel[aria-labelledby=response-threshold-heading]") do
+    link_text = "Petitions with a government response (#{response_petitions_count})"
+    expect(page).to have_link(link_text, href: petitions_path(state: :with_response))
+  end
+end
+
+Then(/^I should see the debate threshold section with a count of (\d+)$/) do |debate_petitions_count|
+  within(:css, ".threshold-panel[aria-labelledby=debate-threshold-heading]") do
+    link_text = "Petitions debated in parliament (#{debate_petitions_count})"
+    expect(page).to have_link(link_text, href: petitions_path(state: :with_debate_outcome))
+  end
 end

--- a/features/suzie_sees_actioned_petitions.feature
+++ b/features/suzie_sees_actioned_petitions.feature
@@ -6,20 +6,28 @@ Feature: Suzie sees actioned petitions
   Scenario: There are no actioned petitions
     Given I am on the home page
     Then I should not see the actioned petitions section
+    But I should see an empty government response threshold section
+    And I should see an empty debate threshold section
 
   Scenario: There are petitions with a response from government
-    Given There are 2 petitions with a government response
+    Given there are 2 petitions with a government response
     And I am on the home page
     Then I should see there are 2 petitions with a government response
+    And I should see the government response threshold section with a count of 2
+    And I should see an empty debate threshold section
 
   Scenario: There are petitions debated in parliament
-    Given There are 123 petitions debated in parliament
+    Given there are 3 petitions debated in parliament
     And I am on the home page
-    Then I should see there are 123 petitions debated in parliament
+    Then I should see there are 3 petitions debated in parliament
+    And I should see an empty government response threshold section
+    And I should see the debate threshold section with a count of 3
 
   Scenario: There are petitions with a response from government and petitions debated in parliament
-    Given There are 57 petitions with a government response
-    Given There are 12 petitions debated in parliament
+    Given there are 5 petitions with a government response
+    And there are 2 petitions debated in parliament
     And I am on the home page
-    Then I should see there are 57 petitions with a government response
-    Then I should see there are 12 petitions debated in parliament
+    Then I should see there are 5 petitions with a government response
+    Then I should see there are 2 petitions debated in parliament
+    And I should see the government response threshold section with a count of 5
+    And I should see the debate threshold section with a count of 2

--- a/lib/tasks/data-generator.rake
+++ b/lib/tasks/data-generator.rake
@@ -84,7 +84,7 @@ namespace :data do
 
         # Should we create a petition with response and 10K signatures
         @should_create_response = (((idx+1) % 5) == 0 && RANDOM_RESPONSE == 'true')
-        @signature_count = 10001 if @should_create_response
+        @signature_count = Site.threshold_for_response + 1 if @should_create_response
 
         @signature_count.to_i.times do
           petition.signatures.create!(


### PR DESCRIPTION
1. https://www.pivotaltracker.com/story/show/97989236 - Make the "view all petitions" link be "view all open petitions" and go to that filtered list, not the all petitions

2. https://www.pivotaltracker.com/story/show/97805100 - Stick some big green header sections on about petitions with a response and petitions with a debate.