### PR TITLE
Reduce signature count job rate

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,7 +27,7 @@ every :weekday, at: '6.30am' do
   rake "epets:threshold_email_reminder", output: nil
 end
 
-every 30.minutes do
+every :day, at: '2.30am' do
   runner "PetitionCountJob.perform_later"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,10 +31,10 @@ every 30.minutes do
   runner "PetitionCountJob.perform_later"
 end
 
-every :weekday, at: '0.00am' do
+every :day, at: '0.00am' do
   runner "ClosePetitionsJob.perform_later"
 end
 
-every :weekday, at: '0.00am' do
+every :day, at: '0.00am' do
   runner "DebatedPetitionsJob.perform_later"
 end


### PR DESCRIPTION
Running the job every half an hour causes the DB CPU to spike - experience has shown that the stability of signature counts is enough to only run it once per day.