### PR TITLE
Fix appsignal deploy notifications

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -15,8 +15,9 @@ default: &defaults
 
   # Exceptions that should not be recorded by AppSignal
   ignore_exceptions:
-    - ActiveRecord::RecordNotFound
+    - ActionController::InvalidAuthenticityToken
     - ActionController::RoutingError
+    - ActiveRecord::RecordNotFound
 
 # Configuration per environment, leave out an environment or set active
 # to false to not push metrics for that environment.


### PR DESCRIPTION
It seems like the AppSignal CLI tool isn't notifying deployments properly but it works by calling the API endpoint directly. This is a supported method of deployment notification so should continue to work going forward.