### PR TITLE
Content changes

### DIFF
--- a/app/assets/stylesheets/petitions/views/_petition-show.scss
+++ b/app/assets/stylesheets/petitions/views/_petition-show.scss
@@ -51,9 +51,13 @@
     @include bold-24;
     margin-bottom: $gutter-two-thirds;
   }
-  .label {
+  .label, .note {
     display: block;
     @include core-16;
     margin-bottom: 5px;
+  }
+  .note {
+    color: $secondary-text-colour;
+    margin-top: 10px;
   }
 }

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -2,14 +2,6 @@
   <dt>Status</dt>
   <dd class="petition-meta-state"><%= @petition.state.capitalize %></dd>
 
-<% if @petition.rejected? or @petition.hidden? -%>
-  <dt>Rejection reason</dt>
-  <dd><p><%= rejection_reason(@petition.rejection.code) %> </dd>
-
-  <dt>Rejection text</dt>
-  <dd><%= @petition.rejection.details %> </dd>
-<% end -%>
-
 <% unless @petition.in_todo_list? %>
   <dt>Signatures</dt>
   <dd class="petition-meta-signature-count"><%= number_with_delimiter(@petition.signature_count) %> </dd>

--- a/app/views/local_petitions/index.html.erb
+++ b/app/views/local_petitions/index.html.erb
@@ -11,7 +11,7 @@
 <% if @constituency.present? %>
 
   <% if @constituency.mp %>
-    <p>Your MP is <%= link_to @constituency.mp.name, @constituency.mp.url, rel: 'external' %></p>
+    <p class="lede">Your member of parliament is <%= link_to @constituency.mp.name, @constituency.mp.url, rel: 'external' %></p>
   <% end %>
 
   <div class="section-panel local-petitions">

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -29,11 +29,12 @@
   <%= render 'share_petition', petition: petition %>
 
   <ul class="petition-meta">
-    <li class="meta-deadline">
-      <span class="label">Deadline</span> <%= short_date_format petition.deadline %>
-    </li>
     <li class="meta-created-by">
       <span class="label">Created by</span> <%= petition.creator_signature.name %>
+    </li>
+    <li class="meta-deadline">
+      <span class="label">Deadline</span> <%= short_date_format petition.deadline %>
+      <span class="note">All petitions run for 6 months</span>
     </li>
   </ul>
 <% end %>

--- a/app/views/petitions/_rejected_petition_show.html.erb
+++ b/app/views/petitions/_rejected_petition_show.html.erb
@@ -17,7 +17,7 @@
   <h2>Reasons for rejection</h2>
   <%= rejection_description(petition.rejection.code) %>
   <% if petition.rejection.details? %>
-    <p><%= petition.rejection.details %></p>
+    <p><%= auto_link(simple_format(petition.rejection.details)) %></p>
   <% end %>
 
   <ul class="petition-meta">

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
@@ -1,2 +1,9 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<% case petition.state %>
+<% when "open" %>
+  <p><%= signature_count(:default, petition.signature_count) %></p>
+<% when "closed" %>
+  <p><%= signature_count(:default, petition.signature_count) %>, now closed</p>
+<% when "rejected" %>
+  <p>Rejected</p>
+<% end %>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
@@ -1,3 +1,4 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
+<p>Government responded – <%= short_date_format(petition.government_response_at) %></p>
+<p><%= petition.government_response.summary %></p>
 <p><%= signature_count(:default, petition.signature_count) %></p>
-<p>Responded <%= short_date_format(petition.government_response_at) %></p>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -104,9 +104,9 @@ en-GB:
       signoff_suffix: "UK Government and Parliament"
 
     waiting_for_in_words:
-      zero: "Waiting less than a day"
-      one: "Waiting 1 day"
-      other: "Waiting %{formatted_count} days"
+      zero: "Waiting for less than a day"
+      one: "Waiting for 1 day"
+      other: "Waiting for %{formatted_count} days"
 
     signature_counts:
       default:

--- a/config/locales/rejections.en-GB.yml
+++ b/config/locales/rejections.en-GB.yml
@@ -14,7 +14,7 @@ en-GB:
         <p>There is already a petition about this issue.</p>
       libellous: |-
         <p>Petitions will not be accepted if they:</p>
-        <ul>
+        <ul class="list-bullet">
           <li>contain information which may be protected by an injunction or court order</li>
           <li>contain material that is potentially confidential, commercially sensitive or which may cause personal distress or loss</li>
           <li>include the names of individuals if they have been accused of a crime or information that may identify them</li>
