### PR TITLE
Moderators can flag petitions

### DIFF
--- a/app/assets/stylesheets/petitions/admin/_list.scss
+++ b/app/assets/stylesheets/petitions/admin/_list.scss
@@ -1,0 +1,5 @@
+.admin {
+  .petition-list-petition-state-flagged {
+    background-color: $mellow-red-25;
+  }
+}

--- a/app/assets/stylesheets/site-admin.scss
+++ b/app/assets/stylesheets/site-admin.scss
@@ -42,6 +42,7 @@
 @import "petitions/admin/header";
 @import "petitions/admin/meta";
 @import "petitions/admin/actions";
+@import "petitions/admin/list";
 
 // Petition admin views
 @import "petitions/admin/views/hub";

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -12,6 +12,7 @@ class PetitionMailer < ApplicationMailer
   end
 
   def notify_creator_that_petition_is_published(signature)
+    @petition = signature.petition
     @signature = signature
     mail to: @signature.email, subject: subject_for(:notify_creator_that_petition_is_published)
   end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -276,6 +276,7 @@ class Petition < ActiveRecord::Base
     end
   end
 
+  private
   def approve?
     moderation == 'approve'
   end
@@ -284,12 +285,17 @@ class Petition < ActiveRecord::Base
     moderation == 'reject'
   end
 
-  def moderation
-    @moderation
+  def flag?
+    moderation == 'flag'
   end
 
   def moderation=(value)
-    @moderation = value if value.in?(%w[approve reject])
+    @moderation = value if value.in?(%w[approve reject flag])
+  end
+  public
+
+  def moderation
+    @moderation
   end
 
   def moderate(params)
@@ -299,6 +305,8 @@ class Petition < ActiveRecord::Base
       publish
     elsif reject?
       reject(params[:rejection])
+    elsif flag?
+      flag
     else
       errors.add :moderation, :blank
       false
@@ -311,6 +319,10 @@ class Petition < ActiveRecord::Base
 
   def reject(attributes)
     build_rejection(attributes) && rejection.save
+  end
+
+  def flag
+    update(state: FLAGGED_STATE)
   end
 
   def close!(time = Time.current)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -6,12 +6,13 @@ class Petition < ActiveRecord::Base
   PENDING_STATE     = 'pending'
   VALIDATED_STATE   = 'validated'
   SPONSORED_STATE   = 'sponsored'
+  FLAGGED_STATE     = 'flagged'
   OPEN_STATE        = 'open'
   CLOSED_STATE      = 'closed'
   REJECTED_STATE    = 'rejected'
   HIDDEN_STATE      = 'hidden'
 
-  STATES            = %w[pending validated sponsored open closed rejected hidden]
+  STATES            = %w[pending validated sponsored flagged open closed rejected hidden]
   DEBATABLE_STATES  = %w[open closed]
   VISIBLE_STATES    = %w[open closed rejected]
   MODERATED_STATES  = %w[open closed hidden rejected]
@@ -19,9 +20,10 @@ class Petition < ActiveRecord::Base
   SELECTABLE_STATES = %w[open closed rejected hidden]
   SEARCHABLE_STATES = %w[open closed rejected]
 
-  TODO_LIST_STATES           = %w[pending sponsored validated]
+  IN_MODERATION_STATES       = %w[sponsored flagged]
+  TODO_LIST_STATES           = %w[pending validated sponsored flagged]
   COLLECTING_SPONSORS_STATES = %w[pending validated]
-  STOP_COLLECTING_STATES     = %w[pending sponsored validated]
+  STOP_COLLECTING_STATES     = %w[pending validated sponsored flagged]
 
   has_perishable_token called: 'sponsor_token'
 
@@ -138,7 +140,7 @@ class Petition < ActiveRecord::Base
     end
 
     def in_moderation
-      where(state: SPONSORED_STATE)
+      where(state: IN_MODERATION_STATES)
     end
 
     def moderated
@@ -332,7 +334,7 @@ class Petition < ActiveRecord::Base
   end
 
   def in_moderation?
-    state == SPONSORED_STATE
+    state.in?(IN_MODERATION_STATES)
   end
 
   def moderated?

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -1,6 +1,6 @@
 <p class="links"><%= link_to 'New user', new_admin_admin_user_path %></p>
 
