### PR TITLE
Front end - sponsor headings, long links, home threshold boxes, word wrap

### DIFF
--- a/app/assets/stylesheets/petitions/_helpers.scss
+++ b/app/assets/stylesheets/petitions/_helpers.scss
@@ -26,3 +26,20 @@
   padding: 0;
   border: 0;
 }
+
+%petitions-outdent {
+  @extend %outdent-to-full-width;
+  @include media(tablet){
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+%petitions-outdent-and-pad {
+  @extend %petitions-outdent;
+  padding-left: $gutter-half;
+  padding-right: $gutter-half;
+  @include media(tablet){
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/app/assets/stylesheets/petitions/_helpers.scss
+++ b/app/assets/stylesheets/petitions/_helpers.scss
@@ -43,3 +43,10 @@
     padding-right: 0;
   }
 }
+
+%word-break {
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens:    auto;
+  hyphens:         auto;
+}

--- a/app/assets/stylesheets/petitions/_typography.scss
+++ b/app/assets/stylesheets/petitions/_typography.scss
@@ -48,6 +48,7 @@ h2, h3, h4 {
 }
 
 p {
+  @extend %word-break;
   margin-top: em(5, 16);
   margin-bottom: em(15, 16);
 

--- a/app/assets/stylesheets/petitions/views/_home.scss
+++ b/app/assets/stylesheets/petitions/views/_home.scss
@@ -25,16 +25,11 @@
 }
 
 .threshold-panel {
-  .threshold-panel-header {
-    @extend .section-panel;
-    background-color: $petitions-header-colour;
-    color: $white;
-    border-bottom: none;
-    padding-top: $gutter-half;
-  }
-  .threshold-panel-body {
-    @extend .section-panel;
-  }
+  @extend %petitions-outdent;
+  background-color: $petitions-header-colour;
+  color: $white;
+  padding: $gutter-half;
+  margin-bottom: $gutter-half;
 }
 
 @include media(tablet) {

--- a/app/assets/stylesheets/petitions/views/_petition-show.scss
+++ b/app/assets/stylesheets/petitions/views/_petition-show.scss
@@ -1,13 +1,3 @@
-.petitions-details {
-  border-bottom: 1px solid $panel-colour;
-  padding: $gutter-half;
-  @extend %outdent-to-full-width;
-
-  li {
-    margin-bottom: $gutter-half;
-  }
-}
-
 // Signature count and signature graph
 
 .signature-count {

--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -58,18 +58,16 @@ input.back-page {
 // Section panel
 // =================
 .section-panel {
-  @extend %outdent-to-full-width;
-  border-bottom: 1px solid $panel-colour;
+  @extend %petitions-outdent-and-pad;
   margin-top: $gutter-half;
   margin-bottom: $gutter-half;
-  padding: 0 $gutter-half $gutter-half;
-
-  @include media(tablet){
-    padding-left: 0;
-    padding-right: 0;
-    margin-left: 0;
-    margin-right: 0;
-  }
+  padding-bottom: $gutter-half;
+  border-bottom: 1px solid $panel-colour;
+}
+.section-panel-borderless {
+  @extend .section-panel;
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 // Notifications

--- a/app/assets/stylesheets/petitions/views/shared/_share-petition.scss
+++ b/app/assets/stylesheets/petitions/views/shared/_share-petition.scss
@@ -3,7 +3,7 @@
 .petition-share {
   $icon-size: 19px;
   @extend %contain-floats;
-  @extend %outdent-to-full-width;
+  @extend %petitions-outdent;
   border-bottom: 1px solid $panel-colour;
   li {
     float: left;
@@ -36,9 +36,6 @@
     background-position: center left;
   }
   @include media(tablet) {
-    margin-left: 0;
-    margin-right: 0;
-
     li {
       width: 25%;
       border-left: 1px solid $panel-colour;

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 
-<div class="section-panel">
+<div class="section-panel-borderless">
   <% trending_petitions do |petitions| %>
     <section class="trending" aria-labelledby="trending-heading">
       <h2 id="trending-heading">Popular petitions</h2>
@@ -27,26 +27,22 @@
 </div>
 
 <% explanation_petition_counts do |counts| %>
-  <section class="threshold-panel" aria-labelledby="response-threshold-heading">
-    <div class="threshold-panel-header">
+  <section class="section-panel-borderless" aria-labelledby="response-threshold-heading">
+    <div class="threshold-panel">
       <span class="graphic graphic-crown-white"></span>
       <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %> <span>signatures</span></h2>
       <p>If a petition gets <%= Site.formatted_threshold_for_response %>, the government will respond</p>
     </div>
-    <div class="threshold-panel-body">
-      <p><%= link_to_unless counts[:with_response].zero?, petition_count(:with_response_explanation, counts[:with_response]), petitions_path(state: :with_response) %></p>
-    </div>
+    <%= link_to_unless counts[:with_response].zero?, petition_count(:with_response_explanation, counts[:with_response]), petitions_path(state: :with_response) %>
   </section>
 
-  <section class="threshold-panel"  aria-labelledby="debate-threshold-heading">
-    <div class="threshold-panel-header">
+  <section class="section-panel" aria-labelledby="debate-threshold-heading">
+    <div class="threshold-panel">
       <span class="graphic graphic-portcullis-white"></span>
       <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %> <span>signatures</span></h2>
       <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
     </div>
-    <div class="threshold-panel-body">
-      <p><%= link_to_unless counts[:with_debate_outcome].zero?, petition_count(:with_debate_outcome_explanation, counts[:with_debate_outcome]), petitions_path(state: :with_debate_outcome) %></p>
-    </div>
+    <%= link_to_unless counts[:with_debate_outcome].zero?, petition_count(:with_debate_outcome_explanation, counts[:with_debate_outcome]), petitions_path(state: :with_debate_outcome) %>
   </section>
 <% end %>
 

--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -10,7 +10,7 @@
 
   <section class="create-warning" aria-labelledby="just-so-you-know-heading">
     <h2 id="just-so-you-know-heading">Just so you know</h2>
-    <span aria-hidden="true">5</span>
+    <span aria-hidden="true"><%= Site.minimum_number_of_sponsors %></span>
     <p>Later on, you'll need email addresses for <%= Site.minimum_number_of_sponsors %> supporters to get your petition started</p>
   </section>
 

--- a/app/views/signatures/_replay_email_ui_heading.html.erb
+++ b/app/views/signatures/_replay_email_ui_heading.html.erb
@@ -1,0 +1,1 @@
+<h1 class="page-title">Make sure this is right</h1>

--- a/app/views/signatures/_signer_ui_heading.html.erb
+++ b/app/views/signatures/_signer_ui_heading.html.erb
@@ -1,0 +1,2 @@
+<h1 class="page-title">Sign petition</h1>
+<h2 class="page-subtitle"><%= @petition.action %></h2>

--- a/app/views/signatures/create/_replay_email_ui.html.erb
+++ b/app/views/signatures/create/_replay_email_ui.html.erb
@@ -1,4 +1,4 @@
-<h1 class="page-title">Make sure this is right</h1>
+<%= render 'replay_email_ui_heading' %>
 
 <%= render 'signatures/email', f: f, signature: signature,  hide_label: true %>
 

--- a/app/views/signatures/create/_signer_ui.html.erb
+++ b/app/views/signatures/create/_signer_ui.html.erb
@@ -1,5 +1,4 @@
-<h1 class="page-title">Sign petition</h1>
-<h2 class="page-subtitle"><%= @petition.action %></h2>
+<%= render 'signer_ui_heading' %>
 
 <%= render 'signatures/form', f: f, signature: signature, context: 'sign' %>
 

--- a/app/views/sponsors/_replay_email_ui_heading.html.erb
+++ b/app/views/sponsors/_replay_email_ui_heading.html.erb
@@ -1,0 +1,1 @@
+<h1 class="page-title">Make sure this is right</h1>

--- a/app/views/sponsors/_signer_ui_heading.html.erb
+++ b/app/views/sponsors/_signer_ui_heading.html.erb
@@ -1,0 +1,1 @@
+<h1 class="page-title">Sign <%= @petition.creator_signature.name %>'s petition</h1>

--- a/app/views/sponsors/show.html.erb
+++ b/app/views/sponsors/show.html.erb
@@ -1,9 +1,3 @@
-<div class="title_block">
-  <h2>Support this petition</h2>
-  <h1 class="petition_action"><%= @petition.action %></h1>
-  <h2>By <%= @petition.creator_signature.name %></h2>
-</div>
-
 <%= form_for @stage_manager.stage_object, url: petition_sponsor_path(@petition, @petition.sponsor_token), html: {method: 'patch', class: 'wizard_form new_petition_form'} do |f| %>
   <%= render_signature_form @stage_manager, f, with_signer_ui_back_link: false %>
 <% end -%>

--- a/app/views/sponsors/sponsored.html.erb
+++ b/app/views/sponsors/sponsored.html.erb
@@ -1,15 +1,8 @@
-<div class="title_block">
-  <h2>Thank you.</h2>
-  <h1 class="petition_action"><%= @petition.action %></h1>
-  <h2>By <%= @petition.creator_signature.name %></h2>
-</div>
-
-<div class="cta_block thank_you_block">
-  <p>Your signature has now been added to this petition as a sponsor.</p>
-
-  <p>This petition is waiting for more sponsors before being checked to make sure it complies with the terms &amp; conditions for creating a petition.</p>
-
-  <p>You will be notified once a decision has been reached.</p>
-
-  <%= link_to "Return to home page", home_path, :class => 'link_button large_link_button return_to_homepage_button' %>
-</div>
+<h1 class="page-title page-title-with-icon">
+  <span class="icon icon-confirmation-tick"></span>
+  Thanks
+</h1>
+<p>Your signature has been added to this petition as a supporter.</p>
+<h2>What next?</h2>
+<p>This petition needs <%= Site.minimum_number_of_sponsors %> supporters to go live.</p>
+<p>When it goes live, we'll email you a link so you can start sharing it.</p>

--- a/app/views/sponsors/thank_you.html.erb
+++ b/app/views/sponsors/thank_you.html.erb
@@ -1,13 +1,8 @@
-<div class="title_block">
-  <h2>Thank you.</h2>
-  <h1 class="petition_action"><%= @petition.action %></h1>
-  <h2>By <%= @petition.creator_signature.name %></h2>
-</div>
+<h1 class="page-title page-title-with-icon">
+  <span class="icon icon-email"></span>
+  One more step&hellip;
+</h1>
 
-<div class="cta_block thank_you_block">
-  <p>An email will be sent to you now to confirm your email address.  If we're busy this may take a few hours to arrive, thanks for your patience.</p>
+<p>Check your email and click the link to sign this petition.</p>
 
-  <p>We can't add you as a sponsor to the petition until you've clicked on the link in this email.</p>
-
-  <%= link_to "Return to home page", home_path, :class => 'link_button large_link_button return_to_homepage_button' %>
-</div>
+<%= render partial: "notification", locals: { text: "You have not signed until you click the link in the email" } %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -124,10 +124,12 @@ en-GB:
       with_response_explanation:
         html:
           zero: "There aren't any petitions with a government response yet"
+          one: "Petitions with a government response (%{formatted_count})"
           other: "Petitions with a government response (%{formatted_count})"
       with_debate_outcome_explanation:
         html:
           zero: There aren't any petitions that have been debated in parliament yet
+          one: "Petitions debated in parliament (%{formatted_count})"
           other: "Petitions debated in parliament (%{formatted_count})"
 
     action_counts:

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -16,7 +16,7 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
     Then I should have a pending signature on the petition as a sponsor
     And I should receive an email explaining the petition I am sponsoring
     When I confirm my email address
-    Then I am taken to a landing page
+    Then I should see a heading called "Thanks"
     And I should have fully signed the petition as a sponsor
 
   Scenario: Laura wants to sign the petition that is already published
@@ -91,9 +91,9 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
   Scenario: Laura sees notice that she has already signed when she validates more than once
     When I have sponsored a petition
     When I confirm my email address
-    Then I am taken to a landing page
+    Then I should see a heading called "Thanks"
     And I should have fully signed the petition as a sponsor
     When I confirm my email address
-    Then I am taken to a landing page
+    Then I should see a heading called "Thanks"
     And I should see "You have already sponsored this petition."
-    And I should see "This petition is waiting for more sponsors"
+    And I should see /This petition needs [0-9]+ supporters to go live/

--- a/features/step_definitions/actioned_steps.rb
+++ b/features/step_definitions/actioned_steps.rb
@@ -23,26 +23,26 @@ Then(/^I should see there are (.*?) petitions debated in parliament$/) do |debat
 end
 
 Then(/^I should see an empty government response threshold section$/) do
-  within(:css, ".threshold-panel[aria-labelledby=response-threshold-heading]") do
+  within(:css, "section[aria-labelledby=response-threshold-heading]") do
     expect(page).to have_no_css("a[href='#{petitions_path(state: :with_response)}']")
   end
 end
 
 Then(/^I should see an empty debate threshold section$/) do
-  within(:css, ".threshold-panel[aria-labelledby=debate-threshold-heading]") do
+  within(:css, "section[aria-labelledby=debate-threshold-heading]") do
     expect(page).to have_no_css("a[href='#{petitions_path(state: :with_debate_outcome)}']")
   end
 end
 
 Then(/^I should see the government response threshold section with a count of (\d+)$/) do |response_petitions_count|
-  within(:css, ".threshold-panel[aria-labelledby=response-threshold-heading]") do
+  within(:css, "section[aria-labelledby=response-threshold-heading]") do
     link_text = "Petitions with a government response (#{response_petitions_count})"
     expect(page).to have_link(link_text, href: petitions_path(state: :with_response))
   end
 end
 
 Then(/^I should see the debate threshold section with a count of (\d+)$/) do |debate_petitions_count|
-  within(:css, ".threshold-panel[aria-labelledby=debate-threshold-heading]") do
+  within(:css, "section[aria-labelledby=debate-threshold-heading]") do
     link_text = "Petitions debated in parliament (#{debate_petitions_count})"
     expect(page).to have_link(link_text, href: petitions_path(state: :with_debate_outcome))
   end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -4,10 +4,6 @@ Given /^a set of petitions$/ do
   end
 end
 
-Then /^I am taken to a landing page$/ do
-  expect(page).to have_content("Thank you")
-end
-
 Given(/^a(n)? ?(pending|validated|sponsored|open)? petition "([^"]*)"$/) do |a_or_an, state, petition_action|
   petition_args = {
     :action => petition_action,


### PR DESCRIPTION
- Standardise approach to outdenting. Add borderless .section-panel. Fix threshold boxes on home page. Leftover from [#97805100](https://www.pivotaltracker.com/story/show/97805100)
- Break long words and links in paragraphs [#97883582](https://www.pivotaltracker.com/story/show/97883582)
- Use site config for petition sponsor count
- Add missing 'one' pluralization for locales. Leftover from [#97805100](https://www.pivotaltracker.com/story/show/97805100)
- Allow custom headings between signature and sponsor flows. Clean up sponsor headings. Fix up 'sponsored' text [#97958522](https://www.pivotaltracker.com/story/show/97958522)