### PR TITLE
Redirect to clean petition url

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -26,7 +26,14 @@ class SignaturesController < ApplicationController
     verify_token
 
     if @signature.validated?
-      @petition = @signature.petition
+
+      if @signature.seen_signed_confirmation_page?
+        redirect_to petition_url @signature.petition
+      else
+        @signature.mark_seen_signed_confirmation_page!
+        @petition = @signature.petition
+      end
+
     else
       redirect_to(verify_signature_url(@signature, @signature.perishable_token))
     end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -111,6 +111,10 @@ class Signature < ActiveRecord::Base
     end
   end
 
+  def mark_seen_signed_confirmation_page!
+    update seen_signed_confirmation_page: true
+  end
+
   def unsubscribe!(token)
     if unsubscribed?
       errors.add(:base, "Already Unsubscribed")

--- a/db/migrate/20150730110838_add_seen_signed_confirmation_page_to_signatures.rb
+++ b/db/migrate/20150730110838_add_seen_signed_confirmation_page_to_signatures.rb
@@ -1,0 +1,5 @@
+class AddSeenSignedConfirmationPageToSignatures < ActiveRecord::Migration
+  def change
+    add_column :signatures, :seen_signed_confirmation_page, :boolean, null: false, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -462,7 +462,8 @@ CREATE TABLE signatures (
     unsubscribe_token character varying,
     constituency_id character varying,
     validated_at timestamp without time zone,
-    number integer
+    number integer,
+    seen_signed_confirmation_page boolean DEFAULT false NOT NULL
 );
 
 
@@ -1153,4 +1154,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150707094523');
 INSERT INTO schema_migrations (version) VALUES ('20150709152530');
 
 INSERT INTO schema_migrations (version) VALUES ('20150714140659');
+
+INSERT INTO schema_migrations (version) VALUES ('20150730110838');
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -46,3 +46,8 @@ Then /^debugger$/ do
   binding.pry
   :debugger
 end
+
+When(/^I click the shared link$/) do
+  expect(@shared_link).not_to be_blank
+  visit @shared_link
+end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -121,7 +121,7 @@ Given(/^an archived petition "([^"]*)" has been rejected with the reason "([^"]*
   @petition = FactoryGirl.create(:archived_petition, :rejected, title: title, reason_for_rejection: reason_for_rejection)
 end
 
-When /^I view the petition$/ do
+When(/^[I|they] view the petition$/) do
   if @petition.is_a?(ArchivedPetition)
     visit archived_petition_url(@petition)
   else

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -121,7 +121,7 @@ Given(/^an archived petition "([^"]*)" has been rejected with the reason "([^"]*
   @petition = FactoryGirl.create(:archived_petition, :rejected, title: title, reason_for_rejection: reason_for_rejection)
 end
 
-When(/^[I|they] view the petition$/) do
+When(/^I view the petition$/) do
   if @petition.is_a?(ArchivedPetition)
     visit archived_petition_url(@petition)
   else

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -127,6 +127,15 @@ Given /^I have signed the petition with a second name$/ do
          :postcode => "SW14 9RQ", :name => "Sam Wibbledon")
 end
 
+Given(/^Suzie has already signed the petition and validated her email$/) do
+  @suzies_signature = FactoryGirl.create(:validated_signature, :petition => @petition, :email => "womboid@wimbledon.com",
+         :postcode => "SW14 9RQ", :name => "Womboid Wibbledon")
+end
+
+When(/^Suzie shares the signatory confirmation link with Eric$/) do
+  @shared_link = signed_signature_url(@suzies_signature, token: @suzies_signature.perishable_token)
+end
+
 When /^I try to sign the petition with the same email address and a different name$/ do
   steps %Q{
     When I decide to sign the petition

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -103,3 +103,9 @@ Feature: Suzie signs a petition
     And I should see "2 signatures"
     And I can click on a link to return to the petition
     Then I should see that I have already signed the petition
+
+  Scenario: Eric clicks the link shared to him by Suzie
+    When Suzie has already signed the petition and validated her email
+    And Suzie shares the signatory confirmation link with Eric
+    And I click the shared link
+    Then I view the petition

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -193,8 +193,9 @@ FactoryGirl.define do
     state                Signature::VALIDATED_STATE
 
     after(:create) do |signature, evaluator|
-      if signature.petition
-        signature.petition.increment!(:signature_count) if signature.validated?
+      if signature.petition && signature.validated?
+        signature.petition.increment!(:signature_count)
+        signature.increment!(:number)
       end
     end
   end
@@ -204,8 +205,9 @@ FactoryGirl.define do
   end
 
   factory :validated_signature, :parent => :signature do
-    state          Signature::VALIDATED_STATE
-    validated_at { Time.current }
+    state                         Signature::VALIDATED_STATE
+    validated_at                  { Time.current }
+    seen_signed_confirmation_page true
   end
 
   sequence(:sponsor_email) { |n| "sponsor#{n}@example.com" }


### PR DESCRIPTION
Adds a redirect back to the petition show page for users that reuse the verify link in the sign petition confirmation email.

If the signer shares the link to others then everyone else will also be redirected to the petition show page

https://www.pivotaltracker.com/story/show/100119558