### PR TITLE
Replace '+' with '%20' in sharing links

### DIFF
--- a/app/helpers/sharing_helper.rb
+++ b/app/helpers/sharing_helper.rb
@@ -34,23 +34,27 @@ module SharingHelper
   private
 
   def share_via_facebook_params(petition)
-    { u: petition_url(petition), ref: "responsive" }.to_query
+    share_params(u: petition_url(petition), ref: "responsive")
   end
 
   def share_via_email_params(petition)
-    { subject: share_title(petition), body: petition_url(petition) }.to_query
+    share_params(subject: share_title(petition), body: petition_url(petition))
   end
 
   def share_via_twitter_params(petition)
-    { text: share_title(petition), url: petition_url(petition) }.to_query
+    share_params(text: share_title(petition), url: petition_url(petition))
   end
 
   def share_via_whatsapp_params(petition)
-    { text: "#{share_title(petition)}\n#{petition_url(petition)}" }.to_query
+    share_params(text: "#{share_title(petition)}\n#{petition_url(petition)}")
   end
 
   def share_title(petition)
     t(:share_title, scope: :petitions, petition: petition.action)
+  end
+
+  def share_params(hash)
+    hash.to_query.gsub('+', '%20')
   end
 
   def share_button(service)

--- a/spec/helpers/sharing_helper_spec.rb
+++ b/spec/helpers/sharing_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SharingHelper, type: :helper do
   describe "#share_via_email_url" do
     it "generates a share via email url" do
       expect(helper.share_via_email_url(petition)).to eq <<-URL.strip
-        mailto:?body=https%3A%2F%2Fpetition.parliament.uk%2Fpetitions%2F100000&subject=Petition%3A+Do+something
+        mailto:?body=https%3A%2F%2Fpetition.parliament.uk%2Fpetitions%2F100000&subject=Petition%3A%20Do%20something
       URL
     end
   end
@@ -29,7 +29,7 @@ RSpec.describe SharingHelper, type: :helper do
   describe "#share_via_twitter_url" do
     it "generates a share via Twitter url" do
       expect(helper.share_via_twitter_url(petition)).to eq <<-URL.strip
-        https://twitter.com/intent/tweet?text=Petition%3A+Do+something&url=https%3A%2F%2Fpetition.parliament.uk%2Fpetitions%2F100000
+        https://twitter.com/intent/tweet?text=Petition%3A%20Do%20something&url=https%3A%2F%2Fpetition.parliament.uk%2Fpetitions%2F100000
       URL
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe SharingHelper, type: :helper do
   describe "#share_via_whatsapp_url" do
     it "generates a share via Whatsapp url" do
       expect(helper.share_via_whatsapp_url(petition)).to eq <<-URL.strip
-        whatsapp://send?text=Petition%3A+Do+something%0Ahttps%3A%2F%2Fpetition.parliament.uk%2Fpetitions%2F100000
+        whatsapp://send?text=Petition%3A%20Do%20something%0Ahttps%3A%2F%2Fpetition.parliament.uk%2Fpetitions%2F100000
       URL
     end
   end


### PR DESCRIPTION
Mailto links in some (all?) browsers don't decode '+' like they do for HTTP urls so convert them to use percent-encoding. Unfortunately the URI.escape method has been marked as obsolete for some time and there is generally some [confusion][1] over what is the right method to use.

Given this the simplest fix is to replace '+' with '%20' since we know that `to_query` will continue to work in later versions of Rails.

[1]: http://stackoverflow.com/questions/2824126