### PR TITLE
Fix constituency lookups so that they update

### DIFF
--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -22,13 +22,13 @@ class Constituency < ActiveRecord::Base
       results = query.fetch(postcode)
 
       if attributes = results.first
-        find_or_initialize_by(external_id: attributes[:external_id]) do |constituency|
-          constituency.attributes = attributes
-
-          if constituency.changed? || constituency.new_record?
-            constituency.save!
-          end
+        constituency = find_or_initialize_by(external_id: attributes[:external_id])
+        constituency.attributes = attributes
+        if constituency.changed? || constituency.new_record?
+          constituency.save!
         end
+
+        constituency
       end
     end
 

--- a/spec/fixtures/constituency_api/updated.xml
+++ b/spec/fixtures/constituency_api/updated.xml
@@ -1,0 +1,27 @@
+<Constituencies>
+  <Constituency>
+    <Constituency_Id>3671</Constituency_Id>
+    <Name>Oldham West and Royton</Name>
+    <ONSCode>E14000871</ONSCode>
+    <RepresentingMembers>
+      <RepresentingMember>
+        <Member_Id>4569</Member_Id>
+        <Member>Jim McMahon MP</Member>
+        <StartDate>2015-12-03T00:00:00</StartDate>
+        <EndDate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      </RepresentingMember>
+      <RepresentingMember>
+        <Member_Id>454</Member_Id>
+        <Member>Mr Michael Meacher</Member>
+        <StartDate>2015-05-07T00:00:00</StartDate>
+        <EndDate>2015-10-21T00:00:00</EndDate>
+      </RepresentingMember>
+      <RepresentingMember>
+        <Member_Id>454</Member_Id>
+        <Member>Mr Michael Meacher</Member>
+        <StartDate>2010-05-06T00:00:00</StartDate>
+        <EndDate>2015-03-30T00:00:00</EndDate>
+      </RepresentingMember>
+    </RepresentingMembers>
+  </Constituency>
+</Constituencies>

--- a/spec/models/constituency_spec.rb
+++ b/spec/models/constituency_spec.rb
@@ -115,6 +115,29 @@ RSpec.describe Constituency, type: :model do
         expect(constituency).to be_nil
       end
     end
+
+    context "when the API returns updated results" do
+      let(:constituency) do
+        Constituency.find_by_postcode('OL90LS')
+      end
+
+      before do
+        FactoryGirl.create(:constituency, {
+          name: "Oldham West and Royton", external_id: "3671", ons_code: "E14000871",
+          mp_id: "454", mp_name: "Mr Michael Meacher", mp_date: "2015-05-07T00:00:00"
+        })
+
+        stub_api_request_for("OL90LS").to_return(api_response(:ok, "updated"))
+      end
+
+      it "updates the existing constituency" do
+        expect(constituency.mp_name).to eq("Jim McMahon MP")
+      end
+
+      it "persists the changes to the database" do
+        expect(constituency.reload.mp_name).to eq("Jim McMahon MP")
+      end
+    end
   end
 
   describe "#mp_url" do


### PR DESCRIPTION
The block passed to find_or_initialize_by is only executed when the constituency isn't found so it never updates if the API results change.