### PR TITLE
Move email delivery to custom jobs

### DIFF
--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -27,11 +27,11 @@ class Admin::ModerationController < Admin::AdminController
   end
 
   def send_published_email
-    PetitionMailer.notify_creator_that_petition_is_published(@petition.creator_signature).deliver_later
+    NotifyCreatorThatPetitionIsPublishedEmailJob.perform_later(@petition.creator_signature)
 
     @petition.sponsor_signatures.each do |signature|
       next unless signature.validated?
-      PetitionMailer.notify_sponsor_that_petition_is_published(signature).deliver_later
+      NotifySponsorThatPetitionIsPublishedEmailJob.perform_later(signature)
     end
   end
 

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -123,7 +123,7 @@ class PetitionsController < ApplicationController
   end
 
   def send_email_to_gather_sponsors(petition)
-    PetitionMailer.gather_sponsors_for_petition(petition).deliver_later
+    GatherSponsorsForPetitionEmailJob.perform_later(petition)
   end
 
   def parse_emails(emails)

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -69,7 +69,7 @@ class SignaturesController < ApplicationController
   end
 
   def send_email_to_petition_signer(signature)
-    PetitionMailer.email_confirmation_for_signer(signature).deliver_later
+    EmailConfirmationForSignerEmailJob.perform_later(signature)
   end
 
   def assign_stage
@@ -93,9 +93,9 @@ class SignaturesController < ApplicationController
     sponsor = petition.sponsors.for(signature)
 
     if petition.in_moderation?
-      SponsorMailer.sponsor_signed_email_on_threshold(petition, sponsor).deliver_later
+      SponsorSignedEmailOnThresholdEmailJob.perform_later(petition, sponsor)
     elsif petition.collecting_sponsors?
-      SponsorMailer.sponsor_signed_email_below_threshold(petition, sponsor).deliver_later
+      SponsorSignedEmailBelowThresholdEmailJob.perform_later(petition, sponsor)
     end
   end
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -82,6 +82,6 @@ class SponsorsController < ApplicationController
   end
 
   def send_email_to_sponsor(sponsor)
-    SponsorMailer.petition_and_email_confirmation_for_sponsor(sponsor).deliver_later
+    PetitionAndEmailConfirmationForSponsorEmailJob.perform_later(sponsor)
   end
 end

--- a/app/jobs/email_confirmation_for_signer_email_job.rb
+++ b/app/jobs/email_confirmation_for_signer_email_job.rb
@@ -1,0 +1,4 @@
+class EmailConfirmationForSignerEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :email_confirmation_for_signer
+end

--- a/app/jobs/email_job.rb
+++ b/app/jobs/email_job.rb
@@ -1,0 +1,43 @@
+class EmailJob < ActiveJob::Base
+  class_attribute :mailer, :email
+
+  PERMANENT_FAILURES = [
+    Net::SMTPFatalError,
+    Net::SMTPSyntaxError
+  ]
+
+  TEMPORARY_FAILURES = [
+    Net::SMTPAuthenticationError,
+    Net::OpenTimeout,
+    Net::SMTPServerBusy,
+    Errno::ECONNRESET,
+    Errno::ECONNREFUSED,
+    Errno::ETIMEDOUT,
+    Timeout::Error
+  ]
+
+  queue_as :default
+
+  rescue_from *PERMANENT_FAILURES do |exception|
+    log_exception(exception)
+  end
+
+  rescue_from *TEMPORARY_FAILURES do |exception|
+    log_exception(exception)
+    retry_job
+  end
+
+  def perform(*args)
+    mailer.send(email, *args).deliver_now
+  end
+
+  private
+
+  def log_exception(exception)
+    logger.info(log_message(exception))
+  end
+
+  def log_message(exception)
+    "#{exception.class.name} while sending email for #{self.class.name}"
+  end
+end

--- a/app/jobs/gather_sponsors_for_petition_email_job.rb
+++ b/app/jobs/gather_sponsors_for_petition_email_job.rb
@@ -1,0 +1,4 @@
+class GatherSponsorsForPetitionEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :gather_sponsors_for_petition
+end

--- a/app/jobs/notify_creator_that_petition_is_published_email_job.rb
+++ b/app/jobs/notify_creator_that_petition_is_published_email_job.rb
@@ -1,0 +1,4 @@
+class NotifyCreatorThatPetitionIsPublishedEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_creator_that_petition_is_published
+end

--- a/app/jobs/notify_sponsor_that_petition_is_published_email_job.rb
+++ b/app/jobs/notify_sponsor_that_petition_is_published_email_job.rb
@@ -1,0 +1,4 @@
+class NotifySponsorThatPetitionIsPublishedEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_sponsor_that_petition_is_published
+end

--- a/app/jobs/petition_and_email_confirmation_for_sponsor_email_job.rb
+++ b/app/jobs/petition_and_email_confirmation_for_sponsor_email_job.rb
@@ -1,0 +1,4 @@
+class PetitionAndEmailConfirmationForSponsorEmailJob < EmailJob
+  self.mailer = SponsorMailer
+  self.email = :petition_and_email_confirmation_for_sponsor
+end

--- a/app/jobs/sponsor_signed_email_below_threshold_email_job.rb
+++ b/app/jobs/sponsor_signed_email_below_threshold_email_job.rb
@@ -1,0 +1,4 @@
+class SponsorSignedEmailBelowThresholdEmailJob < EmailJob
+  self.mailer = SponsorMailer
+  self.email = :sponsor_signed_email_below_threshold
+end

