### PR TITLE
Sanitize referer url before using it

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module ApplicationHelper
   def increment(amount = 1)
     @counter ||= 0
@@ -10,5 +12,20 @@ module ApplicationHelper
 
   def create_petition_page?
     params[:controller] == 'petitions' && params[:action].in?(%w[check create new])
+  end
+
+  def back_url
+    referer_url || 'javascript:history.back()'
+  end
+
+  private
+
+  def referer_url
+    begin
+      uri = URI.parse(request.referer)
+      %i[scheme host port].all?{ |k| uri.send(k) == request.send(k) } ? request.referer : nil
+    rescue URI::InvalidURIError => e
+      nil
+    end
   end
 end

--- a/app/views/petitions/create/_petition_details_ui.html.erb
+++ b/app/views/petitions/create/_petition_details_ui.html.erb
@@ -1,4 +1,4 @@
-<%= link_to :back, class: "back-page" do %>
+<%= link_to back_url, class: "back-page" do %>
   &#9664; Back
 <% end %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -70,4 +70,64 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#back_url" do
+    let(:headers) { helper.request.env }
+
+    before do
+      headers["HTTP_HOST"]   = "petition.parliament.test"
+      headers["HTTPS"]       = "on"
+      headers["SERVER_PORT"] = 443
+    end
+
+    context "when the referer is an internal url" do
+      before do
+        headers["HTTP_REFERER"] = "https://petition.parliament.test/petitions/new"
+      end
+
+      it "returns the referer url" do
+        expect(helper.back_url).to eq("https://petition.parliament.test/petitions/new")
+      end
+    end
+
+    context "when the referer is invalid" do
+      before do
+        headers["HTTP_REFERER"] = "javascript:alert('Hello, World!')"
+      end
+
+      it "returns 'javascript:history.back()'" do
+        expect(helper.back_url).to eq("javascript:history.back()")
+      end
+    end
+
+    context "when the scheme doesn't match" do
+      before do
+        headers["HTTP_REFERER"] = "http://petition.parliament.test/petitions/new"
+      end
+
+      it "returns 'javascript:history.back()'" do
+        expect(helper.back_url).to eq("javascript:history.back()")
+      end
+    end
+
+    context "when the host doesn't match" do
+      before do
+        headers["HTTP_REFERER"] = "https://petition.gov.uk"
+      end
+
+      it "returns 'javascript:history.back()'" do
+        expect(helper.back_url).to eq("javascript:history.back()")
+      end
+    end
+
+    context "when the port doesn't match" do
+      before do
+        headers["HTTP_REFERER"] = "http://petition.parliament.test:8443/petitions/new"
+      end
+
+      it "returns 'javascript:history.back()'" do
+        expect(helper.back_url).to eq("javascript:history.back()")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rails by default doesn't validate the HTTP_REFERER header used when doing a `link_to :back`. This was deemed to be a low priority in rails/rails#14444 as the ability to inject headers via a proxy would allow all sorts of other attacks like session fixation. Coupled with SSL it makes any exploit unlikely.

However we know in our application our usage is limited to internal back links, so we can parse them through `URI.parse` and ensure they are valid.

Fixes GDNT-025-3-1