### PR TITLE
Fix caching of social meta tags

### DIFF
--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -31,6 +31,7 @@ module CacheHelper
       delegate :last_signature_at, to: :template
       delegate :petition_page?, to: :template
       delegate :page_title, to: :template
+      delegate :request, to: :template
 
       def initialize(template)
         @template = template
@@ -66,6 +67,10 @@ module CacheHelper
 
       def site_updated_at
         Site.updated_at
+      end
+
+      def url
+        request.original_url
       end
 
       def for(keys)

--- a/app/views/application/_social_meta.html.erb
+++ b/app/views/application/_social_meta.html.erb
@@ -2,32 +2,31 @@
 <%= open_graph_tag 'site_name', :site_name %>
 <%= open_graph_tag 'locale', 'en_GB' %>
 <%= open_graph_tag 'image', 'os-social/opengraph-image.png' %>
-<% if petition_page? %>
-<%= open_graph_tag 'url', petition_url(@petition) %>
-<%= open_graph_tag 'type', 'article' %>
-<%= open_graph_tag 'title', :title, petition: @petition.action %>
-<%= open_graph_tag 'description', @petition.background %>
-<% elsif archived_petition_page? %>
+<% if archived_petition_page? %>
 <%= open_graph_tag 'url', archived_petition_url(@petition) %>
 <%= open_graph_tag 'type', 'article' %>
 <%= open_graph_tag 'title', :archived_title, petition: @petition.title %>
 <%= open_graph_tag 'description', @petition.description %>
+<% elsif defined?(@petition) %>
+<%= open_graph_tag 'url', petition_url(@petition) %>
+<%= open_graph_tag 'type', 'article' %>
+<%= open_graph_tag 'title', :title, petition: @petition.action %>
+<%= open_graph_tag 'description', @petition.background %>
 <% else %>
 <%= open_graph_tag 'url', request.original_url %>
 <%= open_graph_tag 'type', 'website' %>
 <%= open_graph_tag 'title', page_title %>
 <% end %>
-
 <!-- Twitter -->
 <%= twitter_card_tag 'card', 'summary' %>
 <%= twitter_card_tag 'site', '@hocpetitions' %>
 <%= twitter_card_tag 'image', 'os-social/opengraph-image.png' %>
-<% if petition_page? %>
-<%= twitter_card_tag 'title', :title, petition: @petition.action %>
-<%= twitter_card_tag 'description', @petition.background %>
-<% elsif archived_petition_page? %>
+<% if archived_petition_page? %>
 <%= twitter_card_tag 'title', :title, petition: @petition.title %>
 <%= twitter_card_tag 'description', @petition.description %>
+<% elsif defined?(@petition) %>
+<%= twitter_card_tag 'title', :title, petition: @petition.action %>
+<%= twitter_card_tag 'description', @petition.background %>
 <% else %>
 <%= twitter_card_tag 'title', page_title %>
 <% end %>

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -1,11 +1,7 @@
 head:
   keys:
     - :site_updated_at
-    - :last_signature_at
-    - :petition_page
-    - :archived_petition_page
-    - :page_title
-    - :petition
+    - :url
   options:
     expires_in: 300
 

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -156,6 +156,15 @@ RSpec.describe CacheHelper, type: :helper do
       end
     end
 
+    describe "#url" do
+      let(:request) { double(:request, original_url: "/petitions/123") }
+
+      it "delegates to the request's original_url method" do
+        expect(helper).to receive(:request).and_return(request)
+        expect(keys.url).to eq("/petitions/123")
+      end
+    end
+
     describe "#method_missing" do
       it "returns an assigned variable in the template context" do
         assign('signature_count', 32)


### PR DESCRIPTION
Just use the url and the updated_at timestamp of the site to generate the cache key for the head elements. Whilst this will mean that we add cached head elements for pages that will be only viewed once such as the signature validation page the LRU nature of Memcached means they will be evicted first.

Also if the @petition variable is set then use it for setting the meta tags so that even if someone shares a thank you page or a signature validation page then the URL shared by Facebook will be the main petition url and not the url of the page they last visited.