### PR TITLE
Tagged searches via notes in admin

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -2,8 +2,11 @@ class Admin::PetitionsController < Admin::AdminController
   respond_to :html
 
   def index
-    @petitions = Petition.search(params.merge(count: 50))
-    @query = params[:q]
+    if filter_by_tag?
+      petitions_by_tag
+    else
+      petitions_by_filter_or_keyword_search
+    end
   end
 
   def show
@@ -25,6 +28,27 @@ class Admin::PetitionsController < Admin::AdminController
   end
 
   protected
+  def filter_by_tag?
+    params[:t].present? && !(filter_by_state? || filter_by_keyword?)
+  end
+
+  def filter_by_state?
+    params[:state].present?
+  end
+
+  def filter_by_keyword?
+    params[:q].present?
+  end
+
+  def petitions_by_filter_or_keyword_search
+    @petitions = Petition.search(params.merge(count: 50))
+    @query = params[:q]
+  end
+
+  def petitions_by_tag
+    @petitions = Petition.tagged_with(params[:t]).paginate(page: params[:page], per_page: 50)
+    @query = Petition.sanitized_tag(params[:t])
+  end
 
   def fetch_petition_for_scheduled_debate_date
     @petition = Petition.find(params[:id])

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -5,6 +5,8 @@ class Admin::SearchesController < Admin::AdminController
       find_petition_by_id
     elsif query_is_email?
       find_signatures_by_email
+    elsif query_is_tag?
+      find_petitions_by_tag
     else
       find_petitions_by_keyword
     end
@@ -13,6 +15,10 @@ class Admin::SearchesController < Admin::AdminController
   private
   def query
     @query ||= params.fetch(:q, '')
+  end
+
+  def tag
+    @tag ||= @query.gsub(/\A\[|\]\Z/, '')
   end
 
   def find_petition_by_id
@@ -33,11 +39,19 @@ class Admin::SearchesController < Admin::AdminController
     redirect_to(controller: 'admin/petitions', action: 'index', q: query)
   end
 
+  def find_petitions_by_tag
+    redirect_to(controller: 'admin/petitions', action: 'index', t: tag)
+  end
+
   def query_is_number?
     /^\d+$/ =~ query
   end
 
   def query_is_email?
     query.include?('@')
+  end
+
+  def query_is_tag?
+    query.starts_with?('[') && query.ends_with?(']')
   end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -227,14 +227,14 @@ class Petition < ActiveRecord::Base
 
     def tagged_with(tag)
       joins(:note).
-      where(Note.arel_table['details'].matches(sanitized_tag(tag)))
+      where(Note.arel_table['details'].matches("%#{sanitized_tag(tag)}%"))
+    end
+
+    def sanitized_tag(tag)
+      "[#{tag.gsub(/[\[\]%]/,'')}]"
     end
 
     private
-
-    def sanitized_tag(tag)
-      "%[#{tag.gsub(/[\[\]%]/,'')}]%"
-    end
 
     def threshold_for_debate_reached
       arel_table[:debate_threshold_reached_at].not_eq(nil)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -225,7 +225,16 @@ class Petition < ActiveRecord::Base
         to_a
     end
 
+    def tagged_with(tag)
+      joins(:note).
+      where(Note.arel_table['details'].matches(sanitized_tag(tag)))
+    end
+
     private
+
+    def sanitized_tag(tag)
+      "%[#{tag.gsub(/[\[\]%]/,'')}]%"
+    end
 
     def threshold_for_debate_reached
       arel_table[:debate_threshold_reached_at].not_eq(nil)