-<table class="admin_index">
+<table class="user-list">
   <tr>
     <th>Name</th>
     <th>Email</th>
@@ -9,7 +9,7 @@
     <th></th>
   </tr>
   <%- @users.each do |user| -%>
-    <tr>
+    <tr class="user-list-user">
       <td><%= link_to user.name, edit_admin_admin_user_path(user) %></td>
       <td><%= mail_to user.email %></td>
       <td><%= user.role %></td>

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -25,10 +25,10 @@
           $flag_control = $('#petition_moderation_flag'),
           $submit_button = $('input[type=submit]'),
           $all_controls = $('input[name="petition[moderation]"][type=radio]');
-      <% unless f.object.errors.any? %>
-      // Hide it straight away if there were no errors to display
-      $rejection_controls.hide();
-      <% end %>
+      // Hide it straight away if there were no errors displayed
+      if ($rejection_controls.find('.error-message').size() === 0) {
+        $rejection_controls.hide();
+      }
 
       // Ensure that we get the onchange event when the users uses the keyboard
       // Details: http://bit.ly/iZx9nh

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -6,6 +6,9 @@
     <%= f.label :moderation_reject, nil, class: 'block-label' do %>
       <%= f.radio_button :moderation, 'reject' %> Reject
     <% end %>
+    <%= f.label :moderation_flag, nil, class: 'block-label' do %>
+      <%= f.radio_button :moderation, 'flag' %> Flag
+    <% end %>
     <%= error_messages_for_field petition, :moderation %>
   <% end %>
 
@@ -19,7 +22,9 @@
     $().ready(function() {
       var $rejection_controls = $('.petition-rejection-controls'),
           $reject_control = $('#petition_moderation_reject'),
-          $both_controls = $('input[name="petition[moderation]"][type=radio]');
+          $flag_control = $('#petition_moderation_flag'),
+          $submit_button = $('input[type=submit]'),
+          $all_controls = $('input[name="petition[moderation]"][type=radio]');
       <% unless f.object.errors.any? %>
       // Hide it straight away if there were no errors to display
       $rejection_controls.hide();
@@ -27,7 +32,7 @@
 
       // Ensure that we get the onchange event when the users uses the keyboard
       // Details: http://bit.ly/iZx9nh
-      $both_controls.keyup(function() {
+      $all_controls.keyup(function() {
         this.blur();
         this.focus();
       }).change(function() {
@@ -35,6 +40,11 @@
           $rejection_controls.show();
         } else {
           $rejection_controls.hide();
+        }
+        if ($flag_control.is(':checked')) {
+          $submit_button.attr('value', 'Save without emailing petition creator');
+        } else {
+          $submit_button.attr('value', 'Email petition creator');
         }
       });
     });

--- a/app/views/admin/petitions/_reject.html.erb
+++ b/app/views/admin/petitions/_reject.html.erb
@@ -17,14 +17,15 @@
     });
   <% end -%>
 
-  <%= f.fields_for :rejection do |r| %>
+  <%= f.fields_for :rejection, f.object.rejection do |r| %>
     <%= r.label :code, 'Rejection reason' %><br />
     <%= r.select :code, rejection_reasons, { include_blank: "-- Select a rejection code --" }, class: 'form-control' %>
-    <%= error_messages_for_field @petition.rejection, :code %>
+    <%= error_messages_for_field r.object, :code %>
     <div id="rejection_preview" class="flash-notice" style="display:none">
       <h3>We'll send this standard text to the petition creator:</h3>
       <div class="content"></div>
     </div>
     <%= r.text_area :details, rows: 8, cols: 70, class: 'form-control' %>
+    <%= error_messages_for_field r.object, :details %>
   <% end %>
 </div>

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -6,7 +6,7 @@
   <%= submit_tag "Go", name: nil %>
 <% end -%>
 
-<table class="admin_index">
+<table class="petition-list">
   <thead>
     <tr>
       <th>Id</th>
@@ -19,9 +19,9 @@
   </thead>
   <tbody>
     <% @petitions.each do |petition| -%>
