### PR TITLE
Use postcode in page title when no constituency found

### DIFF
--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -40,6 +40,11 @@ module PageTitleHelper
         opts[:scope]        = :page_titles
         opts[:default]      = [:"#{controller}.default", :default]
         opts[:constituency] = constituency.name if constituency?
+        opts[:postcode]     = formatted_postcode if postcode?
+
+        if postcode?
+          opts[:count] = constituency? ? 1 : 0
+        end
 
         if petition?
           opts[:petition] = petition.action
@@ -51,7 +56,7 @@ module PageTitleHelper
       end
     end
 
-    %w[constituency petition].each do |object|
+    %w[constituency petition postcode].each do |object|
       define_method :"#{object}?" do
         send(:"#{object}").present?
       end
@@ -59,6 +64,10 @@ module PageTitleHelper
       define_method :"#{object}" do
         send(:[], object)
       end
+    end
+
+    def formatted_postcode
+      postcode.gsub(/\A(.+)(.{3})\z/, '\1 \2')
     end
   end
 

--- a/config/locales/page_titles.en-GB.yml
+++ b/config/locales/page_titles.en-GB.yml
@@ -8,7 +8,9 @@ en-GB:
       index: "Send feedback - Petitions"
       thanks: "Thank you - Petitions"
     local_petitions:
-      index: "Petitions in %{constituency}"
+      index:
+        zero: "Petitions in %{postcode}"
+        one: "Petitions in %{constituency}"
     petitions:
       index: "View all petitions - Petitions"
       check: "Start a petition - Petitions"

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe PageTitleHelper, type: :helper do
           index: "Une pétition au Parlement - vers le bas avec ce genre de chose"
         },
         local_petitions: {
-          index: "Pétitions à %{constituency}"
+          index: {
+            zero: "Pétitions à %{postcode}",
+            one: "Pétitions à %{constituency}"
+          }
         },
         petitions: {
           default: "Voir toutes les pétitions",
@@ -95,12 +98,28 @@ RSpec.describe PageTitleHelper, type: :helper do
       end
     end
 
+    context "when there is a postcode assigned but not a constituency" do
+      let(:postcode) { "XM45HQ" }
+
+      before do
+        params[:controller] = "local_petitions"
+        params[:action] = "index"
+        assign('postcode', postcode)
+      end
+
+      it "the formatted postcode is available for interpolation" do
+        expect(helper.page_title).to eq("Pétitions à XM4 5HQ")
+      end
+    end
+
     context "when there is a constituency assigned" do
+      let(:postcode) { "75008" }
       let(:constituency) { double(:constituency, name: "Paris") }
 
       before do
         params[:controller] = "local_petitions"
         params[:action] = "index"
+        assign('postcode', postcode)
         assign('constituency', constituency)
       end
 


### PR DESCRIPTION
If the user enters a postcode that isn't valid then use that in the page title rather than presenting an uninterpolated %{constituency}.

https://www.pivotaltracker.com/story/show/98462500