### PR TITLE
Patch queue adapter for better reporting in AppSignal

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,2 +1,22 @@
 Delayed::Worker.max_attempts = 100
 Delayed::Worker.max_run_time = 1.week
+
+require 'active_job/queue_adapters/delayed_job_adapter'
+
+# We patch in the display_name method to the Delayed Job queue adapter
+# so that all the jobs aren't aggregated under one name in AppSignal.
+module ActiveJob
+  module QueueAdapters
+    class DelayedJobAdapter
+      class JobWrapper
+        def display_name
+          if job_data['job_class'] == 'ActionMailer::DeliveryJob'
+            "#{job_data['arguments'][0]}##{job_data['arguments'][1]}"
+          else
+            "#{job_data['job_class']}#perform"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently all the jobs are reported under the same name in AppSignal. This is a dirty way to fix it but there is no other option as adding a `appsignal_name` method to the job class doesn't work since that's not the object that gets passed to AppSignal's Delayed Job plugin.