### PR TITLE
Personalize notifications for creators

### DIFF
--- a/app/jobs/deliver_debate_outcome_email_job.rb
+++ b/app/jobs/deliver_debate_outcome_email_job.rb
@@ -2,6 +2,10 @@ class DeliverDebateOutcomeEmailJob < ActiveJob::Base
   include EmailDelivery
 
   def create_email
-    mailer.notify_signer_of_debate_outcome signature.petition, signature
+    if signature.creator?
+      mailer.notify_creator_of_debate_outcome signature.petition, signature
+    else
+      mailer.notify_signer_of_debate_outcome signature.petition, signature
+    end
   end
 end

--- a/app/jobs/deliver_debate_scheduled_email_job.rb
+++ b/app/jobs/deliver_debate_scheduled_email_job.rb
@@ -2,6 +2,10 @@ class DeliverDebateScheduledEmailJob < ActiveJob::Base
   include EmailDelivery
 
   def create_email
-    mailer.notify_signer_of_debate_scheduled signature.petition, signature
+    if signature.creator?
+      mailer.notify_creator_of_debate_scheduled signature.petition, signature
+    else
+      mailer.notify_signer_of_debate_scheduled signature.petition, signature
+    end
   end
 end

--- a/app/jobs/deliver_petition_email_job.rb
+++ b/app/jobs/deliver_petition_email_job.rb
@@ -9,6 +9,10 @@ class DeliverPetitionEmailJob < ActiveJob::Base
   end
 
   def create_email
-    mailer.email_signer petition, signature, email
+    if signature.creator?
+      mailer.email_creator petition, signature, email
+    else
+      mailer.email_signer petition, signature, email
+    end
   end
 end

--- a/app/jobs/deliver_threshold_response_email_job.rb
+++ b/app/jobs/deliver_threshold_response_email_job.rb
@@ -2,6 +2,10 @@ class DeliverThresholdResponseEmailJob < ActiveJob::Base
   include EmailDelivery
 
   def create_email
-    mailer.notify_signer_of_threshold_response signature.petition, signature
+    if signature.creator?
+      mailer.notify_creator_of_threshold_response signature.petition, signature
+    else
+      mailer.notify_signer_of_threshold_response signature.petition, signature
+    end
   end
 end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -11,6 +11,11 @@ class PetitionMailer < ApplicationMailer
     mail to: @signature.email, subject: subject_for(:email_signer)
   end
 
+  def email_creator(petition, signature, email)
+    @petition, @signature, @email = petition, signature, email
+    mail to: @signature.email, subject: subject_for(:email_creator)
+  end
+
   def special_resend_of_email_confirmation_for_signer(signature)
     @signature, @petition = signature, signature.petition
     mail to: @signature.email, subject: subject_for(:special_resend_of_email_confirmation_for_signer)
@@ -37,6 +42,11 @@ class PetitionMailer < ApplicationMailer
     mail to: @signature.email, subject: subject_for(:notify_signer_of_threshold_response)
   end
 
+  def notify_creator_of_threshold_response(petition, signature)
+    @petition, @signature, @government_response = petition, signature, petition.government_response
+    mail to: @signature.email, subject: subject_for(:notify_creator_of_threshold_response)
+  end
+
   def notify_creator_of_closing_date_change(signature)
     @signature, @petition = signature, signature.petition
     mail to: @signature.email, subject: subject_for(:notify_creator_of_closing_date_change)
@@ -57,15 +67,34 @@ class PetitionMailer < ApplicationMailer
     end
   end
 
+  def notify_creator_of_debate_outcome(petition, signature)
+    @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+    if @debate_outcome.debated?
+      mail to: @signature.email, subject: subject_for(:notify_creator_of_positive_debate_outcome)
+    else
+      mail to: @signature.email, subject: subject_for(:notify_creator_of_negative_debate_outcome)
+    end
+  end
+
   def notify_signer_of_debate_scheduled(petition, signature)
     @petition, @signature = petition, signature
     mail to: @signature.email, subject: subject_for(:notify_signer_of_debate_scheduled)
