### PR TITLE
Fix incorrect class name in ignore_exceptions config

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -16,7 +16,7 @@ default: &defaults
   # Exceptions that should not be recorded by AppSignal
   ignore_exceptions:
     - ActionDispatch::ParamsParser::ParseError
-    - ActionDispatch::BadRequest
+    - ActionController::BadRequest
     - ActionController::InvalidAuthenticityToken
     - ActionController::RoutingError
     - ActiveRecord::RecordNotFound


### PR DESCRIPTION
The correct name for the class is ActionController::BadRequest and not ActionDispatch::BadRequest.