--- a/features/admin/search_for_petitions_by_tag.feature
+++ b/features/admin/search_for_petitions_by_tag.feature
@@ -1,0 +1,30 @@
+Feature: Maggie searches for petitions by tag
+  In order to find petitions with tags in the notes field
+  As Maggie
+  I would like to be able to enter a structured tag and see all petitions that have that tag in their notes
+
+  Background:
+    Given I am logged in as a moderator
+
+  Scenario: When searching for tag, it returns all petitions with keyword in action OR background OR additional_details
+    Given a petition "Raise benefits" exists with notes "[DWP] [benefits] lorem ipsum"
+    And a petition "Help the poor" exists with notes "[benefits] what about the home less"
+    And a petition "Help the homeless" exists with notes "[home less]"
+    And a petition "Petition about something else" exists with notes "this is not about benefits"
+    When I search for petitions with tag "benefits"
+    Then I should see the following list of petitions:
+          | Raise benefits    |
+          | Help the poor     |
+    When I search for petitions with tag "home less"
+    Then I should see the following list of petitions:
+          | Help the homeless |
+
+  Scenario: A user can search by tag from the admin hub
+    Given a petition "Raise benefits" exists with notes "[DWP] [benefits] lorem ipsum"
+    And a petition "Help the poor" exists with notes "[benefits] what about the home less"
+    And a petition "Help the homeless" exists with notes "[home less]"
+    And a petition "Petition about something else" exists with notes "this is not about benefits"
+    When I search for petitions with tag "benefits" from the admin hub
+    Then I should see the following list of petitions:
+          | Raise benefits    |
+          | Help the poor     |

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -35,6 +35,16 @@ When(/^I search for petitions with keyword "([^"]*)"( from the admin hub)?$/) do
   click_button 'Search'
 end
 
+When(/^I search for petitions with tag "([^"]*)"( from the admin hub)?$/) do |tag, from_the_hub|
+  if from_the_hub.blank?
+    visit admin_petitions_path
+  else
+    visit admin_root_path
+  end
+  fill_in "Search", :with => "[#{tag}]"
+  click_button 'Search'
+end
+
 When(/^I view the petition through the admin interface$/) do
   visit admin_petitions_path
   fill_in "Search", :with => @petition.id

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -27,30 +27,30 @@ Given(/^a rejected archived petition exists with title: "(.*?)"$/) do |title|
   @petition = FactoryGirl.create(:archived_petition, :rejected, title: title)
 end
 
-Given /^the petition "([^"]*)" has (\d+) validated and (\d+) pending signatures$/ do |petition_action, no_validated, no_pending|
+Given(/^the petition "([^"]*)" has (\d+) validated and (\d+) pending signatures$/) do |petition_action, no_validated, no_pending|
   petition = Petition.find_by(action: petition_action)
   (no_validated - 1).times { FactoryGirl.create(:validated_signature, petition: petition) }
   no_pending.times { FactoryGirl.create(:pending_signature, petition: petition) }
   petition.reload
 end
 
-Given /^(\d+) petitions exist with a signature count of (\d+)$/ do |number, count|
+Given(/^(\d+) petitions exist with a signature count of (\d+)$/) do |number, count|
   number.times do
     p = FactoryGirl.create(:open_petition)
     p.update_attribute(:signature_count, count)
   end
 end
 
-Given /^a petition "([^"]*)" exists with a signature count of (\d+)$/ do |petition_action, count|
-    @petition = FactoryGirl.create(:open_petition, action: petition_action)
-    @petition.update_attribute(:signature_count, count)
+Given(/^a petition "([^"]*)" exists with a signature count of (\d+)$/) do |petition_action, count|
+  @petition = FactoryGirl.create(:open_petition, action: petition_action)
+  @petition.update_attribute(:signature_count, count)
 end
 
 Given(/^an open petition "(.*?)" with response "(.*?)" and response summary "(.*?)"$/) do |petition_action, details, summary|
   @petition = FactoryGirl.create(:responded_petition, action: petition_action, response_details: details, response_summary: summary)
 end
 
-Given /^a ?(open|closed)? petition "([^"]*)" exists and has received a government response (\d+) days ago$/ do |state, petition_action, parliament_response_days_ago |
+Given(/^a ?(open|closed)? petition "([^"]*)" exists and has received a government response (\d+) days ago$/) do |state, petition_action, parliament_response_days_ago |
   petition_attributes = {
     action: petition_action,
     closed_at: state == 'closed' ? 1.day.ago : 6.months.from_now,
@@ -83,33 +83,33 @@ Given(/^a petition "(.*?)" passed the threshold for a debate (\d+) days? ago and
   petition.debate_outcome = nil
 end
 
-Given /^I have created a petition$/ do
+Given(/^I have created a petition$/) do
   @petition = FactoryGirl.create(:open_petition)
   reset_mailer
 end
 
-Given /^the petition "([^"]*)" has (\d+) validated signatures$/ do |petition_action, no_validated|
+Given(/^the petition "([^"]*)" has (\d+) validated signatures$/) do |petition_action, no_validated|
   petition = Petition.find_by(action: petition_action)
   (no_validated - 1).times { FactoryGirl.create(:validated_signature, petition: petition) }
   petition.reload
   @petition.reload if @petition
 end
 
