### PR TITLE
Extract formatted threshold numbers to the site model

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,8 +1,11 @@
 require 'bcrypt'
 require 'uri'
+require 'active_support/number_helper'
 
 class Site < ActiveRecord::Base
   class ServiceUnavailable < StandardError; end
+
+  include ActiveSupport::NumberHelper
 
   class << self
     def before_remove_const
@@ -23,6 +26,18 @@ class Site < ActiveRecord::Base
 
     def enabled?
       instance.enabled?
+    end
+
+    def formatted_threshold_for_moderation
+      instance.formatted_threshold_for_moderation
+    end
+
+    def formatted_threshold_for_response
+      instance.formatted_threshold_for_response
+    end
+
+    def formatted_threshold_for_debate
+      instance.formatted_threshold_for_debate
     end
 
     def host
@@ -161,6 +176,18 @@ class Site < ActiveRecord::Base
 
   def email_protocol
     uri.scheme
+  end
+
+  def formatted_threshold_for_moderation
+    number_to_delimited(threshold_for_moderation)
+  end
+
+  def formatted_threshold_for_response
+    number_to_delimited(threshold_for_response)
+  end
+
+  def formatted_threshold_for_debate
+    number_to_delimited(threshold_for_debate)
   end
 
   def host

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -14,8 +14,8 @@
 
   <ol class="list-number">
     <li>Anyone can <%= link_to "create a petition", check_petitions_path %> (as long as they are a British citizen or UK resident)</li>
-    <li>If the petition gets <%= number_with_delimiter Site.threshold_for_response %> signatures, the government will reply</li>
-    <li>If the petition gets <%= number_with_delimiter Site.threshold_for_debate %> signatures, the petition will be considered for debate in Parliament</li>
+    <li>If the petition gets <%= Site.formatted_threshold_for_response %> signatures, the government will reply</li>
+    <li>If the petition gets <%= Site.formatted_threshold_for_debate %> signatures, the petition will be considered for debate in Parliament</li>
   </ol>
 
   <!-- <p>You can see the debates and government responses that petitions have caused</p> -->

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -30,8 +30,8 @@
   <section class="threshold-panel" aria-labelledby="response-threshold-heading">
     <div class="threshold-panel-header">
       <span class="graphic graphic-crown-white"></span>
-      <h2 id="response-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
-      <p>If a petition gets <%= number_with_delimiter Site.threshold_for_response %>, the government will respond</p>
+      <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %> <span>signatures</span></h2>
+      <p>If a petition gets <%= Site.formatted_threshold_for_response %>, the government will respond</p>
     </div>
     <div class="threshold-panel-body">
       <p><%= link_to_unless counts[:with_response].zero?, petition_count(:with_response_explanation, counts[:with_response]), petitions_path(state: :with_response) %></p>
@@ -41,8 +41,8 @@
   <section class="threshold-panel"  aria-labelledby="debate-threshold-heading">
     <div class="threshold-panel-header">
       <span class="graphic graphic-portcullis-white"></span>
-      <h2 id="debate-threshold-heading"><%= number_with_delimiter Site.threshold_for_debate %> <span>signatures</span></h2>
-      <p>If a petition gets <%= number_with_delimiter Site.threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
+      <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %> <span>signatures</span></h2>
+      <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
     </div>
     <div class="threshold-panel-body">
       <p><%= link_to_unless counts[:with_debate_outcome].zero?, petition_count(:with_debate_outcome_explanation, counts[:with_debate_outcome]), petitions_path(state: :with_debate_outcome) %></p>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -1,6 +1,6 @@
 <section class="about-item about-item-count-debate" aria-labelledby="debate-threshold-heading">
   <span class="graphic graphic-portcullis"></span>
-  <h2 id="debate-threshold-heading"><%= number_with_delimiter Site.threshold_for_debate %> <span>signatures</span></h2>
+  <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %> <span>signatures</span></h2>
   <%# Has debate outcome details #%>
   <% if petition.debate_outcome.present? -%>
     <section class="debate-outcome">