+  end
+
+  def notify_creator_of_debate_scheduled(petition, signature)
+    @petition, @signature = petition, signature
+    mail to: @signature.email, subject: subject_for(:notify_creator_of_debate_scheduled)
   end
 
   private
 
   def subject_for(key, options = {})
     I18n.t key, i18n_options.merge(options)
+  end
+
+  def signature_belongs_to_creator?
+    @signature && @signature.creator?
   end
 
   def i18n_options

--- a/app/views/petition_mailer/email_creator.html.erb
+++ b/app/views/petition_mailer/email_creator.html.erb
@@ -1,0 +1,12 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently created the petition "<%= @petition.action %>":<br />
+<%= link_to nil, petition_url(@petition) %></p>
+
+<%= auto_link(simple_format(h(@email.body))) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<p><small>You’re receiving this email because you created this petition. <%= link_to 'Unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/email_creator.text.erb
+++ b/app/views/petition_mailer/email_creator.text.erb
@@ -1,0 +1,12 @@
+Dear <%= @signature.name %>,
+
+You recently created the petition "<%= @petition.action %>":
+<%= petition_url(@petition) %>
+
+<%= @email.body %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+You’re receiving this email because you created this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -1,0 +1,35 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<% if @debate_outcome.debated? %>
+<p>Parliament debated your petition – “<%= @petition.action %>”</p>
+<% if @debate_outcome.overview? %>
+
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+<% end %>
+<% if @debate_outcome.video_url? %>
+
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+<% end %>
+
+<p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+<% else %>
+<p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+<% if @debate_outcome.overview? %>
+
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+<% end %>
+
+<p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+<% end %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<p><small>You’re receiving this email because you created this petition. <%= link_to 'Unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -1,0 +1,36 @@
+Dear <%= @signature.name %>,
+
+<% if @debate_outcome.debated? %>
+Parliament debated your petition – "<%= @petition.action %>"
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+The petition: <%= petition_url(@petition) %>
+
+<% else %>
+The Petitions Committee decided not to debate your petition – "<%= @petition.action %>"
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<% end %>
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+You’re receiving this email because you created this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
@@ -1,0 +1,15 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament is going to debate your petition – “<%= @petition.action %>”.</p>
+
+<p><%= link_to nil, petition_url(@petition) %></p>
+
+<p>The debate is scheduled for <%= short_date_format(@petition.scheduled_debate_date) %>.</p>
+
+<p>Once the debate has happened, we’ll email you a video and transcript.</p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<p><small>You’re receiving this email because you created this petition. <%= link_to 'Unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @signature.name %>,
+
+Parliament is going to debate your petition – "<%= @petition.action %>".
+
+<%= petition_url(@petition) %>
+
+The debate is scheduled for <%= short_date_format(@petition.scheduled_debate_date) %>.
+
+Once the debate has happened, we’ll email you a video and transcript.
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+You’re receiving this email because you created this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -1,0 +1,27 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Government has responded to your petition – “<%= link_to @petition.action, petition_url(@petition) %>”.</p>
+
+<p>Government responded:</p>
+
+<blockquote><%= auto_link(simple_format(h(@government_response.summary))) %></blockquote>
+
+<blockquote><%= auto_link(simple_format(h(@government_response.details))) %></blockquote>
+
+<p>Click this link to view the response online:</p>
+
+<p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
+
+<% if @petition.signature_count < Site.threshold_for_debate %>
+<p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<% else %>
+<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>
+<% end %>
+
+<p>The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<p><small>You’re receiving this email because you created this petition. <%= link_to 'Unsubscribe', unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -1,0 +1,27 @@
+Dear <%= @signature.name %>,
+
+The Government has responded to your petition – "<%= @petition.action %>".
+
+Government responded:
+
+<%= h(@government_response.summary) %>
+
+<%= h(@government_response.details) %>
+
+Click this link to view the response online:
+
+<%= petition_url(@petition, reveal_response: "yes") %>
+
+<% if @petition.signature_count < Site.threshold_for_debate %>
+The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+<% else %>
+This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.
+<% end %>
+
+The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= help_url(anchor: 'petitions-committee') %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+You’re receiving this email because you created this petition. Unsubscribe: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -95,6 +95,18 @@ en-GB:
         notify_signer_of_threshold_response: |-
           Government responded to the petition you signed
 