-      <tr>
-        <td class="petition_id"><%= petition.id %></td>
-        <td class="petition-action"><%= link_to petition.action, admin_petition_path(petition) %></td>
+      <tr class="petition-list-petition petition-list-petition-state-<%= petition.state.dasherize %>">
+        <td><%= petition.id %></td>
+        <td class="petition-list-petition-action"><%= link_to petition.action, admin_petition_path(petition) %></td>
         <td><%= petition.creator_signature.name %><br/>
         <%= mail_to petition.creator_signature.email %></td>
         <td><%= petition.state %></td>

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -6,7 +6,7 @@
 <% if @signatures.present? %>
 
   <%= will_paginate @signatures %>
-  <table class="admin_index">
+  <table class="petition-list">
     <thead>
       <tr>
         <th>Petition Id</th>

--- a/features/admin/admin_users_crud.feature
+++ b/features/admin/admin_users_crud.feature
@@ -16,7 +16,7 @@ Feature: Admin users index and crud
     Given a moderator user exists with email: "derek@example.com", first_name: "Derek", last_name: "Jacobi"
     And a moderator user exists with email: "helen@example.com", first_name: "Helen", last_name: "Hunt", failed_login_count: 5
     When I go to the admin users index page
-    Then I should see the following admin index table:
+    Then I should see the following admin user table:
       | Name            | Email             | Role      | Disabled |
       | Admin, Sys      | muddy@fox.com     | sysadmin  |          |
       | Campbell, Naomi | naomi@example.com | moderator |          |
@@ -28,9 +28,9 @@ Feature: Admin users index and crud
     Given 50 moderator users exist
     When I go to the admin users index page
     And I follow "Next"
-    Then I should see 2 rows in the admin index table
+    Then I should see 2 rows in the admin user table
     And I follow "Previous"
-    Then I should see 50 rows in the admin index table
+    Then I should see 50 rows in the admin user table
 
   Scenario: Inspecting the new user form
     When I go to the admin users index page

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -22,6 +22,7 @@ Feature: A moderator user views all petitions
     Given a pending petition "My pending petition"
     And a validated petition "My validated petition"
     And a sponsored petition "My sponsored petition"
+    And a flagged petition "My flagged petition"
 
     And an open petition exists with action: "My open petition"
     And a closed petition exists with action: "My closed petition"
@@ -46,6 +47,7 @@ Feature: A moderator user views all petitions
      | My rejected petition                          |
      | My closed petition                            |
      | My open petition                              |
+     | My flagged petition                           |
      | My sponsored petition                         |
      | My validated petition                         |
      | My pending petition                           |
@@ -57,6 +59,7 @@ Feature: A moderator user views all petitions
 
     And I filter the list to show "Awaiting moderation" petitions
     Then I should see the following list of petitions:
+     | My flagged petition    |
      | My sponsored petition  |
 
     And I filter the list to show "Open" petitions

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -99,6 +99,7 @@ Feature: Moderator respond to petition
     Then the petition is not available for searching or viewing
     But the petition will still show up in the back-end reporting
 
+  @javascript
   Scenario: Moderator flags petition
     Given I am logged in as a moderator
     When I look at the next petition on my list

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -96,5 +96,14 @@ Feature: Moderator respond to petition
     And a petition "actually libellous" has been rejected with the reason "duplicate"
     When I go to the admin petition page for "actually libellous"
     And I change the rejection status of the petition with a reason code "Confidential, libellous, false or defamatory statements (will be hidden)"
-    And the petition is not available for searching or viewing
+    Then the petition is not available for searching or viewing
+    But the petition will still show up in the back-end reporting
+
+  Scenario: Moderator flags petition
+    Given I am logged in as a moderator
+    When I look at the next petition on my list
+    And I flag the petition
+    Then the petition is not available for searching or viewing
+    And the creator should not receive a notification email
+    And the creator should not receive a rejection notification email
     But the petition will still show up in the back-end reporting

--- a/features/step_definitions/admin_user_steps.rb
+++ b/features/step_definitions/admin_user_steps.rb
@@ -1,4 +1,4 @@
-Given /^I try the password "([^"]*)" (\d+) times in a row$/ do |password, number|
+Given(/^I try the password "([^"]*)" (\d+) times in a row$/) do |password, number|
   number.times do
     steps %Q(
       And I fill in "Email" with "admin@example.com"
@@ -9,7 +9,7 @@ Given /^I try the password "([^"]*)" (\d+) times in a row$/ do |password, number
   end
 end
 
