### PR TITLE
Add the ability to delete a signature from the admin

### DIFF
--- a/app/assets/stylesheets/petitions/admin/_colours.scss
+++ b/app/assets/stylesheets/petitions/admin/_colours.scss
@@ -1,2 +1,3 @@
 $flash-green: #adff2f;
 $flash-blue: #add8e6;
+$flash-red: #b10e1e;

--- a/app/assets/stylesheets/petitions/admin/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_shared.scss
@@ -3,9 +3,16 @@
     margin-top: $gutter-half;
   }
 
-  .flash_error,
   .flash-notice {
     background-color: $flash-green;
+    padding: $gutter-half;
+    @include bold-19;
+  }
+
+  .flash-error,
+  .flash-alert {
+    background-color: $flash-red;
+    color: $white;
     padding: $gutter-half;
     @include bold-19;
   }
@@ -54,5 +61,14 @@
 
   .login {
     margin-top: $gutter;
+  }
+
+  .button_to {
+    input[type=submit] {
+      margin: 0;
+      font-size: 12px;
+      padding: 2px 8px;
+      line-height: 16px;
+    }
   }
 }

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -23,11 +23,9 @@ class Admin::SearchesController < Admin::AdminController
 
   def find_petition_by_id
     begin
-      petition = Petition.find(query.to_i)
-      redirect_to admin_petition_url(petition)
+      redirect_to admin_petition_url(Petition.find(query.to_i))
     rescue ActiveRecord::RecordNotFound
-      flash[:error] = "Cannot find petition with id: #{query}"
-      redirect_to admin_petitions_url
+      redirect_to admin_petitions_url, alert: "Cannot find petition with id: #{query}"
     end
   end
 

--- a/app/controllers/admin/signatures_controller.rb
+++ b/app/controllers/admin/signatures_controller.rb
@@ -1,0 +1,17 @@
+class Admin::SignaturesController < Admin::AdminController
+  before_action :fetch_signature
+
+  def destroy
+    if @signature.destroy
+      redirect_to admin_search_url(q: @signature.email), notice: "Signature removed successfully"
+    else
+      redirect_to admin_search_url(q: @signature.email), alert: "Signature could not be removed - please contact support"
+    end
+  end
+
+  private
+
+  def fetch_signature
+    @signature = Signature.find(params[:id])
+  end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -13,10 +13,10 @@ class Admin::UserSessionsController < Admin::AdminController
     # if failed logins are above the specified level, then authlogic disables account
     # so we need to display appropriate error message
     elsif  @user_session.errors[:base].size > 0
-      flash.now[:error] = @user_session.errors[:base][0]
+      flash.now[:alert] = @user_session.errors[:base][0]
       render :new
     else
-      flash.now[:error] = "Invalid email/password combination"
+      flash.now[:alert] = "Invalid email/password combination"
       render :new
     end
   end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -23,6 +23,14 @@ class Signature < ActiveRecord::Base
   validates_inclusion_of :state, in: STATES
   validates :constituency_id, length: { maximum: 255 }
 
+  before_destroy do
+    !creator?
+  end
+
+  after_destroy do
+    petition.update_signature_count!
+  end
+
   # = Finders =
   scope :validated, -> { where(state: VALIDATED_STATE) }
   scope :pending, -> { where(state: PENDING_STATE) }

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -18,6 +18,7 @@
         <th>Signature Status</th>
         <th>Signature Last Updated</th>
         <th>Petition Creator?</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/admin/shared/_messages.html.erb
+++ b/app/views/admin/shared/_messages.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:notice] %>
 	<p class="flash-notice"><%= flash[:notice] %></p>
 <% end %>
-<% if flash[:error] %>
-	<p class="flash_error"><%= flash[:error] %></p>
+<% if flash[:alert] %>
+	<p class="flash-alert"><%= flash[:alert] %></p>
 <% end %>

--- a/app/views/admin/signatures/_signature.html.erb
+++ b/app/views/admin/signatures/_signature.html.erb
@@ -3,5 +3,11 @@
   <td><%= link_to signature.petition.action, admin_petition_path(signature.petition) %></td>
   <td><%= signature.state %></td>
   <td><%= date_time_format(signature.updated_at) %></td>
-  <td><%= signature.creator? ? "Yes" : "No" %></td>
+  <% if signature.creator? %>
+    <td>Yes</td>
+    <td>&nbsp;</td>
+  <% else %>
+    <td>No</td>
+    <td><%= button_to 'Delete', admin_signature_path(signature), method: :delete, class: 'button', data: { confirm: 'Delete signature?' } %></td>
+  <% end %>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
         resource 'schedule-debate', :only => [:show, :update], as: :schedule_debate, controller: :schedule_debate
       end
       resources :profile, :only => [:edit, :update]
+      resources :signatures, :only => [:destroy]
       resources :user_sessions, :only => [:create]
       get 'logout' => 'user_sessions#destroy', :as => :logout
       get 'login' => 'user_sessions#new', :as => :login

