### PR TITLE
Add reveal_response to cache keys

### DIFF
--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -24,7 +24,7 @@ module CacheHelper
     class Keys
       attr_reader :template
 
-      delegate :assigns, to: :template
+      delegate :assigns, :params, to: :template
       delegate :archived_petition_page?, to: :template
       delegate :create_petition_page?, to: :template
       delegate :home_page?, to: :template
@@ -54,6 +54,10 @@ module CacheHelper
 
       def petition_page
         petition_page?
+      end
+
+      def reveal_response
+        params[:reveal_response] == 'yes'
       end
 
       def site_updated_at

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -24,6 +24,7 @@ footer:
 home_page:
   keys:
     - :last_signature_at
+    - :reveal_response
   options:
     expires_in: 300
 

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -102,6 +102,42 @@ RSpec.describe CacheHelper, type: :helper do
       end
     end
 
+    describe "#reveal_response" do
+      before do
+        expect(helper).to receive(:params).and_return(params)
+      end
+
+      context "when 'reveal_response' is set to 'yes'" do
+        let(:params) do
+          { reveal_response: 'yes' }.with_indifferent_access
+        end
+
+        it "returns true" do
+          expect(keys.reveal_response).to eq(true)
+        end
+      end
+
+      context "when 'reveal_response' is set to 'no'" do
+        let(:params) do
+          { reveal_response: 'no' }.with_indifferent_access
+        end
+
+        it "returns false" do
+          expect(keys.reveal_response).to eq(false)
+        end
+      end
+
+      context "when 'reveal_response' is not set" do
+        let(:params) do
+          {}.with_indifferent_access
+        end
+
+        it "returns false" do
+          expect(keys.reveal_response).to eq(false)
+        end
+      end
+    end
+
     describe "#site_updated_at" do
       let(:now) { Time.current }
 


### PR DESCRIPTION
When sending out response emails we want to display the response already revealed but it may have been already cached so add a cache key to differentiate between the two views.