### PR TITLE
Set X-UA-Compatible HTTP header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module Epets
     config.action_dispatch.rescue_responses.merge!(
       'Site::ServiceUnavailable' => :service_unavailable
     )
+
+    config.action_dispatch.default_headers.merge!('X-UA-Compatible' => 'IE=edge')
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   let(:cache_control) { response.headers['Cache-Control'] }
+  let(:x_ua_compatible) { response.headers['X-UA-Compatible'] }
 
   it "reloads the site instance on every request" do
     expect(Site).to receive(:reload)
@@ -19,6 +20,11 @@ RSpec.describe ApplicationController, type: :controller do
   it "sets cache control headers when asked" do
     get :index
     expect(cache_control).to eq('no-store, no-cache')
+  end
+
+  it "sets X-UA-Compatible control headers" do
+    get :index
+    expect(x_ua_compatible).to eq('IE=edge')
   end
 
   context "when the site is disabled" do


### PR DESCRIPTION
Set X-UA-Compatible header to default to 'IE=edge' so that the site doesn't fall back to compatibility mode