--- a/features/admin/search_for_signatures_by_email.feature
+++ b/features/admin/search_for_signatures_by_email.feature
@@ -15,3 +15,26 @@ Feature: Searching for signatures as Terry
     And I am logged in as a moderator
     When I search for petitions signed by "bob@example.com" from the admin hub
     Then I should see 2 petitions associated with the email address
+
+  Scenario: Deleting a signature
+    Given 1 petition signed by "bob@example.com"
+    And I am logged in as a moderator
+    When I search for petitions signed by "bob@example.com" from the admin hub
+    Then I should see 1 petition associated with the email address
+    When I click the delete button
+    Then I should see 0 petitions associated with the email address
+
+  Scenario: Deleting a signature when the person has signed more than one petition
+    Given 2 petitions signed by "bob@example.com"
+    And I am logged in as a moderator
+    When I search for petitions signed by "bob@example.com" from the admin hub
+    Then I should see 2 petitions associated with the email address
+    When I click the first delete button
+    Then I should see 1 petitions associated with the email address
+
+  Scenario: The creator’s signature can’t be deleted
+    Given an open petition "More money for charities" with some signatures
+    And I am logged in as a moderator
+    When I search for the petition creator from the admin hub
+    Then I should see 1 petition associated with the email address
+    And I should not see the delete button

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -1,4 +1,4 @@
-Given(/^(\d+) petitions signed by "([^"]*)"$/) do |petition_count, email|
+Given(/^(\d+) petitions? signed by "([^"]*)"$/) do |petition_count, email|
   petition_count.times do
     FactoryGirl.create(:signature, :petition => FactoryGirl.create(:open_petition), :email => email)
   end
@@ -45,17 +45,37 @@ When(/^I search for petitions with tag "([^"]*)"( from the admin hub)?$/) do |ta
   click_button 'Search'
 end
 
+When(/^I search for the petition creator from the admin hub$/) do
+  visit admin_petitions_url
+  fill_in "Search", :with => @petition.creator_signature.email
+  click_button 'Search'
+end
+
 When(/^I view the petition through the admin interface$/) do
   visit admin_petitions_url
   fill_in "Search", :with => @petition.id
   click_button 'Search'
 end
 
-Then(/^I should see (\d+) petitions associated with the email address$/) do |petition_count|
+Then(/^I should see (\d+) petitions? associated with the email address$/) do |petition_count|
   expect(page).to have_css("tbody tr", :count => petition_count)
 end
 
 Then(/^I should be taken back to the id search form with an error$/) do
-  expect(page).to have_css(".flash_error")
+  expect(page).to have_css(".flash-alert")
   expect(page).to have_css("form")
+end
+
+When(/^I click the delete button$/) do
+  click_button "Delete"
+end
+
+When(/^I click the first delete button$/) do
+  within :css, "tbody tr:first" do
+    click_button "Delete"
+  end
+end
+
+Then(/^I should not see the delete button$/) do
+  expect(page).not_to have_button "Delete"
 end

--- a/spec/controllers/admin/searches_controller_spec.rb
+++ b/spec/controllers/admin/searches_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::SearchesController, type: :controller, admin: true do
 
           it "sets the flash error" do
             get :show, q: '123'
-            expect(flash[:error]).to match(/123/)
+            expect(flash[:alert]).to match(/123/)
           end
         end
       end

--- a/spec/controllers/admin/signatures_controller_spec.rb
+++ b/spec/controllers/admin/signatures_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SignaturesController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:open_petition) }
+  let!(:signature) { FactoryGirl.create(:validated_signature, petition: petition, email: "user@example.com") }
+
+  context "not logged in" do
+    describe "DELETE /admin/signatures/:id" do
+      it "redirects to the login page" do
+        delete :destroy, id: signature.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+      end
+    end
+  end
+
+  context "logged in as moderator user but need to reset password" do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe "DELETE /admin/signatures/:id" do
+      it "redirects to edit profile page" do
+        delete :destroy, id: signature.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  context "logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+    before { expect(Signature).to receive(:find).with(signature.id.to_s).and_return(signature) }
+
+    describe "DELETE /admin/signatures/:id" do
+      context "when the signature is destroyed" do
+        before do
+          expect(signature).to receive(:destroy).and_return(true)
+          delete :destroy, id: signature.id
+        end
+
+        it "redirects to the search page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/search?q=user%40example.com")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Signature removed successfully")
+        end
+      end
+
+      context "when the signature is not destroyed" do
+        before do
+          expect(signature).to receive(:destroy).and_return(false)
+          delete :destroy, id: signature.id
+        end
+
+        it "redirects to the search page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/search?q=user%40example.com")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Signature could not be removed - please contact support")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
An increasing number of people want to remove their signature from a
petition so to make life easier add a feature to the search results
page in the admin to remove a signature. Note that petition creators
can't have their signature removed.

https://www.pivotaltracker.com/n/projects/307301/stories/102570760