### PR TITLE
Correct section DOM id

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -55,7 +55,7 @@
       </div>
     </section>
 
-    <section aria-labelledby="debate-threshold-heading" id="petitions-with-debate-outcome">
+    <section aria-labelledby="debate-threshold-heading" id="petitions-with-debated-outcome">
       <% if actioned[:with_debated_outcome][:count].zero? %>
         <div class="threshold-panel threshold-panel-debate">
           <h2 id="debate-threshold-heading"><%= Site.formatted_threshold_for_debate %></h2>


### PR DESCRIPTION
The link at the top of the home page to the debated petitions section is tied to the scope name so we need to change the DOM id to match.

https://www.pivotaltracker.com/story/show/106483746