### PR TITLE
JSON API for petitions + CSV petitions download 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,4 +336,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.10.4
+   1.10.6

--- a/app/assets/stylesheets/petitions/admin/_layout.scss
+++ b/app/assets/stylesheets/petitions/admin/_layout.scss
@@ -12,4 +12,9 @@
   .extra-gutter {
     padding: 0 $gutter*1.5 0 $gutter-half;
   }
+
+  .actions-right {
+    text-align: right;
+    line-height: 2em;
+  }
 }

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -7,6 +7,13 @@ class Admin::PetitionsController < Admin::AdminController
     else
       petitions_by_filter_or_keyword_search
     end
+
+    respond_to do |format|
+      format.html
+      format.csv {
+        send_data PetitionsCSVPresenter.new(@petitions), disposition: "attachment; filename=petitions.csv"
+      }
+    end
   end
 
   def show
@@ -28,6 +35,7 @@ class Admin::PetitionsController < Admin::AdminController
   end
 
   protected
+
   def filter_by_tag?
     params[:t].present? && !(filter_by_state? || filter_by_keyword?)
   end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -9,6 +9,7 @@ class PetitionsController < ApplicationController
   before_action :redirect_to_petition_url, if: :moderated?, only: :moderation_info
 
   respond_to :html
+  respond_to :json, only: [:index, :show]
 
   def index
     @petitions = Petition.visible.search(params)

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -34,4 +34,14 @@ module DateTimeHelper
 
     t(key, scope: scope, formatted_count: number_with_delimiter(days))
   end
+
+  def api_date_format(date_time)
+    if date_time
+      if date_time.respond_to?(:getutc)
+        date_time.getutc.iso8601(3)
+      else
+        date_time.strftime("%Y-%m-%d")
+      end
+    end
+  end
 end

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -85,6 +85,10 @@ module Browseable
       current_page <= 1
     end
 
+    def second_page?
+      current_page == 2
+    end
+
     def last_page?
       current_page >= total_pages
     end

--- a/app/models/debate_outcome.rb
+++ b/app/models/debate_outcome.rb
@@ -7,4 +7,8 @@ class DebateOutcome < ActiveRecord::Base
   after_create do
     petition.touch(:debate_outcome_at)
   end
+
+  def date
+    debated_on
+  end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -67,6 +67,13 @@ class Petition < ActiveRecord::Base
   validates_presence_of :creator_signature, on: :create
   validates_inclusion_of :state, in: STATES
 
+  with_options allow_nil: true, prefix: true do
+    delegate :name, :email, to: :creator_signature, prefix: :creator
+    delegate :code, :details, to: :rejection
+    delegate :summary, :details, :created_at, :updated_at, to: :government_response
+    delegate :date, :transcript_url, :video_url, :overview, to: :debate_outcome, prefix: :debate
+  end
+
   class << self
     def by_most_popular
       reorder(signature_count: :desc, created_at: :desc)

--- a/app/presenters/api_pagination_links_presenter.rb
+++ b/app/presenters/api_pagination_links_presenter.rb
@@ -1,0 +1,73 @@
+class ApiPaginationLinksPresenter
+  include Rails.application.routes.url_helpers
+
+  # results should be a Browseable::Search instance that
+  # exposes the attributes delegated to it below
+  def initialize(results)
+    @results = results
+  end
+
+  def serialize
+    {
+      first: first_url,
+      last: last_url,
+      next: next_url,
+      prev: prev_url
+    }
+  end
+
+  private
+
+  attr_reader :results
+
+  delegate :params, :total_pages, :first_page?, :second_page?, :last_page?, to: :results
+
+  # Sense check that the current page cannot be greater than the total number of pages
+  def current_page
+    [results.current_page, results.total_pages].min
+  end
+
+  def first_url
+    url_for url_params
+  end
+
+  def last_url
+    # If there are no results then the first_page == last_page
+    if total_pages == 1
+      first_url
+    else
+      url_for url_params.merge(page: total_pages)
+    end
+  end
+
+  def next_url
+    unless results.last_page?
+      url_for url_params.merge(page: current_page + 1)
+    else
+      nil
+    end
+  end
+
+  def prev_url
+    # first page of results does not need the :page param to improve caching
+    return first_url if second_page?
+
+    # use the last_url if we have paged off the end of the results
+    return last_url if results.current_page > total_pages
+
+    # only supply a link if there is a page of results before the current_page
+    if current_page > 1
+      url_for url_params.merge(page: current_page - 1)
+    else
+      nil
+    end
+  end
+
+  def url_params
+    params.slice(*api_links_allowed_components)
+  end
+
+  def api_links_allowed_components
+    [:protocol, :host, :port, :controller, :action, :q, :count, :state, :format]
+  end
+end

