### PR TITLE
Disable Appsignal monitoring for bulk email sending

### DIFF
--- a/app/jobs/concerns/email_all_petition_signatories.rb
+++ b/app/jobs/concerns/email_all_petition_signatories.rb
@@ -59,8 +59,10 @@ module EmailAllPetitionSignatories
   # Batches the signataries to send emails to in groups of 1000
   # and enqueues a job to do the actual sending
   def enqueue_send_email_jobs
-    signatures_to_email.find_each do |signature|
-      email_delivery_job_class.perform_later(**mailer_arguments(signature))
+    Appsignal.without_instrumentation do
+      signatures_to_email.find_each do |signature|
+        email_delivery_job_class.perform_later(**mailer_arguments(signature))
+      end
     end
   end
 


### PR DESCRIPTION
When sending large email responses (greater than 200,000 emails) the job appears to lock up at the end of queuing all the emails. Since we are also seeing a great deal of memory usage by the delayed_job processs our working theory is that Appsignal is tracking all of the SQL queries and then trying to send gigabytes of data to the API causing it to hang.

We are attempting to workaround this issue by suspending instrumentation for the period of the loop - hopefully this will still give us some usable information such as the job duration and queue time.

Our initial source for this information was appsignal/appsignal#57