### PR TITLE
Add some JS to show / hide rejection interface when moderating

### DIFF
--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -14,4 +14,29 @@
     <%= f.submit 'Email petition creator', :class => 'button', :tabindex => increment %>
   <% end %>
 
+  <%= javascript_tag do %>
+    $().ready(function() {
+      var $rejection_controls = $('.petition-rejection-controls'),
+          $reject_control = $('#moderation_reject'),
+          $both_controls = $('input[name=moderation][type=radio]');
+      <% unless f.object.errors.any? %>
+      // Hide it straight away if there were no errors to display
+      $rejection_controls.hide();
+      <% end %>
+
+      // Ensure that we get the onchange event when the users uses the keyboard
+      // Details: http://bit.ly/iZx9nh
+      $both_controls.keyup(function() {
+        this.blur();
+        this.focus();
+      }).change(function() {
+        if ($reject_control.is(':checked')) {
+          $rejection_controls.show();
+        } else {
+          $rejection_controls.hide();
+        }
+      });
+    });
+  <% end -%>
+
 <% end -%>

--- a/app/views/admin/petitions/_reject.html.erb
+++ b/app/views/admin/petitions/_reject.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="petition-rejection-controls">
   <%= javascript_tag do %>
     var rejection_descriptions = <%= raw rejection_descriptions.to_json %>;
 

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -114,6 +114,7 @@ Then /^I should not see any "([^"]*)" petitions$/ do |state|
 end
 
 Then /^I see relevant reason descriptions when I browse different reason codes$/ do
+  choose "Reject"
   select "Duplicate of an existing petition", :from => :petition_rejection_code
   expect(page).to have_content "already a petition"
   select "Confidential, libellous, false or defamatory statements", :from => :petition_rejection_code


### PR DESCRIPTION
There's no point seeing the rejection interface if you choose approve, and there's no point seeing it before you decide what to do.  We do always show it if there's an error on the object though.

The impl is just some inline JS because we already use inline JS for the rejection description stuff in the rejection interface.  Even if this isn't great, at least it's consistent.