### PR TITLE
Add support for queue priorities via named queues

### DIFF
--- a/app/jobs/close_petitions_job.rb
+++ b/app/jobs/close_petitions_job.rb
@@ -1,4 +1,6 @@
 class ClosePetitionsJob < ActiveJob::Base
+  queue_as :high_priority
+
   def perform
     Petition.close_petitions!
   end

--- a/app/jobs/concerns/email_all_petition_signatories.rb
+++ b/app/jobs/concerns/email_all_petition_signatories.rb
@@ -10,7 +10,7 @@ module EmailAllPetitionSignatories
 
     attr_reader :petition, :requested_at
 
-    queue_as :default
+    queue_as :high_priority
   end
 
   module ClassMethods

--- a/app/jobs/concerns/email_delivery.rb
+++ b/app/jobs/concerns/email_delivery.rb
@@ -22,7 +22,7 @@ module EmailDelivery
 
   included do
     attr_reader :signature, :timestamp_name, :petition, :requested_at
-    queue_as :default
+    queue_as :low_priority
 
     rescue_from *PERMANENT_FAILURES do |exception|
       log_exception(exception)

--- a/app/jobs/debated_petitions_job.rb
+++ b/app/jobs/debated_petitions_job.rb
@@ -1,4 +1,6 @@
 class DebatedPetitionsJob < ActiveJob::Base
+  queue_as :high_priority
+
   def perform
     Petition.mark_petitions_as_debated!
   end

--- a/app/jobs/email_job.rb
+++ b/app/jobs/email_job.rb
@@ -16,7 +16,7 @@ class EmailJob < ActiveJob::Base
     Timeout::Error
   ]
 
-  queue_as :default
+  queue_as :high_priority
 
   rescue_from *PERMANENT_FAILURES do |exception|
     log_exception(exception)

--- a/app/jobs/petition_count_job.rb
+++ b/app/jobs/petition_count_job.rb
@@ -1,6 +1,8 @@
 class PetitionCountJob < ActiveJob::Base
   class InvalidSignatureCounts < RuntimeError; end
 
+  queue_as :high_priority
+
   def perform
     petitions = Petition.with_invalid_signature_counts
 

--- a/spec/jobs/job_priority_spec.rb
+++ b/spec/jobs/job_priority_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe "setting job priorities" do
+  before do
+    ActiveJob::Base.queue_adapter = :delayed_job
+  end
+
+  describe "default priority" do
+    it "is 100" do
+      expect(Delayed::Worker.default_priority).to eq(100)
+    end
+  end
+
+  describe "enqueuing" do
+    let(:job) { Delayed::Job.last }
+    let(:priority) { job.priority }
+
+    before do
+      job_class.perform_later
+    end
+
+    describe "a high priority job" do
+      let(:job_class) do
+        Class.new(ActiveJob::Base) do
+          queue_as :high_priority
+
+          def perform
+            logger.info("High priority job")
+          end
+        end
+      end
+
+      it "is queued with a priority of 0" do
+        expect(priority).to eq(0)
+      end
+    end
+
+    describe "a low priority job" do
+      let(:job_class) do
+        Class.new(ActiveJob::Base) do
+          queue_as :low_priority
+
+          def perform
+            logger.info("Low priority job")
+          end
+        end
+      end
+
+      it "is queued with a priority of 50" do
+        expect(priority).to eq(50)
+      end
+    end
+
+    describe "an unclassified job" do
+      let(:job_class) do
+        Class.new(ActiveJob::Base) do
+          queue_as :unclassified
+
+          def perform
+            logger.info("Unclassified job")
+          end
+        end
+      end
+
+      it "is queued with a priority of 25" do
+        expect(priority).to eq(25)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since it's unlikely we'll have budget to add Sidekiq and Redis to the stack until we have to move to the GaaP then we can add this small change so that we don't have to worry about bulk emails not finishing during the evening.

##### Todo

- [x] Merge #421
- [x] Assign jobs to either `:high_priority` or `:low_priority` queues

##### Description

Active Job in Rails 4.2 doesn't support setting a queue priority but does allow setting a queue name. Whilst we could dedicated one worker to processing the validation emails only it would give us more flexibility if the validation emails took priority over the bulk emails for all workers.

To enable this capability this commit adds a before_create callback to the Delayed Job Active Record model that sets the priority of the job based on a predefined mapping of queue names to priorities.