### PR TITLE
Temporarily disable journals

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -113,8 +113,8 @@ class Signature < ActiveRecord::Base
           updated_at:   Time.current
         )
 
-        ConstituencyPetitionJournal.record_new_signature_for(self)
-        CountryPetitionJournal.record_new_signature_for(self)
+        #ConstituencyPetitionJournal.record_new_signature_for(self)
+        #CountryPetitionJournal.record_new_signature_for(self)
         petition.increment_signature_count!
       end
     end

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} -r features --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} -r features --strict --tags ~@wip --tags ~@disabled"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -16,6 +16,7 @@ Feature: Freya searches petitions by constituency
     And many constituents in "Rochester and Strood" support "Build more quirky theme parks"
     And a constituent in "South Dorset" supports "What about other primates?"
 
+  @disabled
   Scenario: Searching for local petitions
     Given I am on the home page
     When I search for petitions local to me in "BH20 6HH"

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -534,7 +534,7 @@ RSpec.describe Signature, type: :model do
         expect{ signature.validate! }.to change{ petition.reload.signature_count }.by(0)
       end
 
-      it 'tells the relevant constituency petition journal to record a new signature' do
+      xit 'tells the relevant constituency petition journal to record a new signature' do
         expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!
       end
@@ -545,7 +545,7 @@ RSpec.describe Signature, type: :model do
         signature.validate!
       end
 
-      it 'tells the relevant country petition journal to record a new signature' do
+      xit 'tells the relevant country petition journal to record a new signature' do
         expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!
       end
@@ -565,7 +565,7 @@ RSpec.describe Signature, type: :model do
         expect{ signature.validate! }.to change{ creator_signature.reload.validated? }.from(false).to(true)
       end
 
-      it 'tells the relevant constituency petition journal to record a new signature' do
+      xit 'tells the relevant constituency petition journal to record a new signature' do
         expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(creator_signature)
         expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!
@@ -577,7 +577,7 @@ RSpec.describe Signature, type: :model do
         signature.validate!
       end
 
-      it 'tells the relevant country petition journal to record a new signature' do
+      xit 'tells the relevant country petition journal to record a new signature' do
         expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(creator_signature)
         expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!


### PR DESCRIPTION
Due to write contention on the AWS RDS instance temporarily disable the journals for constituency and country whilst we deal with the extreme load from https://petition.parliament.uk/petitions/114003