### PR TITLE
Improve reliability of AppSignal initialization process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,3 +334,6 @@ DEPENDENCIES
   webmock
   whenever
   will_paginate
+
+BUNDLED WITH
+   1.10.4

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -3,4 +3,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'
 
+# Restart the AppSignal thread that we stopped in the initializer
+Appsignal.agent.start_thread if defined?(Appsignal) && Appsignal.config.active?
+
 Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Epets
 
     config.action_dispatch.default_headers.merge!('X-UA-Compatible' => 'IE=edge')
 
-    # Needed as Rails does not eager load app/jobs/concerns by default
-    config.eager_load_paths += [Rails.root.join('app/jobs/concerns')]
+    # Needed as Rails does not add app/jobs/concerns to the load path
+    config.paths.add 'app/jobs/concerns', eager_load: true
   end
 end

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -1,0 +1,2 @@
+# Stop the AppSignal agent thread and restart it when the workers are forked
+Appsignal.agent.stop_thread if defined?(Appsignal) && Appsignal.config.active?

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,4 +24,7 @@ on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
   ActiveRecord::Base.establish_connection
+
+  # Let AppSignal know that a worker process has been forked
+  Appsignal.agent.forked! if defined?(Appsignal) && Appsignal.config.active?
 end


### PR DESCRIPTION
Since Puma detects running threads when preloading an application we need to stop it and then restart when each of the workers are forked. It was sort of working before because it detected when the PID of the process had changed and then restarted the thread itself.