+        # Emails to people who create petitions
+        email_creator: |-
+          %{subject}
+        notify_creator_of_positive_debate_outcome: |-
+          Parliament debated your petition
+        notify_creator_of_negative_debate_outcome: |-
+          Parliament didn't debate your petition
+        notify_creator_of_debate_scheduled: |-
+          Parliament will debate your petition
+        notify_creator_of_threshold_response: |-
+          Government responded to your petition
+
         # Emails to people who support a petition
         gather_sponsors_for_petition: |-
           Action required: Petition "%{action}"

--- a/features/step_definitions/debate_outcome_steps.rb
+++ b/features/step_definitions/debate_outcome_steps.rb
@@ -55,7 +55,7 @@ Then(/^the petition creator should have been emailed about the debate$/) do
   steps %Q(
     Then "#{@petition.creator_signature.email}" should receive an email
     When they open the email
-    Then they should see "Parliament debated the petition you signed" in the email body
+    Then they should see "Parliament debated your petition" in the email body
     When they follow "#{petition_url(@petition)}" in the email
     Then I should be on the petition page for "#{@petition.action}"
   )

--- a/features/step_definitions/debate_scheduled_steps.rb
+++ b/features/step_definitions/debate_scheduled_steps.rb
@@ -3,7 +3,7 @@ Then(/^the petition creator should have been emailed about the scheduled debate$
   steps %Q(
     Then "#{@petition.creator_signature.email}" should receive an email
     When they open the email
-    Then they should see "Parliament is going to debate the petition" in the email body
+    Then they should see "Parliament is going to debate your petition" in the email body
     When they click the first link in the email
     Then I should be on the petition page for "#{@petition.action}"
   )

--- a/spec/controllers/admin/government_response_controller_spec.rb
+++ b/spec/controllers/admin/government_response_controller_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
                   ['laura_1@example.com'],
                   ['laura_2@example.com']
                 ])
-                expect(ActionMailer::Base.deliveries[0].subject).to match(/Government responded to the petition you signed/)
+                expect(ActionMailer::Base.deliveries[0].subject).to match(/Government responded to your petition/)
                 expect(ActionMailer::Base.deliveries[1].subject).to match(/Government responded to the petition you signed/)
                 expect(ActionMailer::Base.deliveries[2].subject).to match(/Government responded to the petition you signed/)
                 expect(ActionMailer::Base.deliveries[3].subject).to match(/Government responded to the petition you signed/)

--- a/spec/jobs/deliver_debate_outcome_email_job_spec.rb
+++ b/spec/jobs/deliver_debate_outcome_email_job_spec.rb
@@ -24,8 +24,25 @@ RSpec.describe DeliverDebateOutcomeEmailJob, type: :job do
 
   it_behaves_like "a job to send an signatory email"
 
-  it "uses the correct mailer method to generate the email" do
-    expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_outcome).with(petition, signature).and_return double.as_null_object
-    subject.perform(**arguments)
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_outcome).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_outcome).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
   end
 end

--- a/spec/jobs/deliver_debate_scheduled_email_job_spec.rb
+++ b/spec/jobs/deliver_debate_scheduled_email_job_spec.rb
@@ -24,8 +24,25 @@ RSpec.describe DeliverDebateScheduledEmailJob, type: :job do
 
   it_behaves_like "a job to send an signatory email"
 
-  it "uses the correct mailer method to generate the email" do
-    expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
-    subject.perform(**arguments)
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
   end
 end