-Given /^I try the password "([^"]*)" (\d+) times in a row for the email "([^"]*)"$/ do |password, number, email|
+Given(/^I try the password "([^"]*)" (\d+) times in a row for the email "([^"]*)"$/) do |password, number, email|
   number.times do
     steps %Q(
       And I fill in "Email" with "#{email}"
@@ -18,4 +18,13 @@ Given /^I try the password "([^"]*)" (\d+) times in a row for the email "([^"]*)
       Then I should see "Invalid email/password combination"
     )
   end
+end
+
+Then(/^I should see the following admin user table:$/) do |values_table|
+  actual_table = find(:css, 'table.user-list').all(:css, 'tr').map { |row| row.all(:css, 'th, td').map { |cell| cell.text.strip } }
+  values_table.diff!(actual_table)
+end
+
+Then(/^I should see (\d+) rows? in the admin user table$/) do |number|
+  expect(page).to have_xpath( "//table#{XPathHelpers.class_matching('user-list')}[count(tr#{XPathHelpers.class_matching('user-list-user')})=#{number.to_i}]" )
 end

--- a/features/step_definitions/inspection_steps.rb
+++ b/features/step_definitions/inspection_steps.rb
@@ -88,10 +88,10 @@ end
 
 Then(/^I should see the following list of petitions:$/) do |table|
   expected_petitions = table.raw.flatten
-  expect(page).to have_selector(:css, '.petition-action', count: expected_petitions.size)
+  expect(page).to have_selector(:css, '.petition-list-petition', count: expected_petitions.size)
 
   expected_petitions.each.with_index do |expected_petition, idx|
-    expect(page).to have_selector(:css, "tr:nth-child(#{idx+1}) .petition-action", text: expected_petition)
+    expect(page).to have_selector(:css, ".petition-list-petition:nth-child(#{idx+1}) .petition-list-petition-action", text: expected_petition)
   end
 end
 

--- a/features/step_definitions/inspection_steps.rb
+++ b/features/step_definitions/inspection_steps.rb
@@ -60,11 +60,6 @@ Then /^the "([^\"]*)" radio button should be selected$/ do |label|
   expect(find_field(label)['checked']).to be_truthy
 end
 
-Then /^the "([^"]*)" row should display as invalid$/ do |field_label|
-  row_node = page.find("//label[.='#{field_label}']/ancestor::*[contains(@class, 'row')] | //*[contains(@class, 'label')][.='#{field_label}']/ancestor::*[contains(@class, 'row')]")
-  expect(row_node["class"]).to include("invalid_row")
-end
-
 ### Tables...
 
 Then(/^I should see the following search results:$/) do |values_table|
