### PR TITLE
Add subdomains to the HSTS headers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Set the HSTS headers to include subdomains
+  config.ssl_options[:hsts] = { expires: 365.days, subdomains: true }
+
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,6 +26,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Set the HSTS headers to include subdomains
+  config.ssl_options[:hsts] = { expires: 365.days, subdomains: true }
+
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 

--- a/spec/requests/hsts_headers_spec.rb
+++ b/spec/requests/hsts_headers_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'HSTS headers', type: :request do
+  subject { response.header["Strict-Transport-Security"] }
+
+  before do
+    get "/"
+  end
+
+  it "sets the includeSubDomains option" do
+    expect(subject).to match(/IncludeSubDomains/i)
+  end
+
+  it "sets the max-ago to 365 days" do
+    expect(subject).to match(/max-age=31536000/i)
+  end
+end


### PR DESCRIPTION
Rails doesn't include subdomains by default when sending the HSTS header as it doesn't know whether this is true but we do so force it to be true.