--- a/spec/jobs/deliver_petition_email_job_spec.rb
+++ b/spec/jobs/deliver_petition_email_job_spec.rb
@@ -26,8 +26,25 @@ RSpec.describe DeliverPetitionEmailJob, type: :job do
 
   it_behaves_like "a job to send an signatory email"
 
-  it "uses the correct mailer method to generate the email" do
-    expect(subject).to receive_message_chain(:mailer, :email_signer).with(petition, signature, email).and_return double.as_null_object
-    subject.perform(**arguments)
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :email_creator).with(petition, signature, email).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :email_signer).with(petition, signature, email).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
   end
 end

--- a/spec/jobs/deliver_threshold_response_email_job_spec.rb
+++ b/spec/jobs/deliver_threshold_response_email_job_spec.rb
@@ -24,8 +24,25 @@ RSpec.describe DeliverThresholdResponseEmailJob, type: :job do
 
   it_behaves_like "a job to send an signatory email"
 
-  it "uses the correct mailer method to generate the email" do
-    expect(subject).to receive_message_chain(:mailer, :notify_signer_of_threshold_response).with(petition, signature).and_return double.as_null_object
-    subject.perform(**arguments)
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_threshold_response).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_threshold_response).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
   end
 end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -138,16 +138,247 @@ RSpec.describe PetitionMailer, type: :mailer do
   end
 
   describe "notifying signature of debate outcome" do
-    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
-    subject(:mail) { described_class.notify_signer_of_debate_outcome(petition, signature) }
+    context "when the signature is the creator" do
+      let(:signature) { petition.creator_signature }
+      subject(:mail) { described_class.notify_creator_of_debate_outcome(petition, signature) }
 