@@ -23,6 +23,6 @@
       You'll be able to watch online at <a href="http://parliamentlive.tv" rel="external">parliamentlive.tv</a>
     </p>
   <% else -%>
-    <p>If a petition gets <%= number_with_delimiter Site.threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
+    <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
   <% end -%>
 </section>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -1,6 +1,6 @@
 <section class="about-item about-item-count-response" aria-labelledby="response-threshold-heading">
   <span class="graphic graphic-crown"></span>
-  <h2 id="response-threshold-heading"><%= number_with_delimiter Site.threshold_for_response %> <span>signatures</span></h2>
+  <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %> <span>signatures</span></h2>
   <%# Has response #%>
   <% if petition.response_summary.present? -%>
     <h3>The government responded</h3>
@@ -17,6 +17,6 @@
       </details>
     <% end -%>
   <% else -%>
-    <p>If a petition gets <%= number_with_delimiter Site.threshold_for_response %> signatures, the government will respond</p>
+    <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the government will respond</p>
   <% end -%>
 </section>

--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -14,7 +14,7 @@
   <%= render 'notification', text: 'If there\'s already a petition on the same topic, your petition is likely to be rejected' %>
 
   <p>If one of the petitions above matches yours, sign it and share it instead.</p>
-  <p>You're more likely to get to <%= number_with_delimiter Site.threshold_for_response %> and <%= number_with_delimiter Site.threshold_for_debate %> signatures that way.</p>
+  <p>You're more likely to get to <%= Site.formatted_threshold_for_response %> and <%= Site.formatted_threshold_for_debate %> signatures that way.</p>
 <% end %>
 <%= link_to create_button_text, new_petition_path(:petition_action => @petitions.query.first(255)),
     :class => 'button' %>

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -131,14 +131,29 @@ RSpec.describe Site, type: :model do
       expect(Site.threshold_for_moderation).to eq(5)
     end
 
+    it "delegates formatted_threshold_for_moderation to the instance" do
+      expect(site).to receive(:formatted_threshold_for_moderation).and_return("5,000")
+      expect(Site.formatted_threshold_for_moderation).to eq("5,000")
+    end
+
     it "delegates threshold_for_response to the instance" do
       expect(site).to receive(:threshold_for_response).and_return(10)
       expect(Site.threshold_for_response).to eq(10)
     end
 
+    it "delegates formatted_threshold_for_response to the instance" do
+      expect(site).to receive(:formatted_threshold_for_response).and_return("10,000")
+      expect(Site.formatted_threshold_for_response).to eq("10,000")
+    end
+
     it "delegates threshold_for_debate to the instance" do
       expect(site).to receive(:threshold_for_debate).and_return(100)
       expect(Site.threshold_for_debate).to eq(100)
+    end
+
+    it "delegates formatted_threshold_for_debate to the instance" do
+      expect(site).to receive(:formatted_threshold_for_debate).and_return("100,000")
+      expect(Site.formatted_threshold_for_debate).to eq("100,000")
     end
 
     it "delegates last_checked_at to the instance" do
@@ -517,6 +532,37 @@ RSpec.describe Site, type: :model do
 
     it "the protocol of the url" do
       expect(site.email_protocol).to eq("https")
+    end
+  end
+
+
+  describe "#formatted_threshold_for_moderation" do
+    subject :site do
+      described_class.create!(threshold_for_moderation: 5000)
+    end
+
+    it "returns a formatted number" do
+      expect(site.formatted_threshold_for_moderation).to eq("5,000")
+    end
+  end
+
+  describe "#formatted_threshold_for_response" do
+    subject :site do
+      described_class.create!(threshold_for_response: 10000)
+    end
+
+    it "returns a formatted number" do
+      expect(site.formatted_threshold_for_response).to eq("10,000")
+    end
+  end
+
+  describe "#formatted_threshold_for_debate" do
+    subject :site do
+      described_class.create!(threshold_for_debate: 100000)
+    end
+
+    it "returns a formatted number" do
+      expect(site.formatted_threshold_for_debate).to eq("100,000")
     end
   end
 


### PR DESCRIPTION
We are calling these formatted numbers in a number of places so add some convenience methods to make generating these easier.