### PR TITLE
[change_rails_logger] Change production logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'jquery-rails'
 gem 'delayed-web', github: 'thebestday/delayed-web'
 gem 'dalli'
 gem 'connection_pool'
+gem 'lograge'
+gem 'logstash-logger'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,14 @@ GEM
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
+    lograge (0.3.3)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
+    logstash-event (1.2.02)
+    logstash-logger (0.10.2)
+      logstash-event (~> 1.2)
+      stud
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -246,6 +254,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    stud (0.0.20)
     textacular (3.2.2)
       activerecord (>= 3.0, < 5.0)
     thor (0.19.1)
@@ -295,6 +304,8 @@ DEPENDENCIES
   jquery-rails
   json
   launchy
+  lograge
+  logstash-logger
   newrelic_rpm
   nokogiri
   pg

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,15 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
+
+  # Turn on lograge, to give us more parseable logs
+  config.lograge.enabled = true
+
+  # Log in logstash format, so that we can easily parse the output
+  config.logger = LogStashLogger.new(
+    uri: ENV.fetch('LOGSTASH_URI') { 'file://' + Rails.root.join('log', 'production.log').to_s }
+  )
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
@@ -82,9 +90,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
- Replace the rails logger with lograge
- Log messages in Logstash format, so that parsers can deal with it
- Change the production log level from :debug to :info