### PR TITLE
Fix discrepancy between model and db for Petition#background

### DIFF
--- a/db/migrate/20150703165930_change_size_of_petition_background.rb
+++ b/db/migrate/20150703165930_change_size_of_petition_background.rb
@@ -1,0 +1,9 @@
+class ChangeSizeOfPetitionBackground < ActiveRecord::Migration
+  def up
+    change_column :petitions, :background, :string, limit: 300
+  end
+
+  def down
+    change_column :petitions, :background, :string, limit: 200
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -368,7 +368,7 @@ CREATE TABLE petitions (
     closed_at timestamp without time zone,
     signature_count integer DEFAULT 0,
     notified_by_email boolean DEFAULT false,
-    background character varying(200),
+    background character varying(300),
     sponsor_token character varying(255),
     government_response_at timestamp without time zone,
     scheduled_debate_date date,
@@ -1148,4 +1148,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150701165425');
 INSERT INTO schema_migrations (version) VALUES ('20150701174136');
 
 INSERT INTO schema_migrations (version) VALUES ('20150703100716');
+
+INSERT INTO schema_migrations (version) VALUES ('20150703165930');
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Petition, type: :model do
     it { is_expected.to validate_presence_of(:background).with_message(/must be completed/) }
     it { is_expected.to validate_presence_of(:creator_signature).with_message(/must be completed/) }
 
+    it { is_expected.to have_db_column(:action).of_type(:string).with_options(limit: 255, null: false) }
+    it { is_expected.to have_db_column(:background).of_type(:string).with_options(limit: 300, null: true) }
+    it { is_expected.to have_db_column(:additional_details).of_type(:text).with_options(null: true) }
+
     it "should validate the length of :action to within 80 characters" do
       expect(FactoryGirl.build(:petition, :action => 'x' * 80)).to be_valid
       expect(FactoryGirl.build(:petition, :action => 'x' * 81)).not_to be_valid


### PR DESCRIPTION
The model validates at 300 chars, but the db was limited to 200.  Set both to 300.  We also add ``shoulda-matcher`` specs for the db fields of the model which raises some other discrepancies: we validate the presence of ``background`` and ``additional_details``, but the db columns are nullable.  These are less likely to break though as it's the model that is more restrictive than the db.

For: https://www.pivotaltracker.com/story/show/98300682