### PR TITLE
Refactor constituency api to eliminate encoding errors

### DIFF
--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -22,9 +22,7 @@ class LocalPetitionsController < ApplicationController
   end
 
   def find_constituency
-    @constituency = ConstituencyApi::Client.constituency(@postcode)
-  rescue ConstituencyApi::Error => e
-    Rails.logger.error("Failed to fetch constituency - #{e}")
+    @constituency = ConstituencyApi.constituency(@postcode)
   end
 
   def constituency?

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -116,10 +116,7 @@ class Signature < ActiveRecord::Base
   end
 
   def constituency
-    @constituency ||= ConstituencyApi::Client.constituencies(self.postcode).first
-  rescue ConstituencyApi::Error => e
-    Rails.logger.error("Failed to fetch constituency - #{e}")
-    nil
+    @constituency ||= ConstituencyApi.constituency(postcode)
   end
 
   def set_constituency_id

--- a/spec/controllers/local_petitions_controller_spec.rb
+++ b/spec/controllers/local_petitions_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe LocalPetitionsController, type: :controller do
 
     shared_examples_for 'a local petitions controller that does not try to lookup a constituency' do
       it 'does not communicate with the API' do
-        expect(ConstituencyApi::Client).not_to receive(:constituency)
+        expect(ConstituencyApi).not_to receive(:constituency)
         get :index, params
       end
 

--- a/spec/lib/constituency_api_spec.rb
+++ b/spec/lib/constituency_api_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe ConstituencyApi do
       let(:mp) { ConstituencyApi::Mp.new("1536", "Emily Thornberry MP", Date.new(2015, 5, 7)) }
 
       it "returns the URL for the mp" do
-        expect(mp.url).to eq "#{ConstituencyApi::Mp::URL}/emily-thornberry-mp/1536"
+        expect(mp.url).to eq "http://www.parliament.uk/biographies/commons/emily-thornberry-mp/1536"
       end
     end
   end
 
   describe "query methods" do
-    let(:api) { ConstituencyApi::Client }
+    let(:api) { ConstituencyApi }
     let(:url) { "http://data.parliament.uk" }
     let(:endpoint) { "#{url}/membersdataplatform/services/mnis/Constituencies" }
 
@@ -162,8 +162,8 @@ RSpec.describe ConstituencyApi do
           stub_request(:get, /.*data.parliament.uk.*/).to_timeout
         end
 
-        it "raises a ConstituencyApi::Error" do
-          expect{ api.constituencies("N1") }.to raise_error(ConstituencyApi::Error)
+        it "returns an empty array" do
+          expect(api.constituencies("N1")).to eq([])
         end
       end
 
@@ -172,8 +172,8 @@ RSpec.describe ConstituencyApi do
           stub_request(:get, /.*data.parliament.uk.*/).to_raise(Faraday::Error::ConnectionFailed)
         end
 
-        it "raises a ConstituencyApi::Error" do
-          expect{ api.constituencies("N1") }.to raise_error(ConstituencyApi::Error)
+        it "returns an empty array" do
+          expect(api.constituencies("N1")).to eq([])
         end
       end
 
@@ -182,8 +182,8 @@ RSpec.describe ConstituencyApi do
           stub_request(:get, /.*data.parliament.uk.*/).to_raise(Faraday::Error::ResourceNotFound)
         end
 
-        it "raises a ConstituencyApi::Error" do
-          expect{ api.constituencies("N1") }.to raise_error(ConstituencyApi::Error)
+        it "returns an empty array" do
+          expect(api.constituencies("N1")).to eq([])
         end
       end
 
@@ -192,8 +192,8 @@ RSpec.describe ConstituencyApi do
           stub_request(:get, /.*data.parliament.uk.*/).to_return(status: 500, body: "<Constituencies/>")
         end
 
-        it "raises a ConstituencyApi::Error" do
-          expect{ api.constituencies("N1") }.to raise_error(ConstituencyApi::Error)
+        it "returns an empty array" do
+          expect(api.constituencies("N1")).to eq([])
         end
       end
     end


### PR DESCRIPTION
Changes the api to do the following:

* Follow redirect responses from the parliament api
* Encode postcodes to eliminate invalid uri errors
* Don't raise errors, just return [] or nil
* Notify AppSignal if we get anything other than a 404 error