### PR TITLE
Fix details element on iOS 8.4.1

### DIFF
--- a/app/assets/stylesheets/petitions/_details.scss
+++ b/app/assets/stylesheets/petitions/_details.scss
@@ -13,8 +13,10 @@ details {
     position: relative;
     margin-bottom: em(5);
 
-    &:hover {
-      color: $link-hover-colour;
+    @include media(desktop){
+      &:hover {
+        color: $link-hover-colour;
+      }
     }
 
     &:focus {


### PR DESCRIPTION
Mobile Safari on iOS 8.4.1 sees the :hover state on the summary element as an attempt to implement a drop-down menu using CSS so applies its [hover state emulation][1]. Wrapping this hover style in a desktop media query prevents the issue from occurring.

[1]: https://coderwall.com/p/bevnew/reset-ios-safari-s-emulated-hover-state
