### PR TITLE
Add an admin interface for validating signatures

### DIFF
--- a/app/assets/stylesheets/petitions/_buttons.scss
+++ b/app/assets/stylesheets/petitions/_buttons.scss
@@ -44,6 +44,10 @@
   outline: none;
 }
 
-.button-secondary{
+.button-secondary {
   @include button-override($panel-colour);
+}
+
+.button-warning{
+  @include button-override($red);
 }

--- a/app/assets/stylesheets/petitions/admin/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_shared.scss
@@ -64,6 +64,8 @@
   }
 
   .button_to {
+    display: inline-block;
+
     input[type=submit] {
       margin: 0;
       font-size: 12px;

--- a/app/controllers/admin/signatures_controller.rb
+++ b/app/controllers/admin/signatures_controller.rb
@@ -1,6 +1,16 @@
 class Admin::SignaturesController < Admin::AdminController
   before_action :fetch_signature
 
+  def validate
+    begin
+      @signature.validate!
+      redirect_to admin_search_url(q: @signature.email), notice: "Signature validated successfully"
+    rescue StandardError => e
+      Appsignal.send_exception e
+      redirect_to admin_search_url(q: @signature.email), alert: "Signature could not be validated - please contact support"
+    end
+  end
+
   def destroy
     if @signature.destroy
       redirect_to admin_search_url(q: @signature.email), notice: "Signature removed successfully"

--- a/app/views/admin/signatures/_signature.html.erb
+++ b/app/views/admin/signatures/_signature.html.erb
@@ -5,9 +5,21 @@
   <td><%= date_time_format(signature.updated_at) %></td>
   <% if signature.creator? %>
     <td>Yes</td>
-    <td>&nbsp;</td>
+    <td>
+      <% if signature.pending? %>
+        <%= button_to 'Validate', validate_admin_signature_path(signature), method: :post, class: 'button', data: { confirm: 'Validate signature?' } %>
+      <% else %>
+        &nbsp;
+      <% end %>
+    </td>
   <% else %>
     <td>No</td>
-    <td><%= button_to 'Delete', admin_signature_path(signature), method: :delete, class: 'button', data: { confirm: 'Delete signature?' } %></td>
+    <td>
+      <% if signature.pending? %>
+        <%= button_to 'Validate', validate_admin_signature_path(signature), method: :post, class: 'button', data: { confirm: 'Validate signature?' } %>
+      <% else %>
+        <%= button_to 'Delete', admin_signature_path(signature), method: :delete, class: 'button-warning', data: { confirm: 'Delete signature?' } %>
+      <% end %>
+    </td>
   <% end %>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,9 @@ Rails.application.routes.draw do
         resource 'schedule-debate', :only => [:show, :update], as: :schedule_debate, controller: :schedule_debate
       end
       resources :profile, :only => [:edit, :update]
-      resources :signatures, :only => [:destroy]
+      resources :signatures, :only => [:destroy] do
+        post :validate, :on => :member
+      end
       resources :user_sessions, :only => [:create]
       get 'logout' => 'user_sessions#destroy', :as => :logout
       get 'login' => 'user_sessions#new', :as => :login

--- a/features/admin/search_for_signatures_by_email.feature
+++ b/features/admin/search_for_signatures_by_email.feature
@@ -16,6 +16,14 @@ Feature: Searching for signatures as Terry
     When I search for petitions signed by "bob@example.com" from the admin hub
     Then I should see 2 petitions associated with the email address
 
+  Scenario: Validating a pending signature
+    Given 1 petition with a pending signature by "bob@example.com"
+    And I am logged in as a moderator
+    When I search for petitions signed by "bob@example.com" from the admin hub
+    Then I should see the email address is pending
+    When I click the validate button
+    Then I should see the email address is validated
+
   Scenario: Deleting a signature
     Given 1 petition signed by "bob@example.com"
     And I am logged in as a moderator

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -4,6 +4,12 @@ Given(/^(\d+) petitions? signed by "([^"]*)"$/) do |petition_count, email|
   end
 end
 
+Given(/^(\d+) petitions? with a pending signature by "([^"]*)"$/) do |petition_count, email|
+  petition_count.times do
+    FactoryGirl.create(:pending_signature, :petition => FactoryGirl.create(:open_petition), :email => email)
+  end
+end
+
 When(/^I search for petitions signed by "([^"]*)"( from the admin hub)?$/) do |email, from_the_hub|
   if from_the_hub.blank?
     visit admin_petitions_url
@@ -64,6 +70,19 @@ end
 Then(/^I should be taken back to the id search form with an error$/) do
   expect(page).to have_css(".flash-alert")
   expect(page).to have_css("form")
+end
+
+Then(/^I should see the email address is pending$/) do
+  expect(page).to have_button "Validate"
+end
+
+When(/^I click the validate button$/) do
+  click_button "Validate"
+end
+
+Then(/^I should see the email address is validated$/) do
+  expect(page).not_to have_button "Validate"
+  expect(page).to have_button "Delete"
 end
 
 When(/^I click the delete button$/) do


### PR DESCRIPTION
The moderators get requests to validate people's signatures via the feedback form for whatever reason and it's easier to validate them manually to explain that they can just re-sign and it will send them a new validation email.

https://www.pivotaltracker.com/story/show/105664320