### PR TITLE
Only show petitions with debate outcome on home page

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -4,7 +4,7 @@ module HomeHelper
       :awaiting_response,
       :with_response,
       :awaiting_debate,
-      :debated,
+      :with_debated_outcome,
       :not_debated
     ]
 
@@ -19,7 +19,7 @@ module HomeHelper
     end
 
     def with_result
-      {:with_response => actioned[:with_response], :debated => actioned[:debated]}
+      {:with_response => actioned[:with_response], :with_debated_outcome => actioned[:with_debated_outcome]}
     end
 
     private

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -49,6 +49,7 @@ class Petition < ActiveRecord::Base
   facet :awaiting_debate,      -> { awaiting_debate.by_most_relevant_debate_date }
   facet :awaiting_debate_date, -> { awaiting_debate_date.by_waiting_for_debate_longest }
   facet :with_debate_outcome,  -> { with_debate_outcome.by_most_recent_debate_outcome }
+  facet :with_debated_outcome, -> { with_debated_outcome.by_most_recent_debate_outcome }
   facet :debated,              -> { debated.by_most_recent_debate_outcome }
   facet :not_debated,          -> { not_debated.by_most_recent_debate_outcome }
 
@@ -223,6 +224,10 @@ class Petition < ActiveRecord::Base
 
     def with_debate_outcome
       where.not(debate_outcome_at: nil)
+    end
+
+    def with_debated_outcome
+      debated.where.not(debate_outcome_at: nil)
     end
 
     def with_response

--- a/app/views/pages/_home_debated_petitions.html.erb
+++ b/app/views/pages/_home_debated_petitions.html.erb
@@ -1,8 +1,8 @@
-<% if actioned[:awaiting_debate][:count].zero? && actioned[:debated][:count].zero? %>
+<% if actioned[:awaiting_debate][:count].zero? && actioned[:with_debated_outcome][:count].zero? %>
   <p>Parliament hasn’t debated any petitions yet</p>
 <% else %>
   <ol class="threshold-petitions">
-    <% actioned[:debated][:list].each.with_index do |petition, index| %>
+    <% actioned[:with_debated_outcome][:list].each.with_index do |petition, index| %>
       <li class="petition-item">
         <h3><%= link_to petition.action, petition_path(petition) %></h3>
         <p class="intro">This topic was debated on <%= short_date_format petition.debate_outcome.debated_on %></p>
@@ -22,7 +22,7 @@
       </li>
     <% end -%>
   </ol>
-  <p><%= link_to petition_count(:debated_explanation, actioned[:debated][:count]), petitions_path(state: :debated), class: "view-all" %></p>
+  <p><%= link_to petition_count(:debated_explanation, actioned[:with_debated_outcome][:count]), petitions_path(state: :debated), class: "view-all" %></p>
   <p><%= link_to petition_count(:awaiting_debate_explanation, actioned[:awaiting_debate][:count]), petitions_path(state: :awaiting_debate), class: "view-all" %></p>
   <p><%= link_to petition_count(:not_debated_explanation, actioned[:not_debated][:count]), petitions_path(state: :not_debated), class: "view-all" %></p>
 <% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -56,7 +56,7 @@
     </section>
 
     <section aria-labelledby="debate-threshold-heading" id="petitions-with-debate-outcome">
-      <% if actioned[:debated][:count].zero? %>
+      <% if actioned[:with_debated_outcome][:count].zero? %>
         <div class="threshold-panel threshold-panel-debate">
           <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %></h2>
           <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_debated.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_debated.html.erb
@@ -1,3 +1,7 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
-<p>Debated <%= short_date_format(petition.debate_outcome.debated_on) %></p>
+<% if debate_outcome = petition.debate_outcome %>
+<p>Debated <%= short_date_format(debate_outcome.debated_on) %></p>
+<% else %>
+<p>Debated <%= short_date_format(petition.scheduled_debate_date) %></p>
+<% end %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -161,7 +161,7 @@ en-GB:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition is waiting to be considered for debate"
           other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting to be considered for debate"
-      debated:
+      with_debated_outcome:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition was debated in the House of Commons"
           other: "<span class=\"count\">%{formatted_count}</span> petitions were debated in the House of Commons"

--- a/features/step_definitions/debate_outcome_steps.rb
+++ b/features/step_definitions/debate_outcome_steps.rb
@@ -9,6 +9,14 @@ Given(/^a petition "(.*?)" has been debated (\d+) days ago?$/) do |petition_acti
   @petition.update(debate_outcome_at: debated_days_ago.days.ago)
 end
 
+Given(/^a petition "(.*?)" has been debated yesterday$/) do |petition_action|
+  @petition = FactoryGirl.create(:open_petition,
+    action: petition_action,
+    scheduled_debate_date: 1.day.ago,
+    debate_state: 'debated'
+  )
+end
+
 Then(/^I should see the date of the debate is (\d+) days ago$/) do |debated_days_ago|
   within :css, '.debate-outcome' do
     expect(page).to have_content("This topic was debated on #{debated_days_ago.days.ago.to_date.strftime('%-d %B %Y')}")

