### PR TITLE
Optimise signature number

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -64,18 +64,8 @@ class Signature < ActiveRecord::Base
   # = Methods =
   attr_accessor :uk_citizenship
 
-  def self.signature_number(petition_id, validated_at)
-    where('petition_id = ? AND validated_at < ?', petition_id, validated_at).count + 1
-  end
-
   def email=(value)
     super(value.to_s.downcase)
-  end
-
-  def number
-    if validated_at?
-      @number ||= self.class.signature_number(petition_id, validated_at)
-    end
   end
 
   def postcode=(value)
@@ -108,10 +98,12 @@ class Signature < ActiveRecord::Base
 
       Petition.transaction do
         self.update_columns(
+          number:       petition.signature_count + 1,
           state:        VALIDATED_STATE,
           validated_at: Time.current,
           updated_at:   Time.current
         )
+
         ConstituencyPetitionJournal.record_new_signature_for(self)
         petition.increment_signature_count!
       end

--- a/db/migrate/20150701111544_add_signature_number.rb
+++ b/db/migrate/20150701111544_add_signature_number.rb
@@ -1,0 +1,5 @@
+class AddSignatureNumber < ActiveRecord::Migration
+  def change
+    add_column :signatures, :number, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -365,7 +365,8 @@ CREATE TABLE signatures (
     email character varying(255),
     unsubscribe_token character varying,
     constituency_id character varying,
-    validated_at timestamp without time zone
+    validated_at timestamp without time zone,
+    number integer
 );
 
 
@@ -944,4 +945,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150622083615');
 INSERT INTO schema_migrations (version) VALUES ('20150622140322');
 
 INSERT INTO schema_migrations (version) VALUES ('20150630105949');
+
+INSERT INTO schema_migrations (version) VALUES ('20150701111544');
 

--- a/lib/tasks/data-generator.rake
+++ b/lib/tasks/data-generator.rake
@@ -87,14 +87,14 @@ namespace :data do
         @signature_count = Site.threshold_for_response + 1 if @should_create_response
 
         @signature_count.to_i.times do
-          petition.signatures.create!(
+          signature = petition.signatures.create!(
             uk_citizenship: '1',
             name: Faker::Name.name,
             email: Faker::Internet.safe_email("#{Faker::Lorem.characters(rand(10..40))}-#{rand(1..999999)}"),
             country: 'United Kingdom',
-            state: 'validated',
             postcode: POSTCODES.sample
           )
+          signature.validate!
         end
 
         # Add responses on random petitions when 10,000 signatures


### PR DESCRIPTION
The 'signature number count' would previously do a very long running select
(1 second runtime per page display on a big db).

We now store the signature sequence in each recorded signature, so that it can be
displayed to the user in a consistent way (even if the page is reloaded).

The signature number is populated based on the current Petition's signature
count at the time of signing.

Note that we've taken the decision that if two people sign at exactly the same
time, they could both be signature number 3 (it's a "dead heat" situation).
This way we don't need to grab a lock on Petitions table before doing the
increment. However, the next person signing would jump to signature number 5,
since the increment of the Petitions table _is_ done in a transaction.

(Discussed initially with Andrew White)
