### PR TITLE
Don't show "Flag" option for already flagged petitions

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -370,6 +370,10 @@ class Petition < ActiveRecord::Base
     state == CLOSED_STATE
   end
 
+  def flagged?
+    state == FLAGGED_STATE
+  end
+
   def published?
     state.in?(PUBLISHED_STATES)
   end

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -6,8 +6,10 @@
     <%= f.label :moderation_reject, nil, class: 'block-label' do %>
       <%= f.radio_button :moderation, 'reject' %> Reject
     <% end %>
-    <%= f.label :moderation_flag, nil, class: 'block-label' do %>
-      <%= f.radio_button :moderation, 'flag' %> Flag
+    <% unless f.object.flagged? %>
+      <%= f.label :moderation_flag, nil, class: 'block-label' do %>
+        <%= f.radio_button :moderation, 'flag' %> Flag
+      <% end %>
     <% end %>
     <%= error_messages_for_field petition, :moderation %>
   <% end %>

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -108,3 +108,4 @@ Feature: Moderator respond to petition
     And the creator should not receive a notification email
     And the creator should not receive a rejection notification email
     But the petition will still show up in the back-end reporting
+    And the petition can no longer be flagged

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -69,6 +69,11 @@ Then /^the petition should be visible on the site for signing$/ do
   expect(page).to have_css("a", :text => "Sign")
 end
 
+Then(/^the petition can no longer be flagged$/) do
+  visit admin_petition_path(@petition)
+  expect(page).to have_no_field('Flag')
+end
+
 Then(/^the creator should receive a notification email$/) do
   steps %Q(
     Then "#{@petition.creator_signature.email}" should receive an email

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -503,6 +503,26 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe "flagged?" do
+    context "when the state is flagged" do
+      let(:petition) { FactoryGirl.build(:petition, state: Petition::FLAGGED_STATE) }
+
+      it "returns true" do
+        expect(petition.flagged?).to be_truthy
+      end
+    end
+
+    context "for other states" do
+      (Petition::STATES - [Petition::FLAGGED_STATE]).each do |state|
+        let(:petition) { FactoryGirl.build(:petition, state: state) }
+
+        it "is not open when state is #{state}" do
+          expect(petition.flagged?).to be_falsey
+        end
+      end
+    end
+  end
+
   describe "#in_moderation?" do
     context "for in moderation states" do
       Petition::IN_MODERATION_STATES.each do |state|


### PR DESCRIPTION
Once a petition is flagged you can't flag it anymore so it's a pointless option.  It's also a stronger signal to the user that the flag action they've taken has worked because we send them back to the show page and the UI has changed.  Before this commit all that changed on the page is the state in the sidebar, which they could easily might miss.

To fix: https://www.pivotaltracker.com/story/show/98299836