### PR TITLE
Fix admin header

### DIFF
--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header role="banner" id="global-header">
   <div class="wrapper">
-    <%= link_to(admin_root_path, :title => 'Go to the petitions admin hub', :tabindex => 1) do %>
-      <span class="graphic graphic-portcullis-white" aria-hidden="true"></span> Petitions Admin
+    <%= link_to(admin_root_path, title: 'Go to the petitions admin hub', tabindex: 1, class: 'proposition') do %>
+      <span class="graphic graphic-portcullis-white"></span> Petitions Admin
     <% end %>
     <%= render 'admin/shared/header_user_actions' %>
   </div>


### PR DESCRIPTION
The change in #319 added a class to the link in the header which means that the admin header doesn't pick up the style. This commit adds that new CSS class to the link in the admin header.