### PR TITLE
Fix header and footer caching

### DIFF
--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -10,13 +10,14 @@ head:
     expires_in: 300
 
 header:
+  keys:
+    - :home_page
   options:
     expires_in: 300
 
 footer:
   keys:
     - :create_petition_page
-    - :home_page
   options:
     expires_in: 300
 


### PR DESCRIPTION
Due to erroneous information from @pixeltrix the `:home_page` key was removed from the `:header` fragment and not the `:footer` fragment as it should've been.