### PR TITLE
Add user agent string to feedback message

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -7,7 +7,7 @@ class FeedbackController < ApplicationController
 
   # TODO: We should use deliver_later but serializing the feedback model is tricky.
   def create
-    @feedback = Feedback.new(params[:feedback])
+    @feedback = Feedback.new(feedback_params)
     if @feedback.valid?
       FeedbackMailer.send_feedback(@feedback).deliver_now
       redirect_to thanks_feedback_url
@@ -17,5 +17,19 @@ class FeedbackController < ApplicationController
   end
 
   def thanks
+  end
+
+  private
+
+  def feedback_params
+    params.require(:feedback).permit(*feedback_attributes).merge(user_agent)
+  end
+
+  def feedback_attributes
+    [:email, :petition_link_or_title, :comment]
+  end
+
+  def user_agent
+    { user_agent: request.user_agent }
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,12 +5,13 @@ class Feedback
   validates_presence_of :comment
   validates_format_of :email, with: EMAIL_REGEX, allow_blank: true
 
-  attr_accessor :email, :petition_link_or_title, :comment
+  attr_accessor :email, :petition_link_or_title, :comment, :user_agent
 
   def initialize(options = {})
     @email = options[:email]
     @petition_link_or_title = options[:petition_link_or_title]
     @comment = options[:comment]
+    @user_agent = options[:user_agent]
   end
 
   def persisted?

--- a/app/views/feedback_mailer/send_feedback.text.erb
+++ b/app/views/feedback_mailer/send_feedback.text.erb
@@ -1,3 +1,4 @@
 Comment: <%= @feedback.comment %>
 Link: <%= @feedback.petition_link_or_title %>
 Email: <%= @feedback.email %>
+Browser: <%= @feedback.user_agent %>

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -1,4 +1,5 @@
 Then(/^I should be able to submit feedback$/) do
+  page.driver.browser.header('User-Agent', 'Chrome')
 
   @feedback = Feedback.new(:name => "Joe Public", :email => "foo@example.com",
     :comment => "I can't submit a petition for some reason", :petition_link_or_title => 'link')
@@ -18,6 +19,7 @@ Then(/^the site owners should be notified$/) do
     Then they should see "#{@feedback.email}" in the email body
     Then they should see "#{@feedback.petition_link_or_title}" in the email body
     Then they should see "#{@feedback.comment}" in the email body
+    Then they should see "Browser: Chrome" in the email body
   )
 end
 

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe FeedbackController, type: :controller do
     context "with invalid input" do
       it "does not send an email" do
         expect {
-          do_post
+          do_post comment: ""
         }.not_to change{ ActionMailer::Base.deliveries.size }
       end
 
       it "returns the user to the form" do
-        do_post
+        do_post comment: ""
         expect(response).to render_template("feedback/index")
       end
     end


### PR DESCRIPTION
Feedback messages are often used to report bugs which tend to be browser dependent so rather than having to go back and ask what their browser was we can just grab the `User-Agent` header and add that to then message.

Rather than trying to parse the data in the application it's left to an administrator to use one of the many online parsers since they are more likely to be up-to-date.

One such parser can be found at: https://udger.com/resources/online-parser