### PR TITLE
Add home_page? method to error view context

### DIFF
--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -19,6 +19,10 @@ namespace :errors do
       def asset_data(path)
         File.read(Rails.root.join('app', 'assets', 'images', path))
       end
+
+      def home_page?
+        false
+      end
     end
 
     %w[404 422 500 503].each do |status|


### PR DESCRIPTION
THe header partial now uses the home_page? method to decide whether to make the site name a link or not so we need to add that to our context.

https://www.pivotaltracker.com/story/show/99040670