### PR TITLE
Ignore 400 Bad Request type errors

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -16,6 +16,7 @@ default: &defaults
   # Exceptions that should not be recorded by AppSignal
   ignore_exceptions:
     - ActionDispatch::ParamsParser::ParseError
+    - ActionDispatch::BadRequest
     - ActionController::InvalidAuthenticityToken
     - ActionController::RoutingError
     - ActiveRecord::RecordNotFound

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -15,6 +15,7 @@ default: &defaults
 
   # Exceptions that should not be recorded by AppSignal
   ignore_exceptions:
+    - ActionDispatch::ParamsParser::ParseError
     - ActionController::InvalidAuthenticityToken
     - ActionController::RoutingError
     - ActiveRecord::RecordNotFound


### PR DESCRIPTION
There are some situations where a request is bad that Rails will blow up with an exception. The public exceptions middleware handles these correctly and returns a 400 Bad Request page but they still get reported by default to AppSignal so we should probably ignore them since we'll probably ignore any emails that get sent for those anyway.