### PR TITLE
Clarify government responses on homepage

### DIFF
--- a/app/assets/stylesheets/petitions/views/_home.scss
+++ b/app/assets/stylesheets/petitions/views/_home.scss
@@ -30,10 +30,13 @@
   text-decoration: underline;
 }
 
+// Threshold panel links
 .threshold-panel {
   display: block;
   @extend %outdent-to-full-width;
   background-color: $petitions-panel-colour;
+  background-position: 15px 15px;
+  background-repeat: no-repeat;
   padding: $gutter-half $gutter*2 $gutter-two-thirds $gutter-half;
   margin: $gutter*1.5 $gutter-half*-1 $gutter;
 
@@ -52,28 +55,35 @@
     margin: 0;
   }
 }
-
 .threshold-panel:hover, .threshold-panel:focus {
   background-color: darken($petitions-panel-colour, 5%);
 }
-
-.response-threshold, .debate-threshold {
-  background-position: 15px 15px;
-  background-repeat: no-repeat;
-}
-.response-threshold {
+.threshold-panel-response {
   background-image: image-url("graphics/graphic_crown-white.png");
   @include device-pixel-ratio() {
     background-image: image-url("graphics/graphic_crown-white-2x.png");
     background-size: 36px;
   }
 }
-.debate-threshold {
+.threshold-panel-debate {
   background-position: 15px 12px;
   background-image: image-url("graphics/graphic_portcullis-white.png");
   @include device-pixel-ratio() {
     background-image: image-url("graphics/graphic_portcullis-white-2x.png");
     background-size: 26px;
+  }
+}
+
+// Threshold petitions
+.threshold-petitions {
+  .response-intro {
+    margin-top: 10px;
+  }
+  .pull-quote {
+    margin-top: 5px;
+  }
+  .pull-quote:before, .pull-quote p {
+    color: $black;
   }
 }
 

--- a/app/views/pages/_home_debated_petitions.html.erb
+++ b/app/views/pages/_home_debated_petitions.html.erb
@@ -1,8 +1,7 @@
 <% if actioned[:with_debate_outcome][:count].zero? %>
   <p>This Parliament has not debated any petitions yet.</p>
 <% else %>
-  <h2>Most recently debated in Parliament</h2>
-  <ol class="threshold-petitions debate-petitions-list">
+  <ol class="threshold-petitions">
     <% actioned[:with_debate_outcome][:list].each do |petition| %>
       <li class="petition-item">
         <h3><%= link_to petition.action, petition_path(petition) %></h3>

--- a/app/views/pages/_home_responded_petitions.html.erb
+++ b/app/views/pages/_home_responded_petitions.html.erb
@@ -1,13 +1,13 @@
 <% if actioned[:with_response][:count].zero? %>
   <p>This Government has not responded to any petitions yet.</p>
 <% else %>
-  <h2>Most recent government responses</h2>
-  <ol class="threshold-petitions response-petitions-list">
+  <ol class="threshold-petitions">
     <% actioned[:with_response][:list].each do |petition| %>
       <li class="petition-item">
         <h3><%= link_to petition.action, petition_path(petition), class: "threshold-petition-title" %></h3>
+        <p class="response-intro">The government responded</p>
         <blockquote class="pull-quote"><%= simple_format(petition.government_response.summary) %></blockquote>
-        <p><%= link_to "Read the government response", petition_path(petition) %></p>
+        <p><%= link_to "Read the response in full", petition_path(petition) %></p>
       </li>
     <% end -%>
   </ol>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -30,12 +30,12 @@
 <% explanation_petitions do |actioned| %>
   <section aria-labelledby="response-threshold-heading" id="petitions-with-response">
     <% if actioned[:with_response][:count].zero? %>
-      <div class="threshold-panel response-threshold">
+      <div class="threshold-panel threshold-panel-response">
         <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %></h2>
         <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the government will&nbsp;respond</p>
       </div>
     <% else %>
-      <%= link_to( petitions_path(state: :with_response), class: "threshold-panel response-threshold" ) do %>
+      <%= link_to( petitions_path(state: :with_response), class: "threshold-panel threshold-panel-response" ) do %>
         <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %></h2>
         <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the government will&nbsp;respond</p>
       <% end %>
@@ -47,12 +47,12 @@
 
   <section aria-labelledby="debate-threshold-heading" id="petitions-with-debate-outcome">
     <% if actioned[:with_debate_outcome][:count].zero? %>
-      <div class="threshold-panel debate-threshold">
+      <div class="threshold-panel threshold-panel-debate">
         <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %></h2>
         <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in&nbsp;Parliament</p>
       </div>
     <% else %>
-      <%= link_to( petitions_path(state: :with_debate_outcome), class: "threshold-panel debate-threshold" ) do %>
+      <%= link_to( petitions_path(state: :with_debate_outcome), class: "threshold-panel threshold-panel-debate" ) do %>
         <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %></h2>
         <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in&nbsp;Parliament</p>
       <% end %>


### PR DESCRIPTION
* Add 'The government responded...' to response quotes
* Remove headings 'Most recent government responses / debates in Parliament'
* Change 'Read the government response' to 'Read the response in full'