### PR TITLE
Adjust delayed_job config to something more sane

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,5 +1,5 @@
-Delayed::Worker.max_attempts = 100
-Delayed::Worker.max_run_time = 1.week
+Delayed::Worker.max_attempts = 15
+Delayed::Worker.max_run_time = 6.hours
 
 require 'active_job/queue_adapters/delayed_job_adapter'
 


### PR DESCRIPTION
The configured max runtime and max attempts were left as set in the initial code dump fron the first version of the website. The rationale for the chosen figures is lost in the mists of time but seem somewhat large.

The 1 week max runtime may have been to send out the bulk emails which is understandable but will be not tolerable for users. The 100 max attempts coupled with the backoff inherent in delayed_job means that the job would be in the queue for over 61 years! Perhaps earlier versions of delayed_job didn't have such a backoff? The figure of 15 for max attempts will mean a job is re-tried for over 35 hours which is a reasonable period of time.