### PR TITLE
Update use of 'government' based on the GDS style guide

### DIFF
--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -131,12 +131,12 @@ en-GB:
     counts:
       awaiting_response:
         html:
-          one: "<span class=\"count\">%{formatted_count}</span> petition is waiting for a response from the Government"
-          other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting for responses from the Government"
+          one: "<span class=\"count\">%{formatted_count}</span> petition is waiting for a response from the government"
+          other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting for responses from the government"
       with_response:
         html:
-          one: "<span class=\"count\">%{formatted_count}</span> petition got a response from the Government"
-          other: "<span class=\"count\">%{formatted_count}</span> petitions got a response from the Government"
+          one: "<span class=\"count\">%{formatted_count}</span> petition got a response from the government"
+          other: "<span class=\"count\">%{formatted_count}</span> petitions got a response from the government"
       awaiting_debate_date:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition is waiting to be considered for debate"

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe HomeHelper, type: :helper do
 
       context "when the petition count is 1" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:with_response, 1)).to eq("<span class=\"count\">1</span> petition got a response from the Government")
+          expect(helper.petition_count(:with_response, 1)).to eq("<span class=\"count\">1</span> petition got a response from the government")
         end
       end
 
       context "when the petition count is 100" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:with_response, 100)).to eq("<span class=\"count\">100</span> petitions got a response from the Government")
+          expect(helper.petition_count(:with_response, 100)).to eq("<span class=\"count\">100</span> petitions got a response from the government")
         end
       end
 
       context "when the petition count is 1000" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:with_response, 1000)).to eq("<span class=\"count\">1,000</span> petitions got a response from the Government")
+          expect(helper.petition_count(:with_response, 1000)).to eq("<span class=\"count\">1,000</span> petitions got a response from the government")
         end
       end
     end


### PR DESCRIPTION
On the home page, the phrase `petitions got a response from the Government` refers to the government with an upper-case G. 

The style guide (https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style) says that government should _always_ be referred to with a lower-case g even when referring to a specific government. This PR simply replaces them. 