--- a/app/jobs/sponsor_signed_email_on_threshold_email_job.rb
+++ b/app/jobs/sponsor_signed_email_on_threshold_email_job.rb
@@ -1,0 +1,4 @@
+class SponsorSignedEmailOnThresholdEmailJob < EmailJob
+  self.mailer = SponsorMailer
+  self.email = :sponsor_signed_email_on_threshold
+end

--- a/spec/jobs/email_job_spec.rb
+++ b/spec/jobs/email_job_spec.rb
@@ -1,0 +1,204 @@
+require 'rails_helper'
+
+RSpec.describe EmailJob, type: :job do
+  let(:job) { described_class.new(petition) }
+  let(:mailer) { double(:mailer) }
+  let(:message) { double(:message, deliver_now: true) }
+  let(:petition) { FactoryGirl.create(:petition) }
+
+  before do
+    job.mailer = mailer
+    job.email  = :email
+  end
+
+  it "calls the email method on the mailer" do
+    expect(mailer).to receive(:email).with(petition).and_return(message)
+    job.perform_now
+  end
+
+  context "email sending fails" do
+    shared_examples_for "catching errors during individual email sending" do
+      let(:logger) { job.logger }
+
+      it "captures the error and doesn't re-raise it" do
+        job.perform_now
+      end
+
+      it "logs the email sending error as information" do
+        expect(logger).to receive(:info).with(/#{Regexp.escape(exception_class.name)}/)
+        job.perform_now
+      end
+    end
+
+    shared_examples_for "retrying the email delivery" do
+      it "retries the job" do
+        expect(job).to receive(:retry_job)
+        job.perform_now
+      end
+    end
+
+    shared_examples_for "not retrying the email delivery" do
+      it "doesn't retry the job" do
+        expect(job).not_to receive(:retry_job)
+        job.perform_now
+      end
+    end
+
+    before do
+      expect(mailer).to receive(:email).and_raise(exception_class)
+    end
+
+    context "with a fatal SMTP error" do
+      let(:exception_class) { Net::SMTPFatalError }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "not retrying the email delivery"
+    end
+
+    context "with a SMTP syntax error" do
+      let(:exception_class) { Net::SMTPSyntaxError }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "not retrying the email delivery"
+    end
+
+    context "with SMTP authentication error" do
+      let(:exception_class) { Net::SMTPAuthenticationError }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+
+    context "with SMTP connection timeout" do
+      let(:exception_class) { Net::OpenTimeout }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+
+    context "with SMTP server busy" do
+      let(:exception_class) { Net::SMTPServerBusy }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+
+    context "with connection reset" do
+      let(:exception_class) { Errno::ECONNRESET }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+
+    context "with connection refused" do
+      let(:exception_class) { Errno::ECONNREFUSED }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+
+    context "with connection timeout" do
+      let(:exception_class) { Errno::ETIMEDOUT }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+
+    context "with timeout error" do
+      let(:exception_class) { Timeout::Error }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
+  end
+end
+
+RSpec.describe EmailConfirmationForSignerEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:open_petition) }
+  let(:signature) { FactoryGirl.create(:pending_signature, petition: petition) }
+
+  it "sends the PetitionMailer#email_confirmation_for_signer email" do
+    expect(PetitionMailer).to receive(:email_confirmation_for_signer).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
+RSpec.describe GatherSponsorsForPetitionEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:petition) }
+
+  it "sends the PetitionMailer#gather_sponsors_for_petition email" do
+    expect(PetitionMailer).to receive(:gather_sponsors_for_petition).with(petition).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(petition)
+    end
+  end
+end
+
+RSpec.describe NotifyCreatorThatPetitionIsPublishedEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:petition) }
+  let(:signature) { FactoryGirl.create(:signature, petition: petition) }
+
+  it "sends the PetitionMailer#notify_creator_that_petition_is_published email" do
+    expect(PetitionMailer).to receive(:notify_creator_that_petition_is_published).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
+RSpec.describe NotifySponsorThatPetitionIsPublishedEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:petition) }
+  let(:signature) { FactoryGirl.create(:signature, petition: petition) }
+
+  it "sends the PetitionMailer#notify_sponsor_that_petition_is_published email" do
+    expect(PetitionMailer).to receive(:notify_sponsor_that_petition_is_published).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
+RSpec.describe PetitionAndEmailConfirmationForSponsorEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:petition) }
+  let(:sponsor) { FactoryGirl.create(:sponsor, :pending, petition: petition) }
+
+  it "sends the SponsorMailer#petition_and_email_confirmation_for_sponsor email" do
+    expect(SponsorMailer).to receive(:petition_and_email_confirmation_for_sponsor).with(sponsor).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(sponsor)
+    end
+  end
+end
+
+RSpec.describe SponsorSignedEmailBelowThresholdEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:petition) }
+  let(:sponsor) { FactoryGirl.create(:sponsor, :validated, petition: petition) }
+
+  it "sends the SponsorMailer#sponsor_signed_email_below_threshold email" do
+    expect(SponsorMailer).to receive(:sponsor_signed_email_below_threshold).with(petition, sponsor).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(petition, sponsor)
+    end
+  end
+end
+
+RSpec.describe SponsorSignedEmailOnThresholdEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:petition) }
+  let(:sponsor) { FactoryGirl.create(:sponsor, :validated, petition: petition) }
+
+  it "sends the SponsorMailer#sponsor_signed_email_on_threshold email" do
+    expect(SponsorMailer).to receive(:sponsor_signed_email_on_threshold).with(petition, sponsor).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(petition, sponsor)
+    end
+  end
+end


### PR DESCRIPTION
The default email delivery job that comes with Rails 4.2 doesn't do any error handling so create custom email jobs that prevents retries where someone has incorrectly typed their email address and gracefully handles temporary failures so that we don't get Appsignal notifications.