### PR TITLE
Fix cacheable SSL responses

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,8 +1,11 @@
 class Admin::AdminController < ApplicationController
   include Authentication
 
-  before_filter :require_admin_and_check_for_password_change
+  before_action :require_admin_and_check_for_password_change
+  before_action :do_not_cache
+
   layout 'admin'
+
   helper_method :admin_petition_facets
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,4 +43,8 @@ class ApplicationController < ActionController::Base
   def public_petition_facets
     I18n.t('public', scope: :"petitions.facets")
   end
+
+  def do_not_cache
+    response.headers['Cache-Control'] = 'no-store, no-cache'
+  end
 end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,6 +1,8 @@
 class PetitionsController < ApplicationController
   include ManagingMoveParameter
+
   before_action :avoid_unknown_state_filters, only: :index
+  before_action :do_not_cache, except: %i[index show]
 
   respond_to :html
 

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -3,6 +3,7 @@ class SignaturesController < ApplicationController
 
   before_filter :retrieve_petition, :only => [:new, :create, :thank_you]
   before_filter :retrieve_signature, :only => [:verify, :unsubscribe, :signed]
+  before_action :do_not_cache
 
   respond_to :html
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -5,6 +5,7 @@ class SponsorsController < ApplicationController
   before_action :redirect_to_petition_url, if: :moderated?
   before_action :redirect_to_moderation_info_url, if: :has_maximum_sponsors?
   before_action :validate_creator_signature, only: %i[show]
+  before_action :do_not_cache
 
   respond_to :html
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,14 +2,23 @@ require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
   controller do
+    before_action :do_not_cache
+
     def index
       render text: 'OK'
     end
   end
 
+  let(:cache_control) { response.headers['Cache-Control'] }
+
   it "reloads the site instance on every request" do
     expect(Site).to receive(:reload)
     get :index
+  end
+
+  it "sets cache control headers when asked" do
+    get :index
+    expect(cache_control).to eq('no-store, no-cache')
   end
 
   context "when the site is disabled" do

--- a/spec/requests/cache_control_header_spec.rb
+++ b/spec/requests/cache_control_header_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe 'Cache-Control headers', type: :request do
+  let(:cache_control) { response.headers['Cache-Control'] }
+  let(:status) { response.status }
+
+  context "when visiting the petition index page" do
+    before do
+      get "/petitions"
+    end
+
+    it "doesn't change the cache control headers" do
+      expect(cache_control).to eq("max-age=0, private, must-revalidate")
+      expect(status).to eq(200)
+    end
+  end
+
+  context "when visiting the petition show page" do
+    let!(:petition) { FactoryGirl.create(:open_petition) }
+
+    before do
+      get "/petitions/#{petition.id}"
+    end
+
+    it "doesn't change the cache control headers" do
+      expect(cache_control).to eq("max-age=0, private, must-revalidate")
+      expect(status).to eq(200)
+    end
+  end
+
+  context "when visiting the new petition page" do
+    let!(:petition) { FactoryGirl.create(:open_petition) }
+
+    before do
+      get "/petitions/new"
+    end
+
+    it "changes the cache control headers to 'no-store, no-cache'" do
+      expect(cache_control).to eq("no-store, no-cache")
+      expect(status).to eq(200)
+    end
+  end
+
+  context "when visiting the new sponsor page" do
+    let!(:petition) { FactoryGirl.create(:pending_petition) }
+
+    before do
+      get "/petitions/#{petition.id}/sponsors/#{petition.sponsor_token}"
+    end
+
+    it "changes the cache control headers to 'no-store, no-cache'" do
+      expect(cache_control).to eq("no-store, no-cache")
+      expect(status).to eq(200)
+    end
+  end
+
+  context "when visiting the new signature page" do
+    let!(:petition) { FactoryGirl.create(:open_petition) }
+
+    before do
+      get "/petitions/#{petition.id}/signatures/new"
+    end
+
+    it "changes the cache control headers to 'no-store, no-cache'" do
+      expect(cache_control).to eq("no-store, no-cache")
+      expect(status).to eq(200)
+    end
+  end
+
+  context "when visiting an admin page", admin: true do
+    before do
+      get "/admin/login"
+    end
+
+    it "changes the cache control headers to 'no-store, no-cache'" do
+      expect(cache_control).to eq("no-store, no-cache")
+      expect(status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Although most of the website is acceptable for caching like browsing the home page, petition list pages and the petition show page, there are some sensistive pages like petition creation, sponsoring and sigining petitions. Also the admin should not be cached either.

Fixes GDNT-025-3-4.