### PR TITLE
Add HttpOnly to the seen_cookie_message cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_seen_cookie_message
-    cookies[:seen_cookie_message] = { value: 'yes', expires: 1.year.from_now }
+    cookies[:seen_cookie_message] = { value: 'yes', expires: 1.year.from_now, httponly: true }
   end
 
   def show_cookie_message?

--- a/spec/requests/seen_cookie_message_spec.rb
+++ b/spec/requests/seen_cookie_message_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'seen_cookie_message cookie', type: :request do
+  subject { response.header["Set-Cookie"] }
+  let(:one_year_from_now) { 1.year.from_now.getutc.rfc2822 }
+
+  before do
+    get "/"
+  end
+
+  it "should set the secure option" do
+    expect(subject).to match(/; secure/i)
+  end
+
+  it "should set the httponly option" do
+    expect(subject).to match(/; httponly/i)
+  end
+
+  it "should set the expiry to 1 year from now" do
+    expect(subject).to match(/; expires=#{one_year_from_now}/)
+  end
+end


### PR DESCRIPTION
Although there was no way of exploiting this for evil it's best practise not to allow JavaScript access to cookies unless necessary for the operation of the application.

Fixes: GDNT-025-3-3