### PR TITLE
Fix race condition when creating journals

### DIFF
--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -28,15 +28,19 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
 
   def record_new_signature(at = Time.current)
     if self.new_record?
-      update_attributes(signature_count: 1)
-    else
-      signature_count_field = self.class.connection.quote_column_name('signature_count')
-      changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
-      self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
-      # NOTE: even though we don't assume +1 is ok for the SQL update, we
-      # want to avoid an extra SQL select from .reload so +1 is ok here
-      raw_write_attribute(:signature_count, signature_count+1)
+      begin
+        update_attributes(signature_count: 0)
+      rescue ActiveRecord::RecordNotUnique => e
+        # Another thread or process beat us to it
+      end
     end
+
+    signature_count_field = self.class.connection.quote_column_name('signature_count')
+    changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
+    self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
+    # NOTE: even though we don't assume +1 is ok for the SQL update, we
+    # want to avoid an extra SQL select from .reload so +1 is ok here
+    raw_write_attribute(:signature_count, signature_count+1)
   end
 
   def self.reset!

--- a/app/models/country_petition_journal.rb
+++ b/app/models/country_petition_journal.rb
@@ -19,15 +19,19 @@ class CountryPetitionJournal < ActiveRecord::Base
 
   def record_new_signature(at = Time.current)
     if self.new_record?
-      update_attributes(signature_count: 1)
-    else
-      signature_count_field = self.class.connection.quote_column_name('signature_count')
-      changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
-      self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
-      # NOTE: even though we don't assume +1 is ok for the SQL update, we
-      # want to avoid an extra SQL select from .reload so +1 is ok here
-      raw_write_attribute(:signature_count, signature_count+1)
+      begin
+        update_attributes(signature_count: 0)
+      rescue ActiveRecord::RecordNotUnique => e
+        # Another thread or process beat us to it
+      end
     end
+
+    signature_count_field = self.class.connection.quote_column_name('signature_count')
+    changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
+    self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
+    # NOTE: even though we don't assume +1 is ok for the SQL update, we
+    # want to avoid an extra SQL select from .reload so +1 is ok here
+    raw_write_attribute(:signature_count, signature_count+1)
   end
 
   def self.reset!


### PR DESCRIPTION
A journal may have been created by another thread/process between the `find_or_initialize_by` and the `update_attributes` calls causing a duplicate record error. We've not seen this in production because the chance of it occurring is low due to the number of constituencies (650) and the fact that the country journal for the United Kingdom will have been set up as part of the sponsor gathering process (other country journals have very low signature counts).