--- a/app/presenters/petition_csv_presenter.rb
+++ b/app/presenters/petition_csv_presenter.rb
@@ -1,0 +1,61 @@
+class PetitionCSVPresenter
+  include DateTimeHelper
+  include Rails.application.routes.url_helpers
+
+  def self.fields
+    urls + attributes + timestamps + [:notes]
+  end
+
+  def initialize(petition)
+    @petition = petition
+  end
+
+  def to_csv
+    self.class.fields.map {|field| send field }
+  end
+
+  attr_reader :petition
+
+  private
+
+  def self.urls
+    [:public_url, :admin_url]
+  end
+
+  def self.attributes
+    [:id,
+      :action, :background, :additional_details, :state,
+      :creator_name, :creator_email, :signature_count, :rejection_code, :rejection_details,
+      :government_response_summary, :government_response_details,
+      :debate_date, :debate_transcript_url, :debate_video_url, :debate_overview
+    ]
+  end
+
+  def self.timestamps
+    [
+      :created_at, :updated_at, :open_at, :closed_at, :government_response_at, :scheduled_debate_date,
+      :debate_threshold_reached_at, :rejected_at, :debate_outcome_at, :moderation_threshold_reached_at,
+      :government_response_created_at, :government_response_updated_at
+    ]
+  end
+
+  def public_url
+    petition_url id
+  end
+
+  def admin_url
+    admin_petition_url id
+  end
+
+  def notes
+    petition.note.details if petition.note
+  end
+
+  delegate *attributes, to: :petition
+
+  timestamps.each do |timestamp|
+    define_method timestamp do
+      api_date_format petition.send timestamp
+    end
+  end
+end

--- a/app/presenters/petitions_csv_presenter.rb
+++ b/app/presenters/petitions_csv_presenter.rb
@@ -1,0 +1,20 @@
+require 'csv'
+
+class PetitionsCSVPresenter
+  attr_reader :petitions, :presenter_class
+
+  def initialize(petitions, presenter_class: PetitionCSVPresenter)
+    @petitions, @presenter_class = petitions, presenter_class
+  end
+
+  def render
+    CSV.generate do |csv|
+      csv << presenter_class.fields
+
+      petitions.each do |petition|
+        csv << presenter_class.new(petition).to_csv
+      end
+    end
+  end
+  alias :to_s :render
+end

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -14,6 +14,9 @@
       <%= submit_tag "Go", name: nil, class: "button" %>
     <% end -%>
   </div>
