### PR TITLE
Ignore ActionController::UnknownFormat exceptions

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -19,6 +19,7 @@ default: &defaults
     - ActionController::BadRequest
     - ActionController::InvalidAuthenticityToken
     - ActionController::RoutingError
+    - ActionController::UnknownFormat
     - ActiveRecord::RecordNotFound
 
 # Configuration per environment, leave out an environment or set active


### PR DESCRIPTION
We currently don't support JSON or XML requests for petition data so there is no need to report these exceptions to AppSignal.