### PR TITLE
Fix bug where `action` was output in support flow `<title>`

### DIFF
--- a/config/locales/page_titles.en-GB.yml
+++ b/config/locales/page_titles.en-GB.yml
@@ -25,7 +25,8 @@ en-GB:
       thank_you: "Thank you - Petitions"
       unsubscribe: "Successfully unsubscribed"
     sponsors:
-      show: "%{petition} - Support this petition - Petitions"
+      show: "Support petition - Petitions"
+      # Ideally "Support %{petition.creator_signature.name}'s petition - Petitions"
       sponsored: "Thank you - Petitions"
       thank_you: "%{petition} - Thank you for supporting this petition - Petitions"
     pages:


### PR DESCRIPTION
Fix bug where the petition `action` was being displayed in the Support petition flow `<title>` tag