### PR TITLE
[simplify_signatures_index] Remove index

### DIFF
--- a/db/migrate/20150705114811_remove_index_signatures_on_petition_id_and_state_and_name.rb
+++ b/db/migrate/20150705114811_remove_index_signatures_on_petition_id_and_state_and_name.rb
@@ -1,0 +1,5 @@
+class RemoveIndexSignaturesOnPetitionIdAndStateAndName < ActiveRecord::Migration
+  def change
+    remove_index :signatures, [:petition_id, :state, :name]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -954,13 +954,6 @@ CREATE INDEX index_signatures_on_petition_id ON signatures USING btree (petition
 
 
 --
--- Name: index_signatures_on_petition_id_and_state_and_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_signatures_on_petition_id_and_state_and_name ON signatures USING btree (petition_id, state, name);
-
-
---
 -- Name: index_signatures_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1150,4 +1143,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150701174136');
 INSERT INTO schema_migrations (version) VALUES ('20150703100716');
 
 INSERT INTO schema_migrations (version) VALUES ('20150703165930');
+
+INSERT INTO schema_migrations (version) VALUES ('20150705114811');
 


### PR DESCRIPTION
The index on signatures for [:petition_id, :state, :name] was not very unique. This was leading to slowdowns on certain queries