### PR TITLE
Fix incorrect caching of social meta tags

### DIFF
--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -25,13 +25,19 @@ module CacheHelper
       attr_reader :template
 
       delegate :assigns, to: :template
+      delegate :archived_petition_page?, to: :template
       delegate :create_petition_page?, to: :template
       delegate :home_page?, to: :template
       delegate :last_signature_at, to: :template
       delegate :petition_page?, to: :template
+      delegate :page_title, to: :template
 
       def initialize(template)
         @template = template
+      end
+
+      def archived_petition_page
+        archived_petition_page?
       end
 
       def create_petition_page

--- a/app/views/application/_social_meta.html.erb
+++ b/app/views/application/_social_meta.html.erb
@@ -2,16 +2,16 @@
 <%= open_graph_tag 'site_name', :site_name %>
 <%= open_graph_tag 'locale', 'en_GB' %>
 <%= open_graph_tag 'image', 'os-social/opengraph-image.png' %>
-<% if petition_page? || archived_petition_page? %>
+<% if petition_page? %>
 <%= open_graph_tag 'url', petition_url(@petition) %>
 <%= open_graph_tag 'type', 'article' %>
-<% if petition_page? %>
 <%= open_graph_tag 'title', :title, petition: @petition.action %>
 <%= open_graph_tag 'description', @petition.background %>
-<% else %> <%# archived_petition_page? %>
-<%= open_graph_tag 'title', :title, petition: @petition.title %>
+<% elsif archived_petition_page? %>
+<%= open_graph_tag 'url', archived_petition_url(@petition) %>
+<%= open_graph_tag 'type', 'article' %>
+<%= open_graph_tag 'title', :archived_title, petition: @petition.title %>
 <%= open_graph_tag 'description', @petition.description %>
-<% end %>
 <% else %>
 <%= open_graph_tag 'url', request.original_url %>
 <%= open_graph_tag 'type', 'website' %>
@@ -25,6 +25,9 @@
 <% if petition_page? %>
 <%= twitter_card_tag 'title', :title, petition: @petition.action %>
 <%= twitter_card_tag 'description', @petition.background %>
+<% elsif archived_petition_page? %>
+<%= twitter_card_tag 'title', :title, petition: @petition.title %>
+<%= twitter_card_tag 'description', @petition.description %>
 <% else %>
 <%= twitter_card_tag 'title', page_title %>
 <% end %>

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -3,6 +3,8 @@ head:
     - :site_updated_at
     - :last_signature_at
     - :petition_page
+    - :archived_petition_page
+    - :page_title
     - :petition
   options:
     expires_in: 300

--- a/config/locales/metadata.en-GB.yml
+++ b/config/locales/metadata.en-GB.yml
@@ -4,7 +4,9 @@ en-GB:
       site_name: "Petitions - UK Government and Parliament"
       default_title: "Petitions - UK Government and Parliament"
       title: "Petition: %{petition}"
+      archived_title: "Archived Petition: %{petition}"
 
     twitter:
       default_title: "Petitions - UK Government and Parliament"
       title: "Petition: %{petition}"
+      archived_title: "Archived Petition: %{petition}"

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe CacheHelper, type: :helper do
     let(:klass) { CacheHelper::CacheKey::Keys }
     let(:keys) { klass.new(helper) }
 
+    describe "#archived_petition_page" do
+      it "delegates to the template context" do
+        expect(helper).to receive(:archived_petition_page?).and_return(true)
+        expect(keys.archived_petition_page).to eq(true)
+      end
+    end
+
     describe "#create_petition_page" do
       it "delegates to the template context" do
         expect(helper).to receive(:create_petition_page?).and_return(true)
@@ -53,6 +60,13 @@ RSpec.describe CacheHelper, type: :helper do
       it "delegates to the template context" do
         expect(helper).to receive(:last_signature_at).and_return(now)
         expect(keys.last_signature_at).to eq(now)
+      end
+    end
+
+    describe "#page_title" do
+      it "delegates to the template context" do
+        expect(helper).to receive(:page_title).and_return("Petitions")
+        expect(keys.page_title).to eq("Petitions")
       end
     end
 


### PR DESCRIPTION
The change in e7167a8 made the content of the :head fragment dependent on the page title and whether the page is an archived petition or not. However these aren't part of the cache key for that fragment so we need to add them to the list of dependencies.

https://www.pivotaltracker.com/story/show/99397764