### PR TITLE
Removing links to the site from email footers

### DIFF
--- a/app/views/petition_mailer/double_signature_confirmation.html.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.html.erb
@@ -6,4 +6,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/double_signature_confirmation.html.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.html.erb
@@ -6,4 +6,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/double_signature_confirmation.text.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.text.erb
@@ -6,4 +6,4 @@ You can’t sign a second time.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/double_signature_confirmation.text.erb
+++ b/app/views/petition_mailer/double_signature_confirmation.text.erb
@@ -6,4 +6,4 @@ You can’t sign a second time.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
@@ -6,4 +6,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.html.erb
@@ -6,4 +6,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
@@ -6,4 +6,4 @@ You can’t sign a second time.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
+++ b/app/views/petition_mailer/email_already_confirmed_for_signature.text.erb
@@ -6,4 +6,4 @@ You can’t sign a second time.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.html.erb
@@ -4,4 +4,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.html.erb
@@ -4,4 +4,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.text.erb
@@ -4,4 +4,4 @@ Click this link to sign the petition "<%= @signature.petition.action %>"
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.text.erb
@@ -4,4 +4,4 @@ Click this link to sign the petition "<%= @signature.petition.action %>"
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
@@ -8,7 +8,7 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>
 
 <hr />
 

--- a/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
@@ -8,7 +8,7 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>
 
 <hr />
 

--- a/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
@@ -8,7 +8,7 @@ Forward the email below to your potential supporters.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament
 
 --
 

--- a/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
@@ -8,7 +8,7 @@ Forward the email below to your potential supporters.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>
 
 --
 

--- a/app/views/petition_mailer/no_signature_for_petition.html.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.html.erb
@@ -11,4 +11,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/no_signature_for_petition.html.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.html.erb
@@ -11,4 +11,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/no_signature_for_petition.text.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.text.erb
@@ -10,4 +10,4 @@ Ignore this email if you think it was sent to you by mistake.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/no_signature_for_petition.text.erb
+++ b/app/views/petition_mailer/no_signature_for_petition.text.erb
@@ -10,4 +10,4 @@ Ignore this email if you think it was sent to you by mistake.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
@@ -12,4 +12,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
@@ -12,4 +12,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
@@ -12,4 +12,4 @@ If you want to give feedback, please contact us at:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
@@ -12,4 +12,4 @@ If you want to give feedback, please contact us at:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
@@ -7,4 +7,4 @@ Click this link to see your petition and start sharing it:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_is_published.text.erb
@@ -7,4 +7,4 @@ Click this link to see your petition and start sharing it:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -19,6 +19,6 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>
 
 <p><small>You’re receiving this email because you signed this petition. Unsubscribe: <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -19,6 +19,6 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>
 
 <p><small>You’re receiving this email because you signed this petition. Unsubscribe: <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -19,6 +19,6 @@ Parliament debated the petition you signed – "<%= @petition.action %>"
 <% end %>
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament
 
 You’re receiving this email because you signed this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -19,6 +19,6 @@ Parliament debated the petition you signed – "<%= @petition.action %>"
 <% end %>
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>
 
 You’re receiving this email because you signed this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -10,6 +10,6 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>
 
 <p><small>You’re receiving this email because you signed this petition. Unsubscribe: <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -10,6 +10,6 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>
 
 <p><small>You’re receiving this email because you signed this petition. Unsubscribe: <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -10,6 +10,6 @@ Once the debate has happened, we’ll email you a video and transcript.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>
 
 You’re receiving this email because you signed this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -10,6 +10,6 @@ Once the debate has happened, we’ll email you a video and transcript.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament
 
 You’re receiving this email because you signed this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -10,6 +10,6 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>
 
 <p><small>You’re receiving this email because you signed this petition. Unsubscribe: <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -10,6 +10,6 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>
 
 <p><small>You’re receiving this email because you signed this petition. Unsubscribe: <%= link_to 'unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -12,6 +12,6 @@ Click this link to view the response online:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>
 
 You’re receiving this email because you signed this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -12,6 +12,6 @@ Click this link to view the response online:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament
 
 You’re receiving this email because you signed this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
@@ -8,4 +8,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.html.erb
@@ -8,4 +8,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
@@ -8,4 +8,4 @@ Click this link to sign the petition "<%= @pending_signature.petition.action %>"
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
+++ b/app/views/petition_mailer/one_pending_one_validated_signature.text.erb
@@ -8,4 +8,4 @@ Click this link to sign the petition "<%= @pending_signature.petition.action %>"
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/petition_rejected.html.erb
+++ b/app/views/petition_mailer/petition_rejected.html.erb
@@ -21,4 +21,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/petition_rejected.html.erb
+++ b/app/views/petition_mailer/petition_rejected.html.erb
@@ -21,4 +21,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/petition_rejected.text.erb
+++ b/app/views/petition_mailer/petition_rejected.text.erb
@@ -21,4 +21,4 @@ If you want to try again, click here to start a petition:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/petition_rejected.text.erb
+++ b/app/views/petition_mailer/petition_rejected.text.erb
@@ -21,4 +21,4 @@ If you want to try again, click here to start a petition:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
@@ -8,4 +8,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
@@ -8,4 +8,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
@@ -8,4 +8,4 @@ Click this link to sign the petition:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
@@ -8,4 +8,4 @@ Click this link to sign the petition:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/two_pending_signatures.html.erb
+++ b/app/views/petition_mailer/two_pending_signatures.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/two_pending_signatures.html.erb
+++ b/app/views/petition_mailer/two_pending_signatures.html.erb
@@ -10,4 +10,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/petition_mailer/two_pending_signatures.text.erb
+++ b/app/views/petition_mailer/two_pending_signatures.text.erb
@@ -10,4 +10,4 @@ You must click both links to confirm both signatures.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/petition_mailer/two_pending_signatures.text.erb
+++ b/app/views/petition_mailer/two_pending_signatures.text.erb
@@ -10,4 +10,4 @@ You must click both links to confirm both signatures.
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.html.erb
@@ -9,4 +9,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.html.erb
@@ -9,4 +9,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.text.erb
@@ -9,4 +9,4 @@ Find out how we check petitions before we publish them:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_below_threshold.text.erb
@@ -9,4 +9,4 @@ Find out how we check petitions before we publish them:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
@@ -11,4 +11,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-<%= link_to nil, home_url %></p>
+UK Government and Parliament</p>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
@@ -11,4 +11,4 @@
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
-UK Government and Parliament</p>
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
@@ -11,4 +11,4 @@ Find out how we check petitions before we publish them:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-UK Government and Parliament
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
@@ -11,4 +11,4 @@ Find out how we check petitions before we publish them:
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
-<%= home_url %>
+UK Government and Parliament

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -93,6 +93,7 @@ en-GB:
         notify_creator_of_closing_date_change: |-
           We’re closing your petition early
       signoff_prefix: "The Petitions team"
+      signoff_suffix: "UK Government and Parliament"
 
     waiting_for_in_words:
       zero: "Waiting for less than a day"


### PR DESCRIPTION
PT:  https://www.pivotaltracker.com/story/show/98541614

These links competed for attention with no value.

Not touching the unsubscribe natch.