### PR TITLE
Change petition creator to delete: restrict not cascade

### DIFF
--- a/db/migrate/20150714140659_change_foreign_key_to_restrict_on_petition_creator.rb
+++ b/db/migrate/20150714140659_change_foreign_key_to_restrict_on_petition_creator.rb
@@ -1,0 +1,11 @@
+class ChangeForeignKeyToRestrictOnPetitionCreator < ActiveRecord::Migration
+  def up
+    remove_foreign_key :petitions, column: :creator_signature_id
+    add_foreign_key :petitions, :signatures, column: :creator_signature_id, on_delete: :restrict
+  end
+
+  def down
+    remove_foreign_key :petitions, column: :creator_signature_id
+    add_foreign_key :petitions, :signatures, column: :creator_signature_id, on_delete: :cascade
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1021,7 +1021,7 @@ ALTER TABLE ONLY constituency_petition_journals
 --
 
 ALTER TABLE ONLY petitions
-    ADD CONSTRAINT fk_rails_5451a341b3 FOREIGN KEY (creator_signature_id) REFERENCES signatures(id) ON DELETE CASCADE;
+    ADD CONSTRAINT fk_rails_5451a341b3 FOREIGN KEY (creator_signature_id) REFERENCES signatures(id) ON DELETE RESTRICT;
 
 
 --
@@ -1151,4 +1151,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150705114811');
 INSERT INTO schema_migrations (version) VALUES ('20150707094523');
 
 INSERT INTO schema_migrations (version) VALUES ('20150709152530');
+
+INSERT INTO schema_migrations (version) VALUES ('20150714140659');
 


### PR DESCRIPTION
If someone accidentally deletes a creator signature we don't want to cascade that delete to the petition and all the other signatures as well.