### PR TITLE
Lock signature row before verifying

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -362,10 +362,6 @@ class Petition < ActiveRecord::Base
     creator_signature && creator_signature.validate! && reload
   end
 
-  def validated_creator_signature?
-    creator_signature && creator_signature.validated?
-  end
-
   def count_validated_signatures
     signatures.validated.count
   end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -359,7 +359,9 @@ class Petition < ActiveRecord::Base
   end
 
   def validate_creator_signature!
-    creator_signature && creator_signature.validate! && reload
+    if pending?
+      creator_signature && creator_signature.validate! && reload
+    end
   end
 
   def count_validated_signatures

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -95,7 +95,7 @@ class Signature < ActiveRecord::Base
 
   def validate!
     if pending?
-      petition.creator_signature.validate! unless creator?
+      petition.validate_creator_signature! unless creator?
 
       Petition.transaction do
         self.update_columns(

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -94,11 +94,11 @@ class Signature < ActiveRecord::Base
   end
 
   def validate!
-    if pending?
-      petition.validate_creator_signature! unless creator?
+    with_lock do
+      if pending?
+        petition.validate_creator_signature! unless creator?
 
-      Petition.transaction do
-        self.update_columns(
+        update_columns(
           number:       petition.signature_count + 1,
           state:        VALIDATED_STATE,
           validated_at: Time.current,

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1164,26 +1164,6 @@ RSpec.describe Petition, type: :model do
     end
   end
 
-  describe "#validated_creator_signature?" do
-    context "when the creator signature is not validated" do
-      let(:petition) { FactoryGirl.create(:pending_petition, creator_signature: signature) }
-      let(:signature) { FactoryGirl.create(:pending_signature) }
-
-      it "returns false" do
-        expect(petition.validated_creator_signature?).to eq(false)
-      end
-    end
-
-    context "when the creator signature is validated" do
-      let(:petition) { FactoryGirl.create(:pending_petition, creator_signature: signature) }
-      let(:signature) { FactoryGirl.create(:validated_signature) }
-
-      it "returns false" do
-        expect(petition.validated_creator_signature?).to eq(true)
-      end
-    end
-  end
-
   describe "#id" do
     let(:petition){ FactoryGirl.create(:petition) }
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe Signature, type: :model do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
 
-      expect(petition.signature_count).to eq(7)
+      expect(signature.petition.signature_count).to eq(7)
       expect(signature.number).to eq(7)
     end
 
@@ -372,10 +372,10 @@ RSpec.describe Signature, type: :model do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
 
-      expect(other_petition.signature_count).to eq(7)
+      expect(other_signature.petition.signature_count).to eq(7)
       expect(other_signature.number).to eq(7)
 
-      expect(petition.signature_count).to eq(7)
+      expect(signature.petition.signature_count).to eq(7)
       expect(signature.number).to eq(7)
     end
 
@@ -496,7 +496,7 @@ RSpec.describe Signature, type: :model do
 
       it 'does not talk to the constituency petition journal if the signature is not pending' do
         expect(ConstituencyPetitionJournal).not_to receive(:record_new_signature_for)
-        signature.state = Signature::VALIDATED_STATE
+        signature.update_columns(state: Signature::VALIDATED_STATE)
         signature.validate!
       end
     end
@@ -517,7 +517,7 @@ RSpec.describe Signature, type: :model do
 
       it 'does not talk to the constituency petition journal if the signature is not pending' do
         expect(ConstituencyPetitionJournal).not_to receive(:record_new_signature_for)
-        signature.state = Signature::VALIDATED_STATE
+        signature.update_columns(state: Signature::VALIDATED_STATE)
         signature.validate!
       end
     end


### PR DESCRIPTION
There exists a race condition where a verification link is used twice at the same time can result in a double signature count increment. To fix this we need to obtain a row level lock on the signature record and then check to see if the signature is pending.

This change shouldn't affect performance significantly as concurrent access to the signature record will only occur when the background job that validates signature counts runs which is every 30 minutes or the verification link is used twice which is what we want to prevent.

The tests needed to be tweaked because `with_lock` reloads the record from the database so in memory changes will have been lost.