-    shared_examples_for "a debate outcome email" do
+      shared_examples_for "a debate outcome email" do
+        it "addresses the signatory by name" do
+          expect(mail).to have_body_text("Dear Barry Butler,")
+        end
+
+        it "sends it only to the creator" do
+          expect(mail.to).to eq(%w[bazbutler@gmail.com])
+          expect(mail.cc).to be_blank
+          expect(mail.bcc).to be_blank
+        end
+
+        it "includes a link to the petition page" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
+        end
+
+        it "includes the petition action" do
+          expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+        end
+
+        it "includes an unsubscribe link" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+        end
+      end
+
+      shared_examples_for "a positive debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament debated your petition")
+        end
+
+        it "has the positive message in the body" do
+          expect(mail).to have_body_text("Parliament debated your petition")
+        end
+      end
+
+      shared_examples_for "a negative debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament didn't debate your petition")
+        end
+
+        it "has the negative message in the body" do
+          expect(mail).to have_body_text("The Petitions Committee decided not to debate your petition")
+        end
+      end
+
+      context "when the debate outcome is positive" do
+        context "when the debate outcome is not filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome, petition: petition)
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a positive debate outcome email"
+        end
+
+        context "when the debate outcome is filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome,
+              debated_on: "2015-09-24",
+              overview: "Discussion of the 2015 Christmas Adjournment",
+              transcript_url: "http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001",
+              video_url: "http://parliamentlive.tv/event/index/20150924000001",
+              petition: petition
+            )
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a positive debate outcome email"
+
+          it "includes the debate outcome overview" do
+            expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+          end
+
+          it "includes a link to the transcript of the debate" do
+            expect(mail).to have_body_text(%r[http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001])
+          end
+
+          it "includes a link to the video of the debate" do
+            expect(mail).to have_body_text(%r[http://parliamentlive.tv/event/index/20150924000001])
+          end
+        end
+      end
+
+      context "when the debate outcome is negative" do
+        context "when the debate outcome is not filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome, debated: false, petition: petition)
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a negative debate outcome email"
+        end
+
+        context "when the debate outcome is filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome,
+              debated: false,
+              overview: "Discussion of the 2015 Christmas Adjournment",
+              petition: petition
+            )
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a negative debate outcome email"
+
+          it "includes the debate outcome overview" do
+            expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+          end
+        end
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
+      subject(:mail) { described_class.notify_signer_of_debate_outcome(petition, signature) }
+
+      shared_examples_for "a debate outcome email" do
+        it "addresses the signatory by name" do
+          expect(mail).to have_body_text("Dear Laura Palmer,")
+        end
+
+        it "sends it only to the signatory" do
+          expect(mail.to).to eq(%w[laura@red-room.example.com])
+          expect(mail.cc).to be_blank
+          expect(mail.bcc).to be_blank
+        end
+
+        it "includes a link to the petition page" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
+        end
+
+        it "includes the petition action" do
+          expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+        end
+
+        it "includes an unsubscribe link" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+        end
+      end
+
+      shared_examples_for "a positive debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament debated the petition you signed")
+        end
+
+        it "has the positive message in the body" do
+          expect(mail).to have_body_text("Parliament debated the petition you signed")
+        end
+      end
+
+      shared_examples_for "a negative debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament didn't debate the petition you signed")
+        end
+
+        it "has the negative message in the body" do
+          expect(mail).to have_body_text("The Petitions Committee decided not to debate the petition you signed")
+        end
+      end
+
+      context "when the debate outcome is positive" do
+        context "when the debate outcome is not filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome, petition: petition)
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a positive debate outcome email"
+        end
+
+        context "when the debate outcome is filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome,
+              debated_on: "2015-09-24",
+              overview: "Discussion of the 2015 Christmas Adjournment",
+              transcript_url: "http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001",
+              video_url: "http://parliamentlive.tv/event/index/20150924000001",
+              petition: petition
+            )
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a positive debate outcome email"
+
+          it "includes the debate outcome overview" do
+            expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+          end
+
+          it "includes a link to the transcript of the debate" do
+            expect(mail).to have_body_text(%r[http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001])
+          end
+
+          it "includes a link to the video of the debate" do
+            expect(mail).to have_body_text(%r[http://parliamentlive.tv/event/index/20150924000001])
+          end
+        end
+      end
+
+      context "when the debate outcome is negative" do
+        context "when the debate outcome is not filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome, debated: false, petition: petition)
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a negative debate outcome email"
+        end
+
+        context "when the debate outcome is filled out" do
+          before do
+            FactoryGirl.create(:debate_outcome,
+              debated: false,
+              overview: "Discussion of the 2015 Christmas Adjournment",
+              petition: petition
+            )
+          end
+
+          it_behaves_like "a debate outcome email"
+          it_behaves_like "a negative debate outcome email"
+
+          it "includes the debate outcome overview" do
+            expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+          end
+        end
+      end
+    end
+  end
+
+  describe "notifying signature of debate scheduled" do
+    let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, creator_signature_attributes: { name: "Bob Jones", email: "bob@jones.com" }, action: "Allow organic vegetable vans to use red diesel") }
+
+    shared_examples_for "a debate scheduled email" do
       it "addresses the signatory by name" do
-        expect(mail).to have_body_text("Dear Laura Palmer,")
+        expect(mail).to have_body_text("Dear #{signature.name},")
       end
 
       it "sends it only to the signatory" do
-        expect(mail.to).to eq(%w[laura@red-room.example.com])
+        expect(mail.to).to eq([signature.email])
         expect(mail.cc).to be_blank
         expect(mail.bcc).to be_blank
       end
@@ -156,160 +387,94 @@ RSpec.describe PetitionMailer, type: :mailer do
         expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
       end
 
-      it "includes the petition action" do
-        expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
-      end
-
       it "includes an unsubscribe link" do
         expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
       end
     end
 
-    shared_examples_for "a positive debate outcome email" do
+    context "when the signature is the creator" do
+      let(:signature) { petition.creator_signature }
+      subject(:mail) { described_class.notify_creator_of_debate_scheduled(petition, signature) }
+
+      it_behaves_like "a debate scheduled email"
+
       it "has the correct subject" do
