### PR TITLE
Show correct error message when no constituency petitions found

### DIFF
--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="page-title">
-  <% if @petitions.present? %>
+  <% if @constituency.present? %>
     Popular petitions in the constituency of <%= @constituency.name %>
   <% elsif @postcode.present? %>
     Sorry!
@@ -8,11 +8,11 @@
   <% end %>
 </h1>
 
-<% if @constituency && @constituency.mp %>
-  <p>Your MP is <%= link_to @constituency.mp.name, @constituency.mp.url, rel: 'external' %></p>
-<% end %>
+<% if @constituency.present? %>
 
-<% if @petitions.present? %>
+  <% if @constituency.mp %>
+    <p>Your MP is <%= link_to @constituency.mp.name, @constituency.mp.url, rel: 'external' %></p>
+  <% end %>
 
   <div class="section-panel local-petitions">
     <% if @petitions.any? %>

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -35,3 +35,10 @@ Feature: Freya searches petitions by constituency
     When I search for petitions local to me in "BH20 6HH"
     Then the markup should be valid
     But I should see an explanation that my constituency couldn't be found
+
+  Scenario: Searching for local petitions when the no-one in my constituency is engaged
+    Given a constituency "South Northamptonshire" is found by postcode "NN13 5QD"
+    And I am on the home page
+    When I search for petitions local to me in "NN13 5QD"
+    Then the markup should be valid
+    But I should see an explanation that there are no petitions popular in my constituency

--- a/features/support/xpath_helpers.rb
+++ b/features/support/xpath_helpers.rb
@@ -1,0 +1,5 @@
+module XPathHelpers
+  def self.class_matching(class_name)
+    "[contains(concat(' ', normalize-space(@class), ' '), ' #{class_name} ')]"
+  end
+end


### PR DESCRIPTION
Because we were using ``@petitions.present?`` as our guard and both ``[].present?`` and ``.present?`` on an AR relation with no results return ``false`` we ended up telling the user that we knew their MP but didn't know their constituency.  We switch to using ``@constituency.present?`` as the guard and this restores the correct behaviour.