### PR TITLE
Synthesize closing at information for petitions

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -243,6 +243,14 @@ class Petition < ActiveRecord::Base
     TODO_LIST_STATES.include? state
   end
 
+  def deadline
+    if closed?
+      closed_at
+    else
+      Site.closed_at_for_opening(open_at)
+    end
+  end
+
   def rejection_reason
     I18n.t(rejection_code.to_sym, scope: :"petitions.rejection_reasons.titles")
   end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -244,11 +244,7 @@ class Petition < ActiveRecord::Base
   end
 
   def deadline
-    if closed?
-      closed_at
-    else
-      Site.closed_at_for_opening(open_at)
-    end
+    open_at && (closed_at || Site.closed_at_for_opening(open_at))
   end
 
   def rejection_reason

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -52,6 +52,10 @@ class Site < ActiveRecord::Base
       instance.opened_at_for_closing(time)
     end
 
+    def closed_at_for_opening(time = Time.current)
+      instance.closed_at_for_opening(time)
+    end
+
     def port
       instance.port
     end
@@ -218,6 +222,10 @@ class Site < ActiveRecord::Base
 
   def opened_at_for_closing(time = Time.current)
     time.end_of_day - petition_duration.months
+  end
+
+  def closed_at_for_opening(time = Time.current)
+    time.end_of_day + petition_duration.months
   end
 
   validates :title, presence: true, length: { maximum: 50 }

--- a/app/views/admin/petitions/_petition.html.erb
+++ b/app/views/admin/petitions/_petition.html.erb
@@ -6,6 +6,6 @@
     <%= mail_to petition.creator_signature.email %>
   </td>
   <td class="count"><%= number_with_delimiter(petition.signature_count) %></td>
-  <td><%= date_format_admin(petition.closed_at) %></td>
+  <td><%= date_format_admin(petition.deadline) %></td>
   <td class="center"><%= petition.response.present? ? image_tag('admin/tick.gif') : '' %></td>
 </tr>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -26,7 +26,7 @@
   <dd><%= date_time_format(@petition.created_at) %></dd>
 <% else %>
   <dt>Deadline</dt>
-  <dd><%= date_format_admin(@petition.closed_at) %></dd>
+  <dd><%= date_format_admin(@petition.deadline) %></dd>
 
   <dt>Link to petition</dt>
   <dd><%= link_to petition_path(@petition), petition_path(@petition), target: "_blank" %></dd>

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -26,7 +26,7 @@
         <%= mail_to petition.creator_signature.email %></td>
         <td><%= petition.state %></td>
         <td class="count"><%= number_with_delimiter(petition.signature_count) %></td>
-        <td><%= date_format_admin(petition.closed_at) %></td>
+        <td><%= date_format_admin(petition.deadline) %></td>
       </tr>
     <% end -%>
   </tbody>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Unfortunately we've had to bring forward the closing date of your petition <%= link_to @signature.petition.action, petition_url(@signature.petition) %> from  <%= short_date_format @signature.petition.closed_at %> to 30 March 2015</p>
+<p>Unfortunately we've had to bring forward the closing date of your petition <%= link_to @signature.petition.action, petition_url(@signature.petition) %> from  <%= short_date_format @signature.petition.deadline %> to 30 March 2015</p>
 
 <p>The dissolution of this Parliament has now been scheduled for 30 March 2015, and it’s not possible for petitions to remain open once Parliament has been dissolved.</p>
 

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @signature.name %>,
 
-Unfortunately we've had to bring forward the closing date of your petition "<%= @signature.petition.action %>" (available at <%= petition_url(@signature.petition) %>) from  <%= short_date_format @signature.petition.closed_at %> to 31 March 2015
+Unfortunately we've had to bring forward the closing date of your petition "<%= @signature.petition.action %>" (available at <%= petition_url(@signature.petition) %>) from  <%= short_date_format @signature.petition.deadline %> to 31 March 2015
 
 The dissolution of this Parliament has now been scheduled for 30 March 2015, and it’s not possible for petitions to remain open once Parliament has been dissolved.
 

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -33,7 +33,7 @@
 
 <ul class="petition-meta">
   <li class="meta-deadline">
