### PR TITLE
Set CORS headers for json get requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,12 +9,18 @@ class ApplicationController < ActionController::Base
   before_action :set_seen_cookie_message, if: :show_cookie_message?
   helper_method :show_cookie_message?, :public_petition_facets
 
+  before_action :set_cors_headers, if: :json_request?
+
   protected
 
   def authenticate
     authenticate_or_request_with_http_basic(Site.name) do |username, password|
       Site.authenticate(username, password)
     end
+  end
+
+  def json_request?
+    request.format.symbol == :json
   end
 
   def unknown_format?
@@ -49,6 +55,12 @@ class ApplicationController < ActionController::Base
 
   def set_seen_cookie_message
     cookies[:seen_cookie_message] = { value: 'yes', expires: 1.year.from_now, httponly: true }
+  end
+
+  def set_cors_headers
+    headers['Access-Control-Allow-Origin'] = '*'
+    headers['Access-Control-Allow-Methods'] = 'GET'
+    headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept'
   end
 
   def show_cookie_message?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe ApplicationController, type: :controller do
   let(:cache_control) { response.headers['Cache-Control'] }
   let(:x_ua_compatible) { response.headers['X-UA-Compatible'] }
 
+  let(:access_control_allow_origin) { response.headers['Access-Control-Allow-Origin'] }
+  let(:access_control_allow_methods) { response.headers['Access-Control-Allow-Methods'] }
+  let(:access_control_allow_headers) { response.headers['Access-Control-Allow-Headers'] }
+
   it "reloads the site instance on every request" do
     expect(Site).to receive(:reload)
     get :index
@@ -25,6 +29,14 @@ RSpec.describe ApplicationController, type: :controller do
   it "sets X-UA-Compatible control headers" do
     get :index
     expect(x_ua_compatible).to eq('IE=edge')
+  end
+
+  it "sets CORS headers for json requests" do
+    request.env["HTTP_ACCEPT"] = 'application/json'
+    get :index
+    expect(access_control_allow_origin).to eq('*')
+    expect(access_control_allow_methods).to eq('GET')
+    expect(access_control_allow_headers).to eq('Origin, X-Requested-With, Content-Type, Accept')
   end
 
   context "when the site is disabled" do


### PR DESCRIPTION
Make the data available from browsers via frontend apps.