### PR TITLE
Add an embed of the debate video stream

### DIFF
--- a/app/assets/stylesheets/petitions/views/_petition-show.scss
+++ b/app/assets/stylesheets/petitions/views/_petition-show.scss
@@ -57,3 +57,20 @@
     margin-bottom: 5px;
   }
 }
+
+// Debate outcome video
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  padding-top: 25px;
+  height: 0;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -57,4 +57,26 @@ module PetitionHelper
       render('/petitions/create/replay_email_ui', petition: stage_manager.stage_object, f: form)
     end
   end
+
+  def debate_video_tag(video_url)
+    options = {
+      src: debate_video_embed_url(video_url),
+      id: 'UKPPlayer',
+      name: 'UKPPlayer',
+      title: 'UK Parliament Player',
+      seamless: true,
+      frameborder: 0,
+      allowfullscreen: true
+    }
+
+    content_tag(:div, class: 'video-wrapper') do
+      concat(content_tag(:iframe, '', options))
+    end
+  end
+
+  def debate_video_embed_url(video_url)
+    video_id = File.basename(URI.parse(video_url).path)
+    params = { audioOnly: "False", autoStart: "False", statsEnabled: "True" }.to_query
+    URI::HTTP.build([nil, 'videoplayback.parliamentlive.tv', 80, "/Player/Index/#{video_id}", params, nil]).to_s
+  end
 end

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -5,6 +5,7 @@
     <section class="debate-outcome">
       <p>This topic was debated on <%= short_date_format debate_outcome.debated_on %></p>
       <% if debate_outcome.video_url? -%>
+        <%= debate_video_tag(debate_outcome.video_url) %>
         <p><%= link_to 'Watch the debate', debate_outcome.video_url, rel: 'external' %></p>
       <% end -%>
       <% if debate_outcome.transcript_url? -%>


### PR DESCRIPTION
Unfortunately we can't merge this until parliamentlive.tv is available over HTTPS, otherwise browsers will present mixed content warnings due to Petitions being served over HTTPS.

@yahoopete @henryhadlow do you have anyone you can ask about this?

https://www.pivotaltracker.com/story/show/98586302