### PR TITLE
Add links to petitions waiting for X to homepage

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -10,6 +10,10 @@ module HomeHelper
       actioned.fetch(state, 0)
     end
 
+    def with_result
+      {:with_response => actioned[:with_response], :with_debate_outcome => actioned[:with_debate_outcome]}
+    end
+
     private
 
     def actioned
@@ -18,9 +22,13 @@ module HomeHelper
 
     def generate_actioned
       scope, actioned = Petition.visible, {}
+      awaiting_response = scope.awaiting_response.by_waiting_for_response_longest
       with_response = scope.with_response.by_most_recent_response
+      awaiting_debate_date = scope.awaiting_debate_date.by_waiting_for_debate_longest
       with_debate_outcome = scope.with_debate_outcome.by_most_recent_debate_outcome
+      actioned[:awaiting_response] = { count: awaiting_response.count, list: awaiting_response.limit(3) }
       actioned[:with_response] = { count: with_response.count, list: with_response.limit(3) }
+      actioned[:awaiting_debate_date] = { count: awaiting_debate_date.count, list: awaiting_debate_date.preload(:debate_outcome).limit(3) }
       actioned[:with_debate_outcome] = { count: with_debate_outcome.count, list: with_debate_outcome.preload(:debate_outcome).limit(3) }
       actioned
     end

--- a/app/views/pages/_home_debated_petitions.html.erb
+++ b/app/views/pages/_home_debated_petitions.html.erb
@@ -1,4 +1,4 @@
-<% if actioned[:with_debate_outcome][:count].zero? %>
+<% if actioned[:awaiting_debate_date][:count].zero? && actioned[:with_debate_outcome][:count].zero? %>
   <p>Parliament hasn’t debated any petitions yet</p>
 <% else %>
   <ol class="threshold-petitions">
@@ -23,4 +23,5 @@
     <% end -%>
   </ol>
   <p><%= link_to petition_count(:with_debate_outcome_explanation, actioned[:with_debate_outcome][:count]), petitions_path(state: :with_debate_outcome), class: "view-all" %></p>
+  <p><%= link_to petition_count(:awaiting_debate_date_explanation, actioned[:awaiting_debate_date][:count]), petitions_path(state: :awaiting_debate_date), class: "view-all" %></p>
 <% end %>

--- a/app/views/pages/_home_responded_petitions.html.erb
+++ b/app/views/pages/_home_responded_petitions.html.erb
@@ -1,4 +1,4 @@
-<% if actioned[:with_response][:count].zero? %>
+<% if actioned[:awaiting_response][:count].zero? && actioned[:with_response][:count].zero? %>
   <p>The government hasn’t responded to any petitions yet</p>
 <% else %>
   <ol class="threshold-petitions">
@@ -12,4 +12,5 @@
     <% end -%>
   </ol>
   <p><%= link_to petition_count(:with_response_explanation, actioned[:with_response][:count]), petitions_path(state: :with_response), class: "view-all" %></p>
+  <p><%= link_to petition_count(:awaiting_response_explanation, actioned[:awaiting_response][:count]), petitions_path(state: :awaiting_response), class: "view-all" %></p>
 <% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -12,7 +12,7 @@
   <% actioned_petitions do |actions| %>
     <div class="section-panel actioned-petitions">
       <ul>
-        <% actions.each do |state, action| %>
+        <% actions.with_result.each do |state, action| %>
           <li>
             <%= link_to petition_count(state, action[:count]), home_path(anchor: 'petitions-' + state.to_s.dasherize) %>
           </li>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -127,24 +127,30 @@ en-GB:
           other: "%{formatted_count} signatures total"
 
     counts:
+      awaiting_response:
+        html:
+          one: "<span class=\"count\">%{formatted_count}</span> petition is waiting for a response from the Government"
+          other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting for responses from the Government"
       with_response:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition got a response from the Government"
           other: "<span class=\"count\">%{formatted_count}</span> petitions got a response from the Government"
+      awaiting_debate_date:
+        html:
+          one: "<span class=\"count\">%{formatted_count}</span> petition is waiting to be considered for debate"
+          other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting to be considered for debate"
       with_debate_outcome:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition was debated in the House of Commons"
           other: "<span class=\"count\">%{formatted_count}</span> petitions were debated in the House of Commons"
+      awaiting_response_explanation:
+        html: "See all petitions waiting for a government response (%{formatted_count})"
       with_response_explanation:
-        html:
-          zero: "There aren't any petitions with a government response yet"
-          one: "See all petitions with a government response (%{formatted_count})"
-          other: "See all petitions with a government response (%{formatted_count})"
+        html: "See all petitions with a government response (%{formatted_count})"
+      awaiting_debate_date_explanation:
+        html: "See all petitions waiting for a debate date (%{formatted_count})"
       with_debate_outcome_explanation:
-        html:
-          zero: There aren't any petitions that have been debated in parliament yet
-          one: "See all petitions debated in parliament (%{formatted_count})"
-          other: "See all petitions debated in parliament (%{formatted_count})"
+        html: "See all petitions debated in parliament (%{formatted_count})"
 
     action_counts:
       in_moderation:


### PR DESCRIPTION
It's a bit misleading to only show the petitions that *have* a response or debate outcome