-And (/^the petition "([^"]*)" has reached maximum amount of sponsors$/) do |petition_action|
+And(/^the petition "([^"]*)" has reached maximum amount of sponsors$/) do |petition_action|
   petition = Petition.find_by(action: petition_action)
   Site.maximum_number_of_sponsors.times { petition.sponsors.build(FactoryGirl.attributes_for(:sponsor)) }
 end
 
-And (/^the petition "([^"]*)" has (\d+) pending sponsors$/) do |petition_action, sponsors|
+And(/^the petition "([^"]*)" has (\d+) pending sponsors$/) do |petition_action, sponsors|
   petition = Petition.find_by(action: petition_action)
   sponsors.times { petition.sponsors.build(FactoryGirl.attributes_for(:sponsor)) }
 end
 
-Given /^a petition "([^"]*)" has been closed$/ do |petition_action|
+Given(/^a petition "([^"]*)" has been closed$/) do |petition_action|
   @petition = FactoryGirl.create(:closed_petition, :action => petition_action)
 end
 
-Given /^a petition "([^"]*)" has been rejected( with the reason "([^"]*)")?$/ do |petition_action, reason_or_not, reason|
+Given(/^a petition "([^"]*)" has been rejected( with the reason "([^"]*)")?$/) do |petition_action, reason_or_not, reason|
   reason_text = reason.nil? ? "It doesn't make any sense" : reason
   @petition = FactoryGirl.create(:rejected_petition,
     :action => petition_action,
@@ -137,25 +137,25 @@ Then(/^I should be redirected to the archived url$/) do
   expect(current_path).to eq(archived_petition_path(@petition))
 end
 
-When /^I view all petitions from the home page$/ do
+When(/^I view all petitions from the home page$/) do
   visit home_path
   click_link "View all"
 end
 
-When /^I check for similar petitions$/ do
+When(/^I check for similar petitions$/) do
   fill_in "q", :with => "Rioters should loose benefits"
   click_button("Continue")
 end
 
-When /^I choose to create a petition anyway$/ do
+When(/^I choose to create a petition anyway$/) do
   click_link_or_button "My petition is different"
 end
 
-Then /^I should see all petitions$/ do
+Then(/^I should see all petitions$/) do
   expect(page).to have_css("ol li", :count => 3)
 end
 
-Then /^I should see the petition details$/ do
+Then(/^I should see the petition details$/) do
   if @petition.is_a?(ArchivedPetition)
     expect(page).to have_content(@petition.title)
     expect(page).to have_content(@petition.description)
@@ -166,7 +166,7 @@ Then /^I should see the petition details$/ do
   end
 end
 
-Then /^I should see the vote count, closed and open dates$/ do
+Then(/^I should see the vote count, closed and open dates$/) do
   @petition.reload
   expect(page).to have_css("p.signature-count-number", :text => "#{@petition.signature_count} #{'signature'.pluralize(@petition.signature_count)}")
 
@@ -178,12 +178,12 @@ Then /^I should see the vote count, closed and open dates$/ do
   end
 end
 
-Then /^I should not see the vote count$/ do
+Then(/^I should not see the vote count$/) do
   @petition.reload
   expect(page).to_not have_css("p.signature-count-number", :text => @petition.signature_count.to_s + " signatures")
 end
 
-Then /^I should see submitted date$/ do
+Then(/^I should see submitted date$/) do
   @petition.reload
   expect(page).to have_css("li", :text =>  "Date submitted " + @petition.created_at.strftime("%e %B %Y").squish)
 end
@@ -192,7 +192,7 @@ Then(/^I should not see the petition creator$/) do
   expect(page).not_to have_css("li.meta-created-by", :text => "Created by " + @petition.creator_signature.name)
 end
 
-Then /^I should see the reason for rejection$/ do
+Then(/^I should see the reason for rejection$/) do
   @petition.reload
 
   if @petition.is_a?(ArchivedPetition)
@@ -202,28 +202,28 @@ Then /^I should see the reason for rejection$/ do
   end
 end
 
-Then /^I should be asked to search for a new petition$/ do
+Then(/^I should be asked to search for a new petition$/) do
   expect(page).to have_content("What do you want us to do?")
   expect(page).to have_css("form textarea[name=q]")
 end
 
-Then /^I should see a list of existing petitions I can sign$/ do
+Then(/^I should see a list of existing petitions I can sign$/) do
   expect(page).to have_content(@petition.action)
 end
 
-Then /^I should see a list of (\d+) petitions$/ do |petition_count|
+Then(/^I should see a list of (\d+) petitions$/) do |petition_count|
   expect(page).to have_css("tbody tr", :count => petition_count)
 end
 
-Then /^I should see my search query already filled in as the action of the petition$/ do
+Then(/^I should see my search query already filled in as the action of the petition$/) do
   expect(page).to have_field("What do you want us to do?", "#{@petition.action}")
 end
 
-Then /^I can click on a link to return to the petition$/ do
+Then(/^I can click on a link to return to the petition$/) do
   expect(page).to have_css("a[href*='/petitions/#{@petition.id}']")
 end
 
-Then /^I should receive an email telling me how to get an MP on board$/ do
+Then(/^I should receive an email telling me how to get an MP on board$/) do
   expect(unread_emails_for(@petition.creator_signature.email).size).to eq 1
   open_email(@petition.creator_signature.email)
   expect(current_email.default_part_body.to_s).to include("MP")
@@ -249,7 +249,7 @@ Then(/^the petition with action: "(.*?)" should not have requested a government 
   expect(email_requested_at).to be_nil
 end
 
-When /^I start a new petition/ do
+When(/^I start a new petition/) do
   steps %Q(
     Given I am on the new petition page
     Then I should see "Start a petition - Petitions" in the browser page title
@@ -257,7 +257,7 @@ When /^I start a new petition/ do
   )
 end
 
-When /^I fill in the petition details/ do
+When(/^I fill in the petition details/) do
   steps %Q(
     When I fill in "What do you want us to do?" with "The wombats of wimbledon rock."
     And I fill in "Background" with "Give half of Wimbledon rock to wombats!"
@@ -265,11 +265,11 @@ When /^I fill in the petition details/ do
   )
 end
 
-Then /^I should see my constituency "([^"]*)"/ do |constituency|
+Then(/^I should see my constituency "([^"]*)"/) do |constituency|
   expect(page).to have_text(constituency)
 end
 
