### PR TITLE
Fix Appsignal when used with multiple DJ workers

### DIFF
--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -3,7 +3,4 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'
 
-# Restart the AppSignal thread that we stopped in the initializer
-Appsignal.agent.start_thread if defined?(Appsignal) && Appsignal.config.active?
-
 Delayed::Command.new(ARGV).daemonize

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -20,3 +20,22 @@ module ActiveJob
     end
   end
 end
+
+# Override the default after_fork method on Delayed::Backend::ActiveRecord::Job
+# to restart the Appsignal agent when the worker is forked.
+module Delayed
+  module Backend
+    module ActiveRecord
+      class Job < ::ActiveRecord::Base
+        def self.after_fork
+          # Worker specific setup for Rails 4.1+
+          # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+          ::ActiveRecord::Base.establish_connection
+
+          # Let AppSignal know that a worker process has been forked
+          ::Appsignal.agent.forked! if defined?(::Appsignal) && ::Appsignal.config.active?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Similar to the fix for Puma we need to let Appsignal know that the process has been forked so that it can re-establish connections. Unfortunately there is no good way to do this so we have to override the after_fork class method in an initializer to call Active Record's establish_connection as well as the Appsignal forked! method.

For some strange reason I was under the impression that the `bin/delayed_job` script was called 4 times when I wrote the previous fix in 6caec23 but on reflection that make no sense since it couldn't take advantage of copy-on-write memory saving.