### PR TITLE
Fix cookie message link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   <body>
     <% if show_cookie_message? %>
       <div id="global-cookie-message">
-        <p>We use cookies to make this service simpler. <a href="/help#cookies">Find out more about cookies</a></p>
+        <p>We use cookies to make this service simpler. <a href="/privacy">Find out more about cookies</a></p>
       </div>
     <% end %>
 


### PR DESCRIPTION
The temporary cookie message link should go to https://petition.parliament.uk/privacy rather than the (non-existent) https://petition.parliament.uk/help#cookies