### PR TITLE
Reinstate journalling

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -119,8 +119,8 @@ class Signature < ActiveRecord::Base
     end
 
     if update_signature_counts
-      #ConstituencyPetitionJournal.record_new_signature_for(self)
-      #CountryPetitionJournal.record_new_signature_for(self)
+      ConstituencyPetitionJournal.record_new_signature_for(self)
+      CountryPetitionJournal.record_new_signature_for(self)
       petition.increment_signature_count!
     end
   end

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -16,7 +16,6 @@ Feature: Freya searches petitions by constituency
     And many constituents in "Rochester and Strood" support "Build more quirky theme parks"
     And a constituent in "South Dorset" supports "What about other primates?"
 
-  @disabled
   Scenario: Searching for local petitions
     Given I am on the home page
     When I search for petitions local to me in "BH20 6HH"

--- a/lib/tasks/epets.rake
+++ b/lib/tasks/epets.rake
@@ -75,4 +75,15 @@ namespace :epets do
       Rails.cache.clear
     end
   end
+
+  namespace :journals do
+    desc 'Reset the countries journal'
+    task :reset_countries => :environment do
+      CountryPetitionJournal.reset!
+    end
+
+    task :reset_constituencies => :environment do
+      ConstituencyPetitionJournal.reset!
+    end
+  end
 end

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -175,4 +175,45 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
       expect(existing.signature_count).to eq 21
     end
   end
+
+  describe ".reset!" do
+    let(:petition_1) { FactoryGirl.create(:petition, creator_signature_attributes: {constituency_id: constituency_1}) }
+    let(:constituency_1) { FactoryGirl.generate(:constituency_id) }
+    let(:petition_2) { FactoryGirl.create(:petition, creator_signature_attributes: {constituency_id: constituency_1}) }
+    let(:constituency_2) { FactoryGirl.generate(:constituency_id) }
+
+    before do
+      described_class.for(petition_1, constituency_1).update_attribute(:signature_count, 20)
+      described_class.for(petition_1, constituency_2).update_attribute(:signature_count, 10)
+      described_class.for(petition_2, constituency_2).update_attribute(:signature_count, 1)
+    end
+
+    context 'when there are no signatures' do
+      it 'resets all the counts to 0 or 1 for the creator' do
+        described_class.reset!
+        expect(described_class.for(petition_1, constituency_1).signature_count).to eq 1
+        expect(described_class.for(petition_1, constituency_2).signature_count).to eq 0
+        expect(described_class.for(petition_2, constituency_1).signature_count).to eq 1
+        expect(described_class.for(petition_2, constituency_2).signature_count).to eq 0
+      end
+    end
+
+    context 'when there are signatures' do
+      before do
+        4.times { FactoryGirl.create(:validated_signature, petition: petition_1, constituency_id: constituency_1) }
+        2.times { FactoryGirl.create(:pending_signature, petition: petition_1, constituency_id: constituency_1) }
+        3.times { FactoryGirl.create(:validated_signature, petition: petition_1, constituency_id: constituency_2) }
+        2.times { FactoryGirl.create(:validated_signature, petition: petition_2, constituency_id: constituency_1) }
+        5.times { FactoryGirl.create(:pending_signature, petition: petition_2, constituency_id: constituency_2) }
+      end
+
+      it 'resets the counts to that of the validated signatures for the petition and country' do
+        described_class.reset!
+        expect(described_class.for(petition_1, constituency_1).signature_count).to eq 5 # +1 for the creator
+        expect(described_class.for(petition_1, constituency_2).signature_count).to eq 3
+        expect(described_class.for(petition_2, constituency_1).signature_count).to eq 3 # +1 for the creator
+        expect(described_class.for(petition_2, constituency_2).signature_count).to eq 0
+      end
+    end
+  end
 end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -534,7 +534,7 @@ RSpec.describe Signature, type: :model do
         expect{ signature.validate! }.to change{ petition.reload.signature_count }.by(0)
       end
 
-      xit 'tells the relevant constituency petition journal to record a new signature' do
+      it 'tells the relevant constituency petition journal to record a new signature' do
         expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!
       end
@@ -545,7 +545,7 @@ RSpec.describe Signature, type: :model do
         signature.validate!
       end
 
-      xit 'tells the relevant country petition journal to record a new signature' do
+      it 'tells the relevant country petition journal to record a new signature' do
         expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!
       end
@@ -565,7 +565,7 @@ RSpec.describe Signature, type: :model do
         expect{ signature.validate! }.to change{ creator_signature.reload.validated? }.from(false).to(true)
       end
 
-      xit 'tells the relevant constituency petition journal to record a new signature' do
+      it 'tells the relevant constituency petition journal to record a new signature' do
         expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(creator_signature)
         expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!
@@ -577,7 +577,7 @@ RSpec.describe Signature, type: :model do
         signature.validate!
       end
 
-      xit 'tells the relevant country petition journal to record a new signature' do
+      it 'tells the relevant country petition journal to record a new signature' do
         expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(creator_signature)
         expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
         signature.validate!


### PR DESCRIPTION
This reverts the PR to temporarily disable them[1].  We're pretty confident that moving count updates outside the lock[2] has resolved the majority of the write contention we were seeing under heavy load so we can re-instate these counts.

We also add rake tasks to regenerate the journal counts from the data: `rake epets:journals:reset_countries` and `rake epets:journals:reset_constituencies`.

[1]: https://github.com/alphagov/e-petitions/pull/413
[2]: https://github.com/alphagov/e-petitions/pull/414