@@ -23,7 +23,7 @@ en-GB:
         </ul>
       offensive: |-
         <p>Petitions will not be accepted if they:</p>
-        <ul>
+        <ul class="list-bullet">
           <li>contain offensive, joke or nonsense content</li>
           <li>use language which may cause offence, is provocative or extreme in its views</li>
           <li>use wording that is impossible to understand</li>
@@ -31,7 +31,7 @@ en-GB:
         </ul>
       irrelevant: |-
         <p>Petitions cannot be used to request action on issues that are outside the responsibility of the government. This includes:</p>
-        <ul>
+        <ul class="list-bullet">
           <li>party political material</li>
           <li>commercial endorsements including the promotion of any product, service or publication</li>
           <li>issues that are dealt with by devolved bodies, eg The Scottish Parliament</li>

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -34,13 +34,13 @@ Feature: Suzie views a petition
     Then I should see "Defence is the best Offence"
 
   Scenario: Suzie sees reason for rejection if appropriate
-    Given a petition "Please bring back Eldorado" has been rejected with the reason "<i>We<i> like http://www.google.com and bambi@gmail.com"
+    Given a petition "Please bring back Eldorado" has been rejected with the reason "We like http://www.google.com and bambi@gmail.com"
     When I view the petition
     Then I should see the petition details
     And I should see the reason for rejection
-    And I should see "<i>We<i>"
-    And I should not see a link called "http://www.google.com" linking to "http://www.google.com"
-    And I should not see a link called "bambi@gmail.com" linking to "mailto:bambi@gmail.com"
+    And I should see "We like http://www.google.com and bambi@gmail.com"
+    And I should see a link called "http://www.google.com" linking to "http://www.google.com"
+    And I should see a link called "bambi@gmail.com" linking to "mailto:bambi@gmail.com"
     And I should not see the vote count
     And I should see submitted date
     And I cannot sign the petition

--- a/spec/helpers/date_time_helper_spec.rb
+++ b/spec/helpers/date_time_helper_spec.rb
@@ -45,40 +45,40 @@ RSpec.describe DateTimeHelper, type: :helper do
     context "when the date is today" do
       let(:date) { 2.hours.ago(now) }
 
-      it "returns 'Waiting less than a day'" do
-        expect(helper.waiting_for_in_words(date)).to eq("Waiting less than a day")
+      it "returns 'Waiting for less than a day'" do
+        expect(helper.waiting_for_in_words(date)).to eq("Waiting for less than a day")
       end
     end
 
     context "when the date is yesterday" do
       let(:date) { 1.day.ago(now) }
 
-      it "returns 'Waiting 1 day'" do
-        expect(helper.waiting_for_in_words(date)).to eq("Waiting 1 day")
+      it "returns 'Waiting for 1 day'" do
+        expect(helper.waiting_for_in_words(date)).to eq("Waiting for 1 day")
       end
     end
 
     context "when the date is last week" do
       let(:date) { 7.days.ago(now) }
 
-      it "returns 'Waiting 7 days'" do
-        expect(helper.waiting_for_in_words(date)).to eq("Waiting 7 days")
+      it "returns 'Waiting for 7 days'" do
+        expect(helper.waiting_for_in_words(date)).to eq("Waiting for 7 days")
       end
     end
 
     context "when the response threshold was reached last month" do
       let(:date) { 30.days.ago(now) }
 
-      it "returns 'Waiting 30 days'" do
-        expect(helper.waiting_for_in_words(date)).to eq("Waiting 30 days")
+      it "returns 'Waiting for 30 days'" do
+        expect(helper.waiting_for_in_words(date)).to eq("Waiting for 30 days")
       end
     end
 
     context "when the response threshold was reached 3 years ago" do
       let(:date) { 1095.days.ago(now) }
 
-      it "returns 'Waiting 1,095 days'" do
-        expect(helper.waiting_for_in_words(date)).to eq("Waiting 1,095 days")
+      it "returns 'Waiting for 1,095 days'" do
+        expect(helper.waiting_for_in_words(date)).to eq("Waiting for 1,095 days")
       end
     end
   end


### PR DESCRIPTION
* Add government response summary to list of petitions with a government response
* Add wording 'Waiting *for* 6 days for a...' because people read it as a wait time
* Treat different petition states differently on the 'All petitions' list
* Add 'All petitions run for 6 months' message to the deadline on open petition show
* Apply `auto_link` and `simple_format` to petition rejection text