### PR TITLE
Rescue Faraday::ClientError as well as Faraday::ResourceNotFound

### DIFF
--- a/app/lib/constituency_api.rb
+++ b/app/lib/constituency_api.rb
@@ -87,7 +87,7 @@ module ConstituencyApi
       else
         []
       end
-    rescue Faraday::Error::ResourceNotFound => e
+    rescue Faraday::ResourceNotFound, Faraday::ClientError => e
       return []
     rescue Faraday::Error => e
       Appsignal.send_exception(e) if defined?(Appsignal)


### PR DESCRIPTION
If someone enters garbage into the postcode field it can cause the parliament api to return a 400 Bad Request which Faraday raises as a ClientError. We don't want to know about these so rescue them along with the 404 Not Found responses.