-Then /^I should see my MP/ do
+Then(/^I should see my MP/) do
   signature = Signature.find_by(email: "womboidian@wimbledon.com",
                                  postcode: "N11TY",
                                  name: "Womboid Wibbledon",
@@ -277,7 +277,7 @@ Then /^I should see my MP/ do
   expect(page).to have_text(signature.constituency.mp.name)
 end
 
-Then /^I can click on a link to visit my MP$/ do
+Then(/^I can click on a link to visit my MP$/) do
   signature = Signature.find_by(email: "womboidian@wimbledon.com",
                                  postcode: "N11TY",
                                  name: "Womboid Wibbledon",
@@ -285,7 +285,7 @@ Then /^I can click on a link to visit my MP$/ do
   expect(page).to have_css("a[href*='#{signature.constituency.mp.url}']")
 end
 
-Then /^I should not see the text "([^"]*)"/ do |text|
+Then(/^I should not see the text "([^"]*)"/) do |text|
   expect(page).to_not have_text(text)
 end
 
@@ -322,7 +322,7 @@ Then(/^I can share it via (.+)$/) do |service|
   end
 end
 
-Then /^I expand "([^"]*)"/ do |text|
+Then(/^I expand "([^"]*)"/) do |text|
   page.find("//details/summary[contains(., '#{text}')]").click
 end
 
@@ -363,6 +363,10 @@ end
 
 Given(/^a petition "(.*?)" exists awaiting government response$/) do |action|
   @petition = FactoryGirl.create(:awaiting_petition, action: action)