-        expect(mail).to have_subject("Parliament debated the petition you signed")
+        expect(mail).to have_subject("Parliament will debate your petition")
       end
 
-      it "has the positive message in the body" do
-        expect(mail).to have_body_text("Parliament debated the petition you signed")
+      it "identifies them as the creator" do
+        expect(mail).to have_body_text(%[Parliament is going to debate your petition])
       end
     end
 
-    shared_examples_for "a negative debate outcome email" do
+    context "when the signature is not the creator" do
+      let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
+      subject(:mail) { described_class.notify_signer_of_debate_scheduled(petition, signature) }
+
+      it_behaves_like "a debate scheduled email"
+
       it "has the correct subject" do
-        expect(mail).to have_subject("Parliament didn't debate the petition you signed")
+        expect(mail).to have_subject("Parliament will debate the petition you signed")
       end
 
-      it "has the negative message in the body" do
-        expect(mail).to have_body_text("The Petitions Committee decided not to debate the petition you signed")
+      it "identifies them as a ordinary signature" do
+        expect(mail).to have_body_text(%[Parliament is going to debate the petition you signed])
       end
-    end
-
-    context "when the debate outcome is positive" do
-      context "when the debate outcome is not filled out" do
-        before do
-          FactoryGirl.create(:debate_outcome, petition: petition)
-        end
-
-        it_behaves_like "a debate outcome email"
-        it_behaves_like "a positive debate outcome email"
-      end
-
-      context "when the debate outcome is filled out" do
-        before do
-          FactoryGirl.create(:debate_outcome,
-            debated_on: "2015-09-24",
-            overview: "Discussion of the 2015 Christmas Adjournment",
-            transcript_url: "http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001",
-            video_url: "http://parliamentlive.tv/event/index/20150924000001",
-            petition: petition
-          )
-        end
-
-        it_behaves_like "a debate outcome email"
-        it_behaves_like "a positive debate outcome email"
-
-        it "includes the debate outcome overview" do
-          expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
-        end
-
-        it "includes a link to the transcript of the debate" do
-          expect(mail).to have_body_text(%r[http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001])
-        end
-
-        it "includes a link to the video of the debate" do
-          expect(mail).to have_body_text(%r[http://parliamentlive.tv/event/index/20150924000001])
-        end
-      end
-    end
-
-    context "when the debate outcome is negative" do
-      context "when the debate outcome is not filled out" do
-        before do
-          FactoryGirl.create(:debate_outcome, debated: false, petition: petition)
-        end
-
-        it_behaves_like "a debate outcome email"
-        it_behaves_like "a negative debate outcome email"
-      end
-
-      context "when the debate outcome is filled out" do
-        before do
-          FactoryGirl.create(:debate_outcome,
-            debated: false,
-            overview: "Discussion of the 2015 Christmas Adjournment",
-            petition: petition
-          )
-        end
-
-        it_behaves_like "a debate outcome email"
-        it_behaves_like "a negative debate outcome email"
-
-        it "includes the debate outcome overview" do
-          expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
-        end
-      end
-    end
-  end
-
-  describe "notifying signature of debate scheduled" do
-    let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, action: "Allow organic vegetable vans to use red diesel") }
-    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
-    subject(:mail) { described_class.notify_signer_of_debate_scheduled(petition, signature) }
-
-    it "has the correct subject" do
-      expect(mail).to have_subject("Parliament will debate the petition you signed")
-    end
-
-    it "addresses the signatory by name" do
-      expect(mail).to have_body_text("Dear Laura Palmer,")
-    end
-
-    it "sends it only to the signatory" do
-      expect(mail.to).to eq(%w[laura@red-room.example.com])
-      expect(mail.cc).to be_blank
-      expect(mail.bcc).to be_blank
-    end
-
-    it "includes a link to the petition page" do
-      expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
-    end
-
-    it "includes an unsubscribe link" do
-      expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
     end
   end
 
   describe "emailing a signature" do