+  <div class="column-half actions-right">
+    <%= link_to "Download CSV", url_for(params.merge(format: 'csv')) %>
+  </div>
 </div>
 
 <%= will_paginate(@petitions) if @petitions.any? %>

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -1,0 +1,62 @@
+json.type "petition"
+json.id petition.id
+
+json.links do
+  json.self petition_url(petition, format: params[:format])
+end if defined?(is_collection)
+
+json.attributes do
+  json.action petition.action
+  json.background petition.background
+  json.additional_details petition.additional_details
+  json.state petition.state
+  json.signature_count petition.signature_count
+
+  json.created_at api_date_format(petition.created_at)
+  json.updated_at api_date_format(petition.updated_at)
+  json.open_at api_date_format(petition.open_at)
+  json.closed_at api_date_format(petition.closed_at)
+  json.government_response_at api_date_format(petition.government_response_at)
+  json.scheduled_debate_date api_date_format(petition.scheduled_debate_date)
+  json.debate_threshold_reached_at api_date_format(petition.debate_threshold_reached_at)
+  json.rejected_at api_date_format(petition.rejected_at)
+  json.debate_outcome_at api_date_format(petition.debate_outcome_at)
+  json.moderation_threshold_reached_at api_date_format(petition.moderation_threshold_reached_at)
+
+  if petition.open?
+    json.creator_name petition.creator_name
+  else
+    json.creator_name nil
+  end
+
+  if petition.rejected?
+    json.rejection do
+      json.code petition.rejection_code
+      json.details petition.rejection_details
+    end
+  else
+    json.rejection nil
+  end
+
+  if petition.government_response?
+    json.government_response do
+      json.summary petition.government_response_summary
+      json.details petition.government_response_details
+      json.created_at api_date_format(petition.government_response_created_at)
+      json.updated_at api_date_format(petition.government_response_updated_at)
+    end
+  else
+    json.government_response nil
+  end
+
+  if petition.debate_outcome?
+    json.debate do
+      json.debated_on petition.debate_date
+      json.transcript_url petition.debate_transcript_url
+      json.video_url petition.debate_video_url
+      json.overview petition.debate_overview
+    end
+  else
+    json.debate nil
+  end
+end

--- a/app/views/petitions/index.json.jbuilder
+++ b/app/views/petitions/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.links do
+  json.self request.url
+  json.merge! ApiPaginationLinksPresenter.new(@petitions).serialize
+end
+
+json.data @petitions do |petition|
+  json.partial! 'petition', petition: petition, is_collection: true
+end

--- a/app/views/petitions/show.json.jbuilder
+++ b/app/views/petitions/show.json.jbuilder
@@ -1,0 +1,7 @@
+json.links do
+  json.self request.url
+end
+
+json.data do
+  json.partial! 'petition', petition: @petition
+end

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -115,3 +115,9 @@ Feature: A moderator user views all petitions
     And an open petition exists with action: "Simply the best"
     When I view all petitions
     Then I should see "Simply the best"
+
+  Scenario: A moderator can download petitions as CSV
+    Given I am logged in as a moderator
+    When I view all petitions
+    And I follow "Download CSV"
+    Then I should get a download with the filename "petitions.csv"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -176,6 +176,10 @@ Then /^(?:|I )should have the following query string:$/ do |expected_pairs|
   expect(actual_params).to eq expected_params
 end
 
+Then(/^I should get a download with the filename "([^\"]*)"$/) do |filename|
+  expect(page.response_headers['Content-Disposition']).to include("attachment; filename=#{filename}")
+end
+
 Then /^show me the page$/ do
   save_and_open_page
 end

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -40,10 +40,30 @@ RSpec.describe Admin::PetitionsController, type: :controller, admin: true do
     before { login_as(user) }
 
     describe "GET 'index'" do
-      it "responds successfully" do
-        get :index
-        expect(response).to be_success
-        expect(response).to render_template('admin/petitions/index')
+
+      describe "a HTML request" do
+        it "responds successfully with HTML" do
+          get :index
+          expect(response).to be_success
+          expect(response).to render_template('admin/petitions/index')
+        end
+      end
+
+      describe "a CSV request" do
+        it "wraps the list of petitions in a PetitionsCSVPresenter" do
+          expect(PetitionsCSVPresenter).to receive(:new).with([]).and_call_original
+          get :index, format: 'csv'
+        end
+
+        it "responds successfully with a CSV file" do
+          csv_presenter = PetitionsCSVPresenter.new([])
+          allow(PetitionsCSVPresenter).to receive(:new).and_return csv_presenter
+
+          expect(controller).to receive(:send_data).with(csv_presenter, disposition: "attachment; filename=petitions.csv").and_call_original
+
+          get :index, format: 'csv'
+          expect(response).to be_success
+        end
       end
 
       describe "when no 'q', 't', or 'state' param is present" do

