### PR TITLE
Fix when transition to sponsored state occurs

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -289,7 +289,7 @@ class Petition < ActiveRecord::Base
 
   def at_threshold_for_moderation?
     unless moderation_threshold_reached_at?
-      signature_count >= Site.threshold_for_moderation - 1
+      signature_count >= Site.threshold_for_moderation
     end
   end
 


### PR DESCRIPTION
The transition from validated to sponsored actually occurs when a petition has six signatures - the five sponsors and the creator.

https://www.pivotaltracker.com/story/show/98889188