+end
+
+Given(/^a petition "(.*?)" exists with notes "([^"]*)"$/) do |action, notes|
+  @petition = FactoryGirl.create(:open_petition, action: action, admin_notes: notes)
 end
 
 Given(/^there are (\d+) petitions with a scheduled debate date$/) do |scheduled_debate_petitions_count|

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -46,14 +46,68 @@ RSpec.describe Admin::PetitionsController, type: :controller do
         expect(response).to render_template('admin/petitions/index')
       end
 
-      it "fetchs a list of 50 petitions" do
-        expect(Petition).to receive(:search).with(hash_including(count: 50)).and_return Petition.none
-        get :index
+      describe "when no 'q', 't', or 'state' param is present" do
+        it "fetchs a list of 50 petitions" do
+          expect(Petition).to receive(:search).with(hash_including(count: 50)).and_return Petition.none
+          get :index
+        end
+        it "passes on pagination params" do
+          expect(Petition).to receive(:search).with(hash_including(page: '3')).and_return Petition.none
+          get :index, page: '3'
+        end
       end
 
-      it "passes in the q param to perform a search for" do
-        expect(Petition).to receive(:search).with(hash_including(q: 'lorem')).and_return Petition.none
-        get :index, q: 'lorem'
+      describe "when a 'q' param is present" do
+        it "passes in the q param to perform a search for" do
+          expect(Petition).to receive(:search).with(hash_including(q: 'lorem')).and_return Petition.none
+          get :index, q: 'lorem'
+        end
+        it "passes on pagination params" do
+          expect(Petition).to receive(:search).with(hash_including(page: '3')).and_return Petition.none
+          get :index, q: 'lorem', page: '3'
+        end
+      end
+
+      describe "when a 't' param is present" do
+        let(:petition_scope) { Petition.none }
+        it "avoids search entirely" do
+          expect(Petition).not_to receive(:search)
+          get :index, t: 'a tag'
+        end
+        it "uses the t param to find tagged petitions" do
+          expect(Petition).to receive(:tagged_with).with('a tag').and_return petition_scope
+          get :index, t: 'a tag'
+        end
+        it "passes on pagination params" do
+          allow(Petition).to receive(:tagged_with).and_return petition_scope
+          expect(petition_scope).to receive(:paginate).with(page: '3', per_page: 50).and_return petition_scope
+          get :index, t: 'a tag', page: '3'
+        end
+        context 'and `q` is also present' do
+          it 'does a search, not a tagged filter' do
+            expect(Petition).to receive(:search)
+            expect(Petition).not_to receive(:tagged_with)
+            get :index, t: 'a tag', q: 'lorem'
+          end
+        end
+        context 'and `state` is also present' do
+          it 'does a search, not a tagged filter' do
+            expect(Petition).to receive(:search)
+            expect(Petition).not_to receive(:tagged_with)
+            get :index, t: 'a tag', state: 'open'
+          end
+        end
+      end
+
+      describe 'when a `state` param is present' do
+        it "passes in the state param to perform a search for" do
+          expect(Petition).to receive(:search).with(hash_including(state: 'open')).and_return Petition.none
+          get :index, state: 'open'
+        end
+        it "passes on pagination params" do
+          expect(Petition).to receive(:search).with(hash_including(page: '3')).and_return Petition.none
+          get :index, state: 'open', page: '3'
+        end
       end
     end
 

--- a/spec/controllers/admin/searches_controller_spec.rb
+++ b/spec/controllers/admin/searches_controller_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe Admin::SearchesController, type: :controller do
           expect(response).to redirect_to("https://petition.parliament.uk/admin/petitions?q=example_keyword")
         end
       end
+
+      context "searching by tag" do
+        it "redirects to the all petitions page for a tag" do
+          get :show, q: '[a tag]'
+          expect(response).to redirect_to("https://petition.parliament.uk/admin/petitions?t=a+tag")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/98300716

Doing a search for `[<something>]` will look only in admin notes fields for `[<something>]`.  This allows admins to "tag" petitions and find them later.  It's an exact match using a SQL `LIKE` statement, and we sanitize it to assume that `<something>` is a single "tag". (e.g. spaces are allowed in tag names and we strip extra `[]` from the search so that `[foo] [bar]` will end up as a search for `[foo bar]`.