-    <span class="label">Deadline</span> <%= short_date_format petition.closed_at %>
+    <span class="label">Deadline</span> <%= short_date_format petition.deadline %>
   </li>
   <li class="meta-created-by">
     <span class="label">Created by</span> <%= petition.creator_signature.name %>

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -174,9 +174,11 @@ end
 Then /^I should see the vote count, closed and open dates$/ do
   @petition.reload
   expect(page).to have_css("p.signature-count-number", :text => "#{@petition.signature_count} #{'signature'.pluralize(@petition.signature_count)}")
-  expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.deadline.strftime("%e %B %Y").squish)
 
-  unless @petition.is_a?(ArchivedPetition)
+  if @petition.is_a?(ArchivedPetition)
+    expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.closed_at.strftime("%e %B %Y").squish)
+  else
+    expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.deadline.strftime("%e %B %Y").squish)
     expect(page).to have_css("li.meta-created-by", :text => "Created by " + @petition.creator_signature.name)
   end
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -174,7 +174,7 @@ end
 Then /^I should see the vote count, closed and open dates$/ do
   @petition.reload
   expect(page).to have_css("p.signature-count-number", :text => "#{@petition.signature_count} #{'signature'.pluralize(@petition.signature_count)}")
-  expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.closed_at.strftime("%e %B %Y").squish)
+  expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.deadline.strftime("%e %B %Y").squish)
 
   unless @petition.is_a?(ArchivedPetition)
     expect(page).to have_css("li.meta-created-by", :text => "Created by " + @petition.creator_signature.name)

--- a/lib/tasks/data-generator.rake
+++ b/lib/tasks/data-generator.rake
@@ -60,9 +60,9 @@ namespace :data do
         # Update to specified state requested
         case PETITION_STATE
         when 'open'
-          petition.update_attributes(state: 'open', open_at: Time.now, closed_at: Time.now + 1.year)
+          petition.update_attributes(state: 'open', open_at: Time.now)
         when 'closed'
-          petition.update_attributes(state: 'open', open_at: Time.now - 1.year, closed_at: Time.now - 1.day)
+          petition.update_attributes(state: 'closed', open_at: Time.now - 1.year, closed_at: Time.now - 1.day)
         when 'rejected'
           petition.update_attributes(
             state: 'rejected',

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe PetitionMailer, type: :mailer do
   end
 
   describe "notifying creator of closing date change" do
+    before { petition.publish! }
     let(:signature) { FactoryGirl.create(:validated_signature, :petition => petition) }
     let(:mail) { PetitionMailer.notify_creator_of_closing_date_change(signature) }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -426,6 +426,20 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe ".closed_at_for_opening" do
+    let(:site) { double(:site) }
+    let(:closed_at) { 3.months.from_now.end_of_day }
+
+    before do
+      expect(Site).to receive(:first_or_create).and_return(site)
+    end
+
+    it "delegates opened_at_for_closing to the instance" do
+      expect(site).to receive(:closed_at_for_opening).and_return(closed_at)
+      expect(Site.closed_at_for_opening).to eq(closed_at)
+    end
+  end
+
   describe ".reload" do
     let(:site) { double(:site) }
 
@@ -535,7 +549,6 @@ RSpec.describe Site, type: :model do
     end
   end
 
-
   describe "#formatted_threshold_for_moderation" do
     subject :site do
       described_class.create!(threshold_for_moderation: 5000)
@@ -615,6 +628,16 @@ RSpec.describe Site, type: :model do
 
     it "returns the opening date at petition_duration months ago" do
       expect(site.opened_at_for_closing).to eq(3.months.ago.end_of_day)
+    end
+  end
+
+  describe "#closed_at_for_opening" do
+    subject :site do
+      described_class.create!(petition_duration: 3)
+    end
+
+    it "returns the closing date at petition_duration months in the future" do
+      expect(site.closed_at_for_opening).to eq(3.months.from_now.end_of_day)
     end
   end
 end


### PR DESCRIPTION
Since merging in #213 we no longer have a `closed_at` timestamp filled in on open petitions so we can't show a deadline.  We implement `Petition#deadline` to work around this by advancing ahead from `open_at` by the appropriate number of months and using this new method wherever we were using `.closed_at`.