### PR TITLE
The reveal_response is a cache key for petition pages

### DIFF
--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -24,12 +24,12 @@ footer:
 home_page:
   keys:
     - :last_signature_at
-    - :reveal_response
   options:
     expires_in: 300
 
 petition:
   keys:
     - :petition
+    - :reveal_response
   options:
     expires_in: 300


### PR DESCRIPTION
The key was incorrectly used on the home page when it should be the petition page