-    let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, action: "Allow organic vegetable vans to use red diesel") }
-    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
+    let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, creator_signature_attributes: { name: "Bob Jones", email: "bob@jones.com" }, action: "Allow organic vegetable vans to use red diesel") }
     let(:email) { FactoryGirl.create(:petition_email, petition: petition, subject: "This is a message from the committee", body: "Message body from the petition committee") }
-    subject(:mail) { described_class.email_signer(petition, signature, email) }
 
-    it "has the correct subject" do
-      expect(mail).to have_subject("This is a message from the committee")
+    shared_examples_for "a petition email" do
+      it "has the correct subject" do
+        expect(mail).to have_subject("This is a message from the committee")
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear #{signature.name},")
+      end
+
+      it "sends it only to the signatory" do
+        expect(mail.to).to eq([signature.email])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+      end
+
+      it "includes the message body" do
+        expect(mail).to have_body_text(%r[Message body from the petition committee])
+      end
     end
 
-    it "addresses the signatory by name" do
-      expect(mail).to have_body_text("Dear Laura Palmer,")
+    context "when the signature is the creator" do
+      let(:signature) { petition.creator_signature }
+      subject(:mail) { described_class.email_creator(petition, signature, email) }
+
+      it_behaves_like "a petition email"
+
+      it "identifies them as the creator" do
+        expect(mail).to have_body_text(%[You recently created the petition])
+      end
     end
 
-    it "sends it only to the signatory" do
-      expect(mail.to).to eq(%w[laura@red-room.example.com])
-      expect(mail.cc).to be_blank
-      expect(mail.bcc).to be_blank
-    end
+    context "when the signature is not the creator" do
+      let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
+      subject(:mail) { described_class.email_signer(petition, signature, email) }
 
-    it "includes a link to the petition page" do
-      expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
-    end
+      it_behaves_like "a petition email"
 
-    it "includes an unsubscribe link" do
-      expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
-    end
-
-    it "includes the message body" do
-      expect(mail).to have_body_text(%r[Message body from the petition committee])
+      it "identifies them as a ordinary signature" do
+        expect(mail).to have_body_text(%[You recently signed the petition])
+      end
     end
   end
 end

--- a/spec/mailers/previews/petition_mailer_preview.rb
+++ b/spec/mailers/previews/petition_mailer_preview.rb
@@ -16,6 +16,14 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.email_signer(petition, signature, email)
   end
 
+  def email_creator
+    email = Petition::Email.last
+    petition = email.petition
+    signature = petition.creator_signature
+
+    PetitionMailer.email_creator(petition, signature, email)
+  end
+
   def notify_signer_of_threshold_response
     petition = Petition.with_response.last
     signature = petition.signatures.validated.last
@@ -23,17 +31,38 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.notify_signer_of_threshold_response(petition, signature)
   end
 
-  def debated_petition_notification
+  def notify_creator_of_threshold_response
+    petition = Petition.with_response.last
+    signature = petition.creator_signature
+
+    PetitionMailer.notify_creator_of_threshold_response(petition, signature)
+  end
+
+  def debated_petition_signer_notification
     petition = Petition.debated.last
     signature = petition.signatures.validated.last
 
     PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
   end
 
-  def not_debated_petition_notification
+  def debated_petition_creator_notification
+    petition = Petition.debated.last
+    signature = petition.signatures.validated.last
+
+    PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+  end
+
+  def not_debated_petition_signer_notification
     petition = Petition.not_debated.last
     signature = petition.signatures.validated.last
 
     PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+  end
+
+  def not_debated_petition_creator_notification
+    petition = Petition.not_debated.last
+    signature = petition.signatures.validated.last
+
+    PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
   end
 end


### PR DESCRIPTION
It's impersonal to refer to creators as signers when sending notifications and it's easy to detect so create personalized emails for them.