### PR TITLE
Record IP address when signing a petition

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -9,7 +9,7 @@ class SignaturesController < ApplicationController
 
   def new
     assign_stage
-    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, @petition, params[:stage], params[:move])
+    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, request, @petition, params[:stage], params[:move])
     respond_with @stage_manager.stage_object
   end
 
@@ -114,7 +114,7 @@ class SignaturesController < ApplicationController
   def handle_new_signature(petition)
     assign_move
     assign_stage
-    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_create, petition, params[:stage], params[:move])
+    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_create, request, petition, params[:stage], params[:move])
     if @stage_manager.create_signature
       @stage_manager.signature.store_constituency_id
       send_email_to_petition_signer(@stage_manager.signature)

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -12,13 +12,13 @@ class SponsorsController < ApplicationController
   def show
     assign_stage
     @sponsor = @petition.sponsors.build
-    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, @petition, params[:stage], params[:move])
+    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, request, @petition, params[:stage], params[:move])
   end
 
   def update
     assign_move
     assign_stage
-    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_create, @petition, params[:stage], params[:move])
+    @stage_manager = Staged::PetitionSigner.manage(signature_params_for_create, request, @petition, params[:stage], params[:move])
     if @stage_manager.create_signature
       @signature = @stage_manager.signature
       @signature.store_constituency_id

--- a/app/models/staged/petition_signer.rb
+++ b/app/models/staged/petition_signer.rb
@@ -1,7 +1,7 @@
 module Staged
   module PetitionSigner
-    def self.manage(params, petition, stage, move)
-      Manager.new(params, petition, stage, move, self::Stages)
+    def self.manage(params, request, petition, stage, move)
+      Manager.new(params, request, petition, stage, move, self::Stages)
     end
 
     def self.stages
@@ -9,8 +9,9 @@ module Staged
     end
 
     class Manager
-      def initialize(params, petition, stage, move, stages)
+      def initialize(params, request, petition, stage, move, stages)
         @params = params
+        @request = request
         @petition = petition
         @previous_stage = stage
         @move = move
@@ -51,7 +52,9 @@ module Staged
       end
 
       def build_signature
-        @petition.signatures.build(@params)
+        @petition.signatures.build(@params) do |signature|
+          signature.ip_address = @request.remote_ip
+        end
       end
     end
   end

--- a/spec/models/staged/petition_signer_spec.rb
+++ b/spec/models/staged/petition_signer_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Staged::PetitionSigner, type: :model do
   let(:signature_params) { {} }
+  let(:request) { double(remote_ip: '192.168.0.1') }
   let(:move) { '' }
   let(:stage) { '' }
   let(:petition) { FactoryGirl.create(:open_petition) }
-  subject { described_class.manage(signature_params, petition, stage, move) }
+  subject { described_class.manage(signature_params, request, petition, stage, move) }
   let(:signature) { subject.signature }
 
   describe '#create_signature' do
@@ -31,6 +32,12 @@ RSpec.describe Staged::PetitionSigner, type: :model do
       it 'returns false if the signature object can not be saved' do
         allow(signature).to receive(:save).and_return false
         expect(subject.create_signature).to eq false
+      end
+
+      it 'assigns the remote_ip of the request to the ip_address of the signature' do
+        allow(signature).to receive(:save).and_return true
+        expect(subject.create_signature).to eq true
+        expect(signature.ip_address).to eq '192.168.0.1'
       end
     end
 


### PR DESCRIPTION
To allow for detecting misuse of the system on a gross scale record the ip address of the signature. To be deleted when signatures are deleted after 1 year.