--- a/spec/presenters/petition_csv_presenter_spec.rb
+++ b/spec/presenters/petition_csv_presenter_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe PetitionCSVPresenter do
+  include TimestampsSpecHelper
+
+  describe "#initialize" do
+    it "initializes the presenter with a petition" do
+      presenter = described_class.new("foo")
+      expect(presenter.petition).to eq("foo")
+    end
+  end
+
+  describe ".fields" do
+    it "returns a list of all the fields to serialize" do
+      expect(described_class.fields).to be_a Array
+    end
+  end
+
+  describe "#to_csv" do
+    subject { described_class.new(petition).to_csv }
+
+    Petition::STATES.each do |state_name|
+      context "with a #{state_name} petition" do
+        let!(:petition) { FactoryGirl.create "#{state_name}_petition" }
+
+        specify { is_expected.to eq(csvd_petition petition) }
+      end
+    end
+  end
+
+  def csvd_petition(petition)
+    [
+      "#{Site.send :default_url}/petitions/#{petition.id}",
+      "#{Site.send :default_moderate_url}/admin/petitions/#{petition.id}",
+      petition.id,
+      petition.action,
+      petition.background,
+      petition.additional_details,
+      petition.state,
+      petition.creator_name,
+      petition.creator_email,
+      petition.signature_count,
+      petition.rejection_code,
+      petition.rejection_details,
+      petition.government_response_summary,
+      petition.government_response_details,
+      petition.debate_date,
+      petition.debate_transcript_url,
+      petition.debate_video_url,
+      petition.debate_overview,
+      timestampify(petition.created_at),
+      timestampify(petition.updated_at),
+      timestampify(petition.open_at),
+      timestampify(petition.closed_at),
+      timestampify(petition.government_response_at),
+      datestampify(petition.scheduled_debate_date),
+      timestampify(petition.debate_threshold_reached_at),
+      timestampify(petition.rejected_at),
+      timestampify(petition.debate_outcome_at),
+      timestampify(petition.moderation_threshold_reached_at),
+      timestampify(petition.government_response_created_at),
+      timestampify(petition.government_response_updated_at),
+      petition.note.try(:details)
+    ]
+  end
+end

--- a/spec/presenters/petitions_csv_presenter_spec.rb
+++ b/spec/presenters/petitions_csv_presenter_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe PetitionsCSVPresenter do
+  class DummyPresenterClass
+    def self.fields
+      [:id, :name]
+    end
+
+    def initialize(petition)
+      @petition = petition
+    end
+
+    def to_csv
+      self.class.fields.map {|f| @petition[f] }
+    end
+  end
+
+  subject { described_class.new([{id: 321, name: "Slim Jim"}], presenter_class: DummyPresenterClass) }
+
+  describe "#initialize" do
+    it "initializes the presenter with default" do
+      presenter = described_class.new([1,2,3])
+      expect(presenter.petitions).to eq([1,2,3])
+      expect(presenter.presenter_class).to eq(PetitionCSVPresenter)
+    end
+
+    it "initializes the presenter with custom options" do
+      presenter = described_class.new([1,2,3], presenter_class: DummyPresenterClass)
+      expect(presenter.petitions).to eq([1,2,3])
+      expect(presenter.presenter_class).to eq(DummyPresenterClass)
+    end
+  end
+
+  describe "#render" do
+    it "renders a header row" do
+      expect(subject.render.split("\n")[0]).to eq("id,name")
+    end
+
+    it "renders the fields for each petition" do
+      expect(subject.render.split("\n")[1]).to eq("321,Slim Jim")
+    end
+  end
+
+  describe "#to_s" do
+    it "is an alias to #render" do
+      expect(subject.to_s).to eq("id,name\n321,Slim Jim\n")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,18 +29,5 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-  # config.infer_spec_type_from_file_location!
+  config.include Requests::JsonHelpers, type: :request
 end