--- a/features/suzie_sees_actioned_petitions.feature
+++ b/features/suzie_sees_actioned_petitions.feature
@@ -45,3 +45,10 @@ Feature: Suzie sees actioned petitions
     And I should see 2 debated petition transcript links
     And I should see 3 petitions counted in the debate threshold section
     And I should see 3 petitions listed in the debate threshold section
+
+  Scenario: There was a petition debated without any debate outcome
+    Given a petition "Free the wombles" has been debated yesterday
+    And a petition "Ban Badger Baiting" has been debated 12 days ago
+    And I am on the home page
+    Then I should see "Ban Badger Baiting"
+    And I should not see "Free the wombles"

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -88,3 +88,10 @@ Feature: Suzie views a petition
     Given a petition "Spend more money on Defence" with a negative debate outcome
     When I view the petition
     Then I should see "The Petitions Committee decided not to debate this petition"
+
+  Scenario: Suzie views a petition which was debated yesterday
+    Given the date is the "27/10/2015"
+    And a petition "Free the wombles" has been debated yesterday
+    When I view the petition
+    Then I should see "Parliament debated this petition on 26 October 2015"
+    And I should see "Waiting for 1 day for Parliament to publish the debate outcome"

--- a/features/suzie_views_all_petitions.feature
+++ b/features/suzie_views_all_petitions.feature
@@ -59,13 +59,15 @@ Feature: Suzy Signer views all petitions
     And the markup should be valid
 
   Scenario: Suzie browses petitions which have been debated
-    Given a petition "Ban Badger Baiting" has been debated 2 days ago
+    Given a petition "Free the wombles" has been debated yesterday
+    And a petition "Ban Badger Baiting" has been debated 2 days ago
     And a petition "Spend more money on Defence" has been debated 18 days ago
     And a petition "Force supermarkets to give unsold food to charities" has been debated 234 days ago
     And a petition "Make every monday bank holiday" exists
     When I browse to see only "Debated in Parliament" petitions
-    Then I should see "3 petitions"
+    Then I should see "4 petitions"
     Then I should see the following ordered list of petitions:
+     | Free the wombles                                    |
      | Ban Badger Baiting                                  |
      | Spend more money on Defence                         |
      | Force supermarkets to give unsold food to charities |

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -28,24 +28,24 @@ RSpec.describe HomeHelper, type: :helper do
 
     describe "for counting debated petitions" do
       it "returns a HTML-safe string" do
-        expect(helper.petition_count(:debated, 1)).to be_an(ActiveSupport::SafeBuffer)
+        expect(helper.petition_count(:with_debated_outcome, 1)).to be_an(ActiveSupport::SafeBuffer)
       end
 
       context "when the petition count is 1" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:debated, 1)).to eq("<span class=\"count\">1</span> petition was debated in the House of Commons")
+          expect(helper.petition_count(:with_debated_outcome, 1)).to eq("<span class=\"count\">1</span> petition was debated in the House of Commons")
         end
       end
 
       context "when the petition count is 100" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:debated, 100)).to eq("<span class=\"count\">100</span> petitions were debated in the House of Commons")
+          expect(helper.petition_count(:with_debated_outcome, 100)).to eq("<span class=\"count\">100</span> petitions were debated in the House of Commons")
         end
       end
 
       context "when the petition count is 1000" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:debated, 1000)).to eq("<span class=\"count\">1,000</span> petitions were debated in the House of Commons")
+          expect(helper.petition_count(:with_debated_outcome, 1000)).to eq("<span class=\"count\">1,000</span> petitions were debated in the House of Commons")
         end
       end
     end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -270,6 +270,24 @@ RSpec.describe Petition, type: :model do
       end
     end
 
+    context "with_debated_outcome" do
+      before do
+        @p1 = FactoryGirl.create(:debated_petition)
+        @p2 = FactoryGirl.create(:open_petition)
+        @p3 = FactoryGirl.create(:not_debated_petition)
+        @p4 = FactoryGirl.create(:closed_petition)
+        @p5 = FactoryGirl.create(:rejected_petition)
+        @p6 = FactoryGirl.create(:sponsored_petition)
+        @p7 = FactoryGirl.create(:pending_petition)
+        @p8 = FactoryGirl.create(:validated_petition)
+        @p9 = FactoryGirl.create(:open_petition, scheduled_debate_date: 1.day.ago, debate_state: 'debated')
+      end
+
+      it "returns only the petitions which have a positive debate outcome" do
+        expect(Petition.with_debated_outcome).to match_array([@p1])
+      end
+    end
+
     context "awaiting_debate" do
       before do
         @p1 = FactoryGirl.create(:open_petition)


### PR DESCRIPTION
There was an edge condition around petitions that had been debated but had not yet had there debate outcome added when viewing the home page and the debated list. The code assumed that there was a debate outcome present so to fix this the affected petitions will not appear on the home page until they have a positive debate outcome and the debated list will fall back to the scheduled debate date if there is no debate outcome.