### PR TITLE
Slimming transactional queries for validate

### DIFF
--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -15,7 +15,7 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
   }
 
   def self.for(petition, constituency_id)
-    find_or_create_by(petition: petition, constituency_id: constituency_id)
+    find_or_initialize_by(petition: petition, constituency_id: constituency_id)
   end
 
   def self.record_new_signature_for(signature)
@@ -24,9 +24,13 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
   end
 
   def record_new_signature(at = Time.current)
-    signature_count_field = self.class.connection.quote_column_name('signature_count')
-    changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
-    self.class.where(id: id).update_all([changes, updated_at: at])
-    reload
+    if self.new_record?
+      update_attributes(signature_count: 1)
+    else
+      signature_count_field = self.class.connection.quote_column_name('signature_count')
+      changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
+      self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
+      reload
+    end
   end
 end

--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -30,7 +30,9 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
       signature_count_field = self.class.connection.quote_column_name('signature_count')
       changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
       self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
-      reload
+      # NOTE: even though we don't assume +1 is ok for the SQL update, we
+      # want to avoid an extra SQL select from .reload so +1 is ok here
+      raw_write_attribute(:signature_count, signature_count+1)
     end
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -104,15 +104,15 @@ class Signature < ActiveRecord::Base
 
   def validate!
     if pending?
+      petition.creator_signature.validate! unless creator?
+
       Petition.transaction do
         self.update_columns(
           state:        VALIDATED_STATE,
           validated_at: Time.current,
           updated_at:   Time.current
         )
-
         ConstituencyPetitionJournal.record_new_signature_for(self)
-        petition.creator_signature.validate!
         petition.increment_signature_count!
       end
     end

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
         other_copy.record_new_signature
         second_signature_count = other_copy.reload.signature_count
         subject.record_new_signature
+        expect(subject.signature_count).to eq(second_signature_count)
         expect(subject.reload.signature_count).to eq(second_signature_count + 1)
       end
 

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -95,6 +95,21 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
         subject.reload
         expect(subject.signature_count).not_to eq old_signature_count
       end
+
+      it "increments the signature_count in the DB properly" do
+        first_signature_count = subject.signature_count
+        other_copy = described_class.for(petition, constituency_id)
+        other_copy.record_new_signature
+        second_signature_count = other_copy.reload.signature_count
+        subject.record_new_signature
+        expect(subject.reload.signature_count).to eq(second_signature_count + 1)
+      end
+
+      it 'only executes the update SQL query' do
+        expect {
+          subject.record_new_signature
+        }.not_to exceed_query_limit(1)
+      end
     end
 
     context 'on a new instance' do

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -46,16 +46,15 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     end
 
     context "when there is no journal for the requested petition and constituency" do
-      it "creates a new instance in the DB" do
-        expect {
-          described_class.for(petition, constituency_id)
-        }.to change(described_class, :count).by(1)
-      end
-
-      it "returns the newly created instance" do
+      it "returns the newly initialized instance" do
         fetched = described_class.for(petition, constituency_id)
         expect(fetched).to be_a described_class
-        expect(fetched).to be_persisted
+      end
+
+      it "does not persist the new instance in the DB" do
+        expect {
+          described_class.for(petition, constituency_id)
+        }.to change(described_class, :count).by(0)
       end
 
       it "sets the petition of the new instance to the supplied petition" do
@@ -81,17 +80,33 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
 
     subject { described_class.for(petition, constituency_id) }
 
-    it "increments signature_count by 1" do
-      expect {
+    context 'on a saved instance' do
+      before { subject.update_attribute(:signature_count, 20) }
+
+      it "increments signature_count by 1" do
+        expect {
+          subject.record_new_signature
+        }.to change(subject, :signature_count).by(1)
+      end
+
+      it "persists the change" do
+        old_signature_count = subject.signature_count
         subject.record_new_signature
-      }.to change(subject, :signature_count).by(1)
+        subject.reload
+        expect(subject.signature_count).not_to eq old_signature_count
+      end
     end
 
-    it "persists the change" do
-      old_signature_count = subject.signature_count
-      subject.record_new_signature
-      subject.reload
-      expect(subject.signature_count).not_to eq old_signature_count
+    context 'on a new instance' do
+      it "sets the signature_count to 1" do
+        subject.record_new_signature
+        expect(subject.signature_count).to eq 1
+      end
+
+      it "saves the instance to the DB" do
+        subject.record_new_signature
+        expect(subject).to be_persisted
+      end
     end
   end
 
@@ -136,7 +151,7 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
 
     it "increments the signature_count of the existing instance by 1" do
       existing = described_class.for(signature.petition, signature.constituency_id)
-      existing.update_column(:signature_count, 20)
+      existing.update_attribute(:signature_count, 20)
 
       described_class.record_new_signature_for(signature)
 

--- a/spec/support/exceed_query_limit.rb
+++ b/spec/support/exceed_query_limit.rb
@@ -1,0 +1,19 @@
+# From: https://gist.github.com/rsutphin/af06c9e3dadf658d2293
+# Derived from http://stackoverflow.com/a/13423584/153896. Updated for RSpec 3.
+RSpec::Matchers.define :exceed_query_limit do |expected|
+  supports_block_expectations
+
+  match do |block|
+    query_count(&block) > expected
+  end
+
+  failure_message_when_negated do |actual|
+    "Expected to run maximum #{expected} queries, got #{@counter.query_count}"
+  end
+
+  def query_count(&block)
+    @counter = ActiveRecord::QueryCounter.new
+    ActiveSupport::Notifications.subscribed(@counter.to_proc, 'sql.active_record', &block)
+    @counter.query_count
+  end
+end

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,19 @@
+# From: https://gist.github.com/rsutphin/af06c9e3dadf658d2293
+# adapted from http://stackoverflow.com/a/13423584/153896
+module ActiveRecord
+  class QueryCounter
+    attr_reader :query_count
+
+    def initialize
+      @query_count = 0
+    end
+
+    def to_proc
+      lambda(&method(:callback))
+    end
+
+    def callback(name, start, finish, message_id, values)
+      @query_count += 1 unless %w(CACHE SCHEMA).include?(values[:name])
+    end
+  end
+end


### PR DESCRIPTION
@oskarpearson had a look at our query log during performance testing and noticed that doing signature validation had a bunch of queries in a transaction.  This PR is about trying to reduce that number:

1. move creator signature validation out of the transaction - it's a bit belt-and-braces that we even have it in here still, as the creator signature should be validated earlier in the process.  It doesn't hurt to try (as it's almost a no-op if it's already validated), but it doesn't need to happen in the transaction for validating the current signature
2. reduce the queries used by stamping the constituency petition journal.
  1. when the record already exists don't do a reload to refresh the in-memoery object after we issue the atomic sql `UPDATE` statement
  2. when the record doesn't exist, don't save it and then update it (2 queries), just insert with the correct signature count (1 query)
