### PR TITLE
Fix page title on local petitions without a postcode

### DIFF
--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -44,6 +44,8 @@ module PageTitleHelper
 
         if postcode?
           opts[:count] = constituency? ? 1 : 0
+        else
+          opts[:count] = -1
         end
 
         if petition?

--- a/config/locales/page_titles.en-GB.yml
+++ b/config/locales/page_titles.en-GB.yml
@@ -11,6 +11,7 @@ en-GB:
       index:
         zero: "Petitions in %{postcode}"
         one: "Petitions in %{constituency}"
+        other: "Local to you - Petitions"
     petitions:
       index: "View all petitions - Petitions"
       check: "Start a petition - Petitions"

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe PageTitleHelper, type: :helper do
         local_petitions: {
           index: {
             zero: "Pétitions à %{postcode}",
-            one: "Pétitions à %{constituency}"
+            one: "Pétitions à %{constituency}",
+            other: "Local pour vous - Pétitions"
           }
         },
         petitions: {
@@ -95,6 +96,17 @@ RSpec.describe PageTitleHelper, type: :helper do
         params[:action] = "show"
 
         expect(helper.page_title).to eq("La pétition de soutien Jacques Cousteau - Pétitions")
+      end
+    end
+
+    context "when on the local petitions page without a postcode" do
+      before do
+        params[:controller] = "local_petitions"
+        params[:action] = "index"
+      end
+
+      it "uses the :other option from the translation" do
+        expect(helper.page_title).to eq("Local pour vous - Pétitions")
       end
     end
 


### PR DESCRIPTION
If the user doesn't enter a postcode when searching from the home page or they navigate to the page directly then the page title helper doesn't have a count to pick which translation to use. For this case set the count to -1 so that the :other key is used from the translation.