### PR TITLE
Use id lookup in SignaturesController#signed

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -2,7 +2,7 @@ class SignaturesController < ApplicationController
   include ManagingMoveParameter
 
   before_filter :retrieve_petition, :only => [:new, :create, :thank_you]
-  before_filter :retrieve_signature, :only => [:verify, :unsubscribe]
+  before_filter :retrieve_signature, :only => [:verify, :unsubscribe, :signed]
 
   respond_to :html
 
@@ -22,9 +22,13 @@ class SignaturesController < ApplicationController
   end
 
   def signed
-    @signature = Signature.find_by!(perishable_token: params[:id])
-    redirect_to(verify_signature_url(@signature, @signature.perishable_token)) and return unless @signature.validated?
-    @petition = @signature.petition
+    verify_token
+
+    if @signature.validated?
+      @petition = @signature.petition
+    else
+      redirect_to(verify_signature_url(@signature, @signature.perishable_token))
+    end
   end
 
   def verify
@@ -129,7 +133,7 @@ class SignaturesController < ApplicationController
     else
       @signature.validate!
     end
-    redirect_to signed_petition_signature_url(@signature.petition, @signature.perishable_token)
+    redirect_to signed_signature_url(@signature, token: @signature.perishable_token)
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,6 @@ Rails.application.routes.draw do
     resources :signatures, :only => [:new] do
       post 'new' => 'signatures#create', :as => :sign, :on => :collection
       get 'thank-you', :action => :thank_you, :on => :collection, :as => :thank_you
-      get 'signed', :action => :signed, :on => :member, :as => :signed
     end
   end
 
@@ -35,9 +34,10 @@ Rails.application.routes.draw do
 
   get 'search' => 'search#search', :as => :search
 
-  resources :signatures, :only => [] do
-    get 'verify/:token', :action => :verify, :on => :member, :as => :verify
-    get 'unsubscribe/:unsubscribe_token', :action => :unsubscribe, :on => :member, :as => :unsubscribe
+  scope 'signatures/:id' do
+    get 'verify/:token' => 'signatures#verify', :as => :verify_signature
+    get 'unsubscribe/:unsubscribe_token' => 'signatures#unsubscribe', :as => :unsubscribe_signature
+    get 'signed/:token' => 'signatures#signed', :as => :signed_signature
   end
 
   namespace :archived do

--- a/spec/routing/signatures_spec.rb
+++ b/spec/routing/signatures_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe "routes for signatures", type: :routing do
+  # Routes nested to /petition/:petition_id
+  it "doesn't route GET /petitions/1/signatures" do
+    expect(get("/petitions/1/signatures")).not_to be_routable
+  end
+
+  it "routes GET /petitions/1/signatures/new to signatures#new" do
+    expect(get("/petitions/1/signatures/new")).to route_to('signatures#new', petition_id: '1')
+  end
+
+  it "doesn't route POST /petitions/1/signatures" do
+    expect(post("/petitions/1/signatures")).not_to be_routable
+  end
+
+  it "routes POST /petitions/1/signatures/new to signatures#create" do
+    expect(post("/petitions/1/signatures/new")).to route_to('signatures#create', petition_id: '1')
+  end
+
+  it "routes GET /petitions/1/signatures/thank-you to signatures#thank_you" do
+    expect(get("/petitions/1/signatures/thank-you")).to route_to('signatures#thank_you', petition_id: '1')
+  end
+
+  it "doesn't route GET /petitions/1/signatures/2" do
+    expect(post("/petitions/1/signatures/2")).not_to be_routable
+  end
+
+  it "doesn't route GET /petitions/1/signatures/2/edit" do
+    expect(post("/petitions/1/signatures/2/edit")).not_to be_routable
+  end
+
+  it "doesn't route PATCH /petitions/1/signatures/2" do
+    expect(patch("/petitions/1/signatures/2")).not_to be_routable
+  end
+
+  it "doesn't route DELETE /petitions/1/signatures/2" do
+    expect(delete("/petitions/1/signatures/2")).not_to be_routable
+  end
+
+  # un-nested routes
+  it "routes GET /signatures/:id/verify/:token to signatures#verify" do
+    expect({:get => "/signatures/1/verify/abcdef1234567890"}).
+      to route_to("signatures#verify", id: '1', token: 'abcdef1234567890')
+
+    expect(verify_signature_path('1', 'abcdef1234567890')).to eq('/signatures/1/verify/abcdef1234567890')
+  end
+
+  it "routes GET /signatures/:id/unsubscribe/:token to signatures#unsubscribe" do
+    expect({:get => "/signatures/1/unsubscribe/abcdef1234567890"}).
+      to route_to("signatures#unsubscribe", id: '1', unsubscribe_token: 'abcdef1234567890')
+
+    expect(unsubscribe_signature_path('1', 'abcdef1234567890')).to eq('/signatures/1/unsubscribe/abcdef1234567890')
+  end
+
+  it "routes GET /signatures/:id/signed/:token to signatures#signed" do
+    expect({:get => "/signatures/1/signed/abcdef1234567890"}).
+      to route_to("signatures#signed", id: '1', token: 'abcdef1234567890')
+
+    expect(signed_signature_path('1', 'abcdef1234567890')).to eq('/signatures/1/signed/abcdef1234567890')
+  end
+
+  it "doesn't route GET /signatures" do
+    expect(get("/signatures")).not_to be_routable
+  end
+
+  it "doesn't route GET /signatures/new" do
+    expect(get("/signatures/new")).not_to be_routable
+  end
+
+  it "doesn't route POST /signatures" do
+    expect(post("/signatures")).not_to be_routable
+  end
+
+  it "doesn't route GET /signatures/1" do
+    expect(post("/signatures/2")).not_to be_routable
+  end
+
+  it "doesn't route GET /signatures/1/edit" do
+    expect(post("/signatures/2/edit")).not_to be_routable
+  end
+
+  it "doesn't route PATCH /signatures/1" do
+    expect(patch("/signatures/2")).not_to be_routable
+  end
+
+  it "doesn't route DELETE /signatures/1" do
+    expect(delete("/signatures/2")).not_to be_routable
+  end
+end


### PR DESCRIPTION
This page, the final step in signing a petition, had a url ``/petitions/<id>/signatures/<token>/signed`` which meant to find the signature we did a full table scan lookup on ``Signature#perishable_token``.  This is not particularly performant, particularly as ``perishable_token`` is not indexed, as such it was a bottleneck in the signing flow: these slow full table scans cause a lock on any writes to the table (e.g. for other signers at the initial signing or verification point in the flow).

The fix is to rework this action to be like ``SignaturesController#verify`` and ``SignaturesController#unsubscribe`` and lookup by id, but reject the request if the token does not match.  This means moving the url from ``/petitions/<id>/signatures/<token>/signed`` to ``/signatures/<id>/signed/<token>``.

(Discovered as part of: https://www.pivotaltracker.com/story/show/95979302)