--- a/spec/requests/api_request_helpers.rb
+++ b/spec/requests/api_request_helpers.rb
@@ -1,0 +1,79 @@
+module ApiRequestHelpers
+  include TimestampsSpecHelper
+
+  def assert_serialized_rejection(petition, attributes)
+    if petition.rejected?
+      expect(attributes["rejection"]).to be_a Hash
+      attributes["rejection"].tap do |rejection|
+        expect(rejection["code"]).to eq(petition.rejection.code)
+        expect(rejection["details"]).to eq(petition.rejection.details)
+      end
+    else
+      expect(attributes["rejection"]).to be_nil
+    end
+  end
+
+  def assert_serialized_government_response(petition, attributes)
+    if petition.government_response?
+      attributes["government_response"].tap do |government_response|
+        expect(government_response["summary"]).to eq(petition.government_response.summary)
+        expect(government_response["details"]).to eq(petition.government_response.details)
+        expect(government_response["created_at"]).to eq(timestampify petition.government_response.created_at)
+        expect(government_response["updated_at"]).to eq(timestampify petition.government_response.updated_at)
+      end
+    else
+      expect(attributes["government_response"]).to be_nil
+    end
+  end
+
+  def assert_serialized_debate(petition, attributes)
+    if petition.debate_outcome?
+      expect(attributes["debate"]).to be_a Hash
+      attributes["debate"].tap do |debate|
+        expect(debate["debated_on"]).to eq(datestampify petition.debate_outcome.debated_on)
+        expect(debate["transcript_url"]).to eq(petition.debate_outcome.transcript_url)
+        expect(debate["video_url"]).to eq(petition.debate_outcome.video_url)
+        expect(debate["overview"]).to eq(petition.debate_outcome.overview)
+      end
+    else
+      expect(attributes["debate"]).to be_nil
+    end
+  end
+
+
+  def assert_serialized_petition(petition, serialized)
+    # petition attributes
+    expect(serialized["type"]).to eq("petition")
+    expect(serialized["id"]).to eq(petition.id)
+
+    expect(serialized["attributes"]).to be_a Hash
+    serialized["attributes"].tap do |attributes|
+      expect(attributes["action"]).to eq(petition.action)
+      expect(attributes["background"]).to eq(petition.background)
+      expect(attributes["additional_details"]).to eq(petition.additional_details)
+      expect(attributes["state"]).to eq(petition.state)
+      expect(attributes["signature_count"]).to eq(petition.signature_count)
+
+      # timestamps
+      expect(attributes["created_at"]).to eq(timestampify petition.created_at)
+      expect(attributes["updated_at"]).to eq(timestampify petition.updated_at)
+      expect(attributes["open_at"]).to eq(timestampify petition.open_at)
+      expect(attributes["closed_at"]).to eq(timestampify petition.closed_at)
+      expect(attributes["government_response_at"]).to eq(timestampify petition.government_response_at)
+      expect(attributes["scheduled_debate_date"]).to eq(timestampify petition.scheduled_debate_date)
+      expect(attributes["response_threshold_reached_at"]).to eq(timestampify petition.response_threshold_reached_at)
+      expect(attributes["debate_threshold_reached_at"]).to eq(timestampify petition.debate_threshold_reached_at)
+      expect(attributes["rejected_at"]).to eq(timestampify petition.rejected_at)
+      expect(attributes["debate_outcome_at"]).to eq(timestampify petition.debate_outcome_at)
+      expect(attributes["moderation_threshold_reached_at"]).to eq(timestampify petition.moderation_threshold_reached_at)
+
+      if petition.open?
+        expect(attributes["creator_name"]).to eq(petition.creator_signature.name)
+      end
+
+      assert_serialized_rejection petition, attributes
+      assert_serialized_government_response petition, attributes
+      assert_serialized_debate petition, attributes
+    end
+  end
+end

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+require_relative 'api_request_helpers'
+
+RSpec.describe 'API request to show a petition', type: :request, show_exceptions: true do
+  include ApiRequestHelpers
+
+  def make_successful_request(petition, params = {})
+    get petition_url(petition, {format: 'json'}.merge(params))
+    expect(response).to be_success
+  end
+
+  let(:petition) { FactoryGirl.create :open_petition }
+
+  describe "format" do
+    it "responds to JSON" do
+      make_successful_request petition
+    end
+
+    it "does not respond to XML" do
+      get petition_url(petition, format: 'xml')
+      expect(response.status).to eq(406)
+    end
+  end
+
+  describe "links" do
+    it "returns a link to itself" do
+      make_successful_request petition
+
+      expect(json["links"]).to include({"self" => petition_url(petition, format: 'json')})
+    end
+  end
+
+  describe "data" do
+    it "includes the creator_name field for open petitions" do
+      petition = FactoryGirl.create :open_petition
+
+      make_successful_request petition
+
+      expect(json["data"]["attributes"]).to include("creator_name" => petition.creator_signature.name)
+    end
+
+    (Petition::VISIBLE_STATES - Array(Petition::OPEN_STATE)).each do |state_name|
+      let!(:petition) { FactoryGirl.create "#{state_name}_petition".to_sym }
+
+      it "does not include the creator_name field for #{state_name} petitions" do
+        make_successful_request petition
+
+        expect(json["data"]["attributes"]).not_to include("creator_name" => petition.creator_signature.name)
+      end
+    end
+
+    it "returns the petition with the expected fields" do
+      make_successful_request petition
+
+      expect(json["data"]).to be_a Hash
+      assert_serialized_petition petition, json["data"]
+    end
+
+    it "includes the rejection section for rejected petitions" do
+      rejected_petition = FactoryGirl.create :rejected_petition
+
+      make_successful_request rejected_petition
+
+      assert_serialized_rejection rejected_petition, json["data"]["attributes"]
+    end
+
+    it "includes the government_response section for petitions with a government_response" do
+      responded_petition = FactoryGirl.create :responded_petition
+
+      make_successful_request responded_petition
+
+      assert_serialized_government_response responded_petition, json["data"]["attributes"]
+    end
+
+    it "includes the debate section for petitions that have been debated" do
+      debated_petition = FactoryGirl.create :debated_petition
+
+      make_successful_request debated_petition
+
+      assert_serialized_debate debated_petition, json["data"]["attributes"]
+    end
+  end
+end
+

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -1,0 +1,156 @@
+require 'rails_helper'
+require_relative 'api_request_helpers'
+
+RSpec.describe 'API request to list petitions', type: :request, show_exceptions: true do
+  include ApiRequestHelpers
+
+  def make_successful_request(params = {})
+    get petitions_url({format: 'json'}.merge(params))
+    expect(response).to be_success
+  end
+
+  describe "format" do
+    it "responds to JSON" do
+      make_successful_request
+    end
+
+    it "does not respond to XML" do
+      get petitions_url(format: 'xml')
+      expect(response.status).to eq(500)
+    end
+  end
+
+  describe "links" do
+    before do
+      FactoryGirl.create_list :open_petition, 3
+    end
+
+    it "returns a link to itself" do
+      make_successful_request
+
+      expect(json["links"]).to include({"self" => petitions_url(format: 'json')})
+    end
+
+    it "returns a link to the first page of results" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"first" => petitions_url(count: 2, format: 'json')})
+    end
+
+    it "returns a link to the last page of results" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"last" => petitions_url(count: 2, page: 2, format: 'json')})
+    end
+
+    it "returns a link to the next page of results if there is one" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"next" => petitions_url(count: 2 ,page: 2, format: 'json')})
+    end
+
+    it "returns a link to the previous page of results if there is one" do
+      make_successful_request count: 2, page: 2
+
+      expect(json["links"]).to include({"prev" => petitions_url(count: 2, format: 'json')})
+    end
+
+    it "returns no link to the previous page of results when on the first page of results" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"prev" => nil})
+    end
+
+    it "returns no link to the next page of results when on the last page of results" do
+      make_successful_request count: 2, page: 2
+
+      expect(json["links"]).to include({"next" => nil})
+    end
+
+    it "returns the last link == first link for empty results" do
+      make_successful_request count: 2, page: 2, state: 'rejected'
+
+      expect(json["links"]).to include({"last" => json["links"]["first"]})
+    end
+
+    it "returns previous page link == last link when paging off the end of the results" do
+      make_successful_request count: 2, page: 3, state: 'rejected'
+
+      expect(json["links"]).to include({"prev" => json["links"]["last"]})
+    end
+  end
+
+  describe "data" do
+    it "returns an empty response if no petitions are public" do
+      make_successful_request
+
+      expect(json["data"]).to be_empty
+    end
+
+    it "returns a list of serialized petitions in the expected order" do
+      FactoryGirl.create_list :open_petition, 3
+
+      # reload petitions to get the expected ordering
+      petitions = Petition.order("signature_count DESC, created_at DESC")
+
+      make_successful_request
+
+      expect(json["data"].length).to eq(3)
+      assert_serialized_petition petitions.first, json["data"].first
+      assert_serialized_petition petitions.second, json["data"].second
+      assert_serialized_petition petitions.third, json["data"].third
+    end
+
+    it "includes a link to each petitions details" do
+      petition = FactoryGirl.create :open_petition
+
+      make_successful_request
+
+      expect(json["data"][0]["links"]).to be_a Hash
+      expect(json["data"][0]["links"]).to include("self" => petition_url(petition, format: 'json'))
+    end
+
+    it "includes the creator_name field for open petitions" do
+      petition = FactoryGirl.create :open_petition
+
+      make_successful_request
+
+      expect(json["data"][0]["attributes"]).to include("creator_name" => petition.creator_signature.name)
+    end
+
+    (Petition::VISIBLE_STATES - Array(Petition::OPEN_STATE)).each do |state_name|
+      it "does not include the creator_name field for #{state_name} petitions" do
+        petition = FactoryGirl.create "#{state_name}_petition".to_sym
+
+        make_successful_request
+
+        expect(json["data"][0]["attributes"]).not_to include("creator_name" => petition.creator_signature.name)
+      end
+    end
+
+    it "includes the rejection section for rejected petitions" do
+      petition = FactoryGirl.create :rejected_petition
+
+      make_successful_request
+
+      assert_serialized_rejection petition, json["data"][0]["attributes"]
+    end
+
+    it "includes the government_response section for petitions with a government_response" do
+      petition = FactoryGirl.create :responded_petition
+
+      make_successful_request
+
+      assert_serialized_government_response petition, json["data"][0]["attributes"]
+    end
+
+    it "includes the debate section for petitions that have been debated" do
+      petition = FactoryGirl.create :debated_petition
+
+      make_successful_request
+
+      assert_serialized_debate petition, json["data"][0]["attributes"]
+    end
+  end
+end
+

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,7 @@
+module Requests
+  module JsonHelpers
+    def json
+      @json ||= JSON.parse(response.body)
+    end
+  end
+end

--- a/spec/support/timestamps_spec_helper.rb
+++ b/spec/support/timestamps_spec_helper.rb
@@ -1,0 +1,9 @@
+module TimestampsSpecHelper
+  def timestampify(time)
+    time.getutc.iso8601(3) unless time.nil?
+  end
+
+  def datestampify(date)
+    date.strftime("%Y-%m-%d") unless date.nil?
+  end
+end


### PR DESCRIPTION
public petitions list with JSON
public petitions detail with JSON
download petitions list from admin as CSV

Implements:

* https://www.pivotaltracker.com/story/show/100635802
* https://www.pivotaltracker.com/story/show/100635838
* https://www.pivotaltracker.com/story/show/100547702

/cc @pixeltrix 