@@ -127,5 +122,5 @@ Then /^I should (not |)see a link called "([^\"]*)" linking to "([^\"]*)"$/ do |
 end
 
 Then /^"([^"]*)" should show as "([^"]*)"$/ do |node_text, node_class_name|
-  expect(page).to have_xpath("//*[.='#{node_text}'][contains(@class, '#{node_class_name}')]")
+  expect(page).to have_xpath("//*[.='#{node_text}']#{XPathHelpers.class_matching(node_lcass_name)}")
 end

--- a/features/step_definitions/inspection_steps.rb
+++ b/features/step_definitions/inspection_steps.rb
@@ -67,12 +67,7 @@ end
 
 ### Tables...
 
-Then /^I should see the following admin index table:$/ do |values_table|
-  actual_table = find(:css, 'table').all(:css, 'tr').map { |row| row.all(:css, 'th, td').map { |cell| cell.text.strip } }
-  values_table.diff!(actual_table)
-end
-
-Then /^I should see the following search results:$/ do |values_table|
+Then(/^I should see the following search results:$/) do |values_table|
   values_table.raw.each do |row|
     row.each do |column|
       expect(page).to have_content(column)
@@ -114,10 +109,6 @@ end
 
 Then /^the row with the name "([^\"]*)" is not listed$/ do |name|
   expect(page.body).not_to match(/#{name}/)
-end
-
-Then /^I should see (\d+) rows? in the admin index table$/ do |number|
-  expect(page).to have_xpath( "//table[@class='admin_index' and count(tr)=#{number.to_i + 1}]" )
 end
 
 Then /^I should see (\d+) petitions?$/ do |number|

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -4,7 +4,7 @@ Given /^a set of petitions$/ do
   end
 end
 
-Given(/^a(n)? ?(pending|validated|sponsored|open)? petition "([^"]*)"$/) do |a_or_an, state, petition_action|
+Given(/^a(n)? ?(pending|validated|sponsored|flagged|open)? petition "([^"]*)"$/) do |a_or_an, state, petition_action|
   petition_args = {
     :action => petition_action,
     :closed_at => 1.day.from_now,

--- a/features/step_definitions/resend_confirmation_steps.rb
+++ b/features/step_definitions/resend_confirmation_steps.rb
@@ -1,6 +1,6 @@
 When(/^I ask for my confirmation email to be resent$/) do
   visit petition_path(@petition)
-  page.find("//details[contains(@class, 'confirmation-resend')]/summary").click
+  page.find("//details#{XPathHelpers.class_matching('confirmation-resend')}/summary").click
   fill_in "confirmation_email", with: 'suzie@example.com'
   click_button "Resend"
 end
@@ -53,7 +53,7 @@ end
 
 When(/^I ask for my confirmation email to be resent with an invalid address$/) do
   visit petition_path(@petition)
-  page.find("//details[contains(@class, 'confirmation-resend')]/summary").click
+  page.find("//details#{XPathHelpers.class_matching('confirmation-resend')}/summary").click
   fill_in "confirmation_email", with: 'garbage email address'
   click_button "Resend"
 end

--- a/features/support/sections.rb
+++ b/features/support/sections.rb
@@ -14,9 +14,6 @@ module SectionHelpers
     when 'search results table'
       "#{prefix}div[contains(@class, 'petition_list')]//table"
 
-    when 'admin index table'
-      "#{prefix}table[contains(@class, 'admin_index')]"
-
     when 'admin report table'
       "#{prefix}table[contains(@class, 'admin_report')]"
 

--- a/features/support/sections.rb
+++ b/features/support/sections.rb
@@ -4,18 +4,12 @@ module SectionHelpers
 
     # Non site-specific based
     when /"([^\"]*)" fieldset/
-      "#{prefix}fieldset[contains(@class, '#{$1.downcase.gsub(/\s/, '_')}')]"
+      "#{prefix}fieldset#{XPathHelpers.class_matching($1.downcase.gsub(/\s/, '_'))}"
 
     # Sitewide
     when /^single h1$/
       expect(page).to have_xpath("//h1", :count => 1)
       "#{prefix}h1"
-
-    when 'search results table'
-      "#{prefix}div[contains(@class, 'petition_list')]//table"
-
-    when 'admin report table'
-      "#{prefix}table[contains(@class, 'admin_report')]"
 
     else
       raise "Can't find mapping from \"#{section_name}\" to a section."

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -106,6 +106,10 @@ FactoryGirl.define do
     state  Petition::SPONSORED_STATE
   end
 
+  factory :flagged_petition, :parent => :petition do
+    state  Petition::FLAGGED_STATE
+  end
+
   factory :open_petition, :parent => :petition do
     state      Petition::OPEN_STATE
     open_at    { Time.current }

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -897,6 +897,18 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe '#flag' do
+    subject(:petition) { FactoryGirl.create(:petition) }
+
+    before do
+      petition.flag
+    end
+
+    it "sets the state to FLAGGED" do
+      expect(petition.state).to eq(Petition::FLAGGED_STATE)
+    end
+  end
+
   describe '#deadline' do
     let(:now) { Time.current }
 


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/98299836

On the moderation screen they should be able to choose "Flag" as an option as well as "Approve" or "Reject".  "Flagged" petitions are still considered as being in moderation, but have a state that can be identified separately from the existing pending/validated states.  The goal here is to identify that someone has looked at the petition, but don't yet know if it should be published or rejected.  This stops the situation where a moderator looks at a petition, can't decide to publish or reject and while they're seeking advice a different moderator goes to the moderation queue and moderates the same petition.