### PR TITLE
Really fix race condition

### DIFF
--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -4,53 +4,53 @@ class ConstituencyPetitionJournal < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :constituency_id, presence: true, length: { maximum: 255 }
-  validates :constituency_id, uniqueness: { scope: [:petition_id] }
   validates :signature_count, presence: true
 
   delegate :name, :ons_code, :mp_name, to: :constituency
 
-  scope :ordered, -> {
-    order("#{table_name}.signature_count DESC")
-  }
-  scope :with_signatures_for, ->(constituency_id) {
-    where("#{table_name}.signature_count > 0").
-    where(table_name => { constituency_id: constituency_id})
-  }
+  class << self
+    def for(petition, constituency_id)
+      begin
+        find_or_create_by(petition: petition, constituency_id: constituency_id)
+      rescue ActiveRecord::RecordNotUnique => e
+        retry
+      end
+    end
 
-  def self.for(petition, constituency_id)
-    begin
-      find_or_create_by(petition: petition, constituency_id: constituency_id)
-    rescue ActiveRecord::RecordNotUnique => e
-      retry
+    def ordered
+      order(signature_count: :desc)
+    end
+
+    def record_new_signature_for(signature, now = Time.current)
+      unless unrecordable?(signature)
+        journal = self.for(signature.petition, signature.constituency_id)
+        updates = "signature_count = signature_count + 1, updated_at = :now"
+        unscoped.where(id: journal.id).update_all([updates, now: now])
+      end
+    end
+
+    def reset!
+      connection.execute "TRUNCATE TABLE #{self.table_name}"
+      connection.execute <<-SQL.strip_heredoc
+        INSERT INTO #{self.table_name}
+          (petition_id, constituency_id, signature_count, created_at, updated_at)
+        SELECT
+          petition_id, constituency_id, COUNT(*) AS signature_count,
+          timezone('utc', now()), timezone('utc', now())
+        FROM signatures
+        WHERE state = 'validated'
+        GROUP BY petition_id, constituency_id
+      SQL
+    end
+
+    def with_signatures_for(constituency_id)
+      where(arel_table[:signature_count].gt(0)).where(arel_table[:constituency_id].eq(constituency_id))
+    end
+
+    private
+
+    def unrecordable?(signature)
+      signature.nil? || signature.petition.nil? || signature.constituency_id.blank? || !signature.validated?
     end
   end
-
-  def self.record_new_signature_for(signature)
-    return if signature.nil? || signature.petition.nil? || signature.constituency_id.blank? || !signature.validated?
-    self.for(signature.petition, signature.constituency_id).record_new_signature
-  end
-
-  def record_new_signature(at = Time.current)
-    signature_count_field = self.class.connection.quote_column_name('signature_count')
-    changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
-    self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
-    # NOTE: even though we don't assume +1 is ok for the SQL update, we
-    # want to avoid an extra SQL select from .reload so +1 is ok here
-    raw_write_attribute(:signature_count, signature_count+1)
-  end
-
-  def self.reset!
-    connection.execute "TRUNCATE TABLE #{self.table_name}"
-    connection.execute <<-SQL.strip_heredoc
-      INSERT INTO #{self.table_name}
-        (petition_id, constituency_id, signature_count, created_at, updated_at)
-      SELECT
-        petition_id, constituency_id, COUNT(*) AS signature_count,
-        timezone('utc', now()), timezone('utc', now())
-      FROM signatures
-      WHERE state = 'validated'
-      GROUP BY petition_id, constituency_id
-    SQL
-  end
-
 end

--- a/app/models/country_petition_journal.rb
+++ b/app/models/country_petition_journal.rb
@@ -3,44 +3,45 @@ class CountryPetitionJournal < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :country, presence: true, length: { maximum: 255 }
-  validates :country, uniqueness: { scope: [:petition_id] }
   validates :signature_count, presence: true
 
   alias_attribute :name, :country
 
-  def self.for(petition, country)
-    begin
-      find_or_create_by(petition: petition, country: country)
-    rescue ActiveRecord::RecordNotUnique => e
-      retry
+  class << self
+    def for(petition, country)
+      begin
+        find_or_create_by(petition: petition, country: country)
+      rescue ActiveRecord::RecordNotUnique => e
+        retry
+      end
     end
-  end
 
-  def self.record_new_signature_for(signature)
-    return if signature.nil? || signature.petition.nil? || signature.country.blank? || !signature.validated?
-    self.for(signature.petition, signature.country).record_new_signature
-  end
+    def record_new_signature_for(signature, now = Time.current)
+      unless unrecordable?(signature)
+        journal = self.for(signature.petition, signature.country)
+        updates = "signature_count = signature_count + 1, updated_at = :now"
+        unscoped.where(id: journal.id).update_all([updates, now: now])
+      end
+    end
 
-  def record_new_signature(at = Time.current)
-    signature_count_field = self.class.connection.quote_column_name('signature_count')
-    changes = "#{signature_count_field} = #{signature_count_field} + 1, updated_at = :updated_at"
-    self.class.unscoped.where(id: id).update_all([changes, updated_at: at])
-    # NOTE: even though we don't assume +1 is ok for the SQL update, we
-    # want to avoid an extra SQL select from .reload so +1 is ok here
-    raw_write_attribute(:signature_count, signature_count+1)
-  end
+    def reset!
+      connection.execute 'TRUNCATE TABLE country_petition_journals'
+      connection.execute <<-SQL.strip_heredoc
+        INSERT INTO country_petition_journals
+          (petition_id, country, signature_count, created_at, updated_at)
+        SELECT
+          petition_id, country, COUNT(*) AS signature_count,
+          timezone('utc', now()), timezone('utc', now())
+        FROM signatures
+        WHERE state = 'validated'
+        GROUP BY petition_id, country
+      SQL
+    end
 
-  def self.reset!
-    connection.execute 'TRUNCATE TABLE country_petition_journals'
-    connection.execute <<-SQL.strip_heredoc
-      INSERT INTO country_petition_journals
-        (petition_id, country, signature_count, created_at, updated_at)
-      SELECT
-        petition_id, country, COUNT(*) AS signature_count,
-        timezone('utc', now()), timezone('utc', now())
-      FROM signatures
-      WHERE state = 'validated'
-      GROUP BY petition_id, country
-    SQL
+    private
+
+    def unrecordable?(signature)
+      signature.nil? || signature.petition.nil? || signature.country.blank? || !signature.validated?
+    end
   end
 end

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
         expect(fetched).to be_a described_class
       end
 
-      it "does not persist the new instance in the DB" do
+      it "persists the new instance in the DB" do
         expect {
           described_class.for(petition, constituency_id)
-        }.to change(described_class, :count).by(0)
+        }.to change(described_class, :count).by(1)
       end
 
       it "sets the petition of the new instance to the supplied petition" do

--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe CountryPetitionJournal, type: :model do
   end
 
   describe "defaults" do
-    subject { described_class.new }
     it "has 0 for initial signature_count" do
       expect(subject.signature_count).to eq 0
     end
@@ -17,12 +16,9 @@ RSpec.describe CountryPetitionJournal, type: :model do
   end
 
   describe "validations" do
-    subject { FactoryGirl.build(:country_petition_journal) }
-
     it { is_expected.to validate_presence_of(:country) }
     it { is_expected.to validate_length_of(:country).is_at_most(255) }
     it { is_expected.to validate_presence_of(:petition) }
-    it { is_expected.to validate_uniqueness_of(:country).scoped_to(:petition_id) }
     it { is_expected.to validate_presence_of(:signature_count) }
   end
 
@@ -41,87 +37,31 @@ RSpec.describe CountryPetitionJournal, type: :model do
 
       it "fetches the instance from the DB" do
         fetched = described_class.for(petition, country)
-        expect(fetched).to eq existing_record
+        expect(fetched).to eq(existing_record)
       end
     end
 
     context "when there is no journal for the requested petition and country" do
-      it "returns the newly initialized instance" do
-        fetched = described_class.for(petition, country)
-        expect(fetched).to be_a described_class
+      let!(:journal) { described_class.for(petition, country) }
+
+      it "returns a newly created instance" do
+        expect(journal).to be_an_instance_of(described_class)
       end
 
       it "persists the new instance in the DB" do
-        expect {
-          described_class.for(petition, country)
-        }.to change(described_class, :count).by(1)
+        expect(journal).to be_persisted
       end
 
       it "sets the petition of the new instance to the supplied petition" do
-        fetched = described_class.for(petition, country)
-        expect(fetched.petition).to eq petition
+        expect(journal.petition).to eq(petition)
       end
 
-      it "sets the country of the new instance to the supplied petition" do
-        fetched = described_class.for(petition, country)
-        expect(fetched.country).to eq country
+      it "sets the country of the new instance to the supplied country" do
+        expect(journal.country).to eq(country)
       end
 
       it "has 0 for a signature count" do
-        fetched = described_class.for(petition, country)
-        expect(fetched.signature_count).to eq 0
-      end
-    end
-  end
-
-  describe "#record_new_signature" do
-    let(:petition) { FactoryGirl.create(:petition) }
-    let(:country) { "United Kingdom" }
-
-    subject { described_class.for(petition, country) }
-
-    context 'on a saved instance' do
-      before { subject.update_attribute(:signature_count, 20) }
-
-      it "increments signature_count by 1" do
-        expect {
-          subject.record_new_signature
-        }.to change(subject, :signature_count).by(1)
-      end
-
-      it "persists the change" do
-        old_signature_count = subject.signature_count
-        subject.record_new_signature
-        subject.reload
-        expect(subject.signature_count).not_to eq old_signature_count
-      end
-
-      it "increments the signature_count in the DB properly" do
-        first_signature_count = subject.signature_count
-        other_copy = described_class.for(petition, country)
-        other_copy.record_new_signature
-        second_signature_count = other_copy.reload.signature_count
-        subject.record_new_signature
-        expect(subject.signature_count).to eq(second_signature_count)
-        expect(subject.reload.signature_count).to eq(second_signature_count + 1)
-      end
-
-      it 'only executes the update SQL query' do
-        expect {
-          subject.record_new_signature
-        }.not_to exceed_query_limit(1)
-      end
-    end
-
-    context 'on a new instance' do
-      it "sets the signature_count to 1" do
-        subject.record_new_signature
-        expect(subject.signature_count).to eq 1
-      end
-
-      it "saves the instance to the DB" do
-        subject.record_new_signature
-        expect(subject).to be_persisted
+        expect(journal.signature_count).to eq(0)
       end
     end
   end
@@ -129,50 +69,76 @@ RSpec.describe CountryPetitionJournal, type: :model do
   describe ".record_new_signature_for" do
     let(:petition) { FactoryGirl.create(:open_petition) }
     let(:country) { "United Kingdom" }
-    let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, country: country) }
 
-    it "does nothing if the supplied signature is nil" do
-      expect {
-        described_class.record_new_signature_for(nil)
-      }.not_to change(described_class, :count)
+    def journal
+      described_class.for(petition, country)
     end
 
-    it "does nothing if the supplied signature has no petition" do
-      signature.petition = nil
-      expect {
-        described_class.record_new_signature_for(signature)
-      }.not_to change(described_class, :count)
+    context "when the supplied signature is valid" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, country: country) }
+      let(:now) { 1.hour.from_now.change(usec: 0) }
+
+      it "increments the signature_count by 1" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.to change { journal.signature_count }.by(1)
+      end
+
+      it "updates the updated_at timestamp" do
+        expect {
+          described_class.record_new_signature_for(signature, now)
+        }.to change { journal.updated_at }.to(now)
+      end
     end
 
-    it "does nothing if the supplied signature has no country" do
-      signature.country = nil
-      expect {
-        described_class.record_new_signature_for(signature)
-      }.not_to change(described_class, :count)
+    context "when the supplied signature is niL" do
+      let(:signature) { nil }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.signature_count }
+      end
     end
 
-    it "does nothing if the supplied signature is not validated?" do
-      signature.state = Signature::PENDING_STATE
-      expect {
-        described_class.record_new_signature_for(signature)
-      }.not_to change(described_class, :count)
+    context "when the supplied signature has no petition" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: nil, country: country) }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.signature_count }
+      end
     end
 
-    it "creates a new instance and sets the count to 1 if nothing exists already" do
-      expect {
-        described_class.record_new_signature_for(signature)
-      }.to change(described_class, :count).by(1)
-      expect(described_class.for(petition, country).signature_count).to eq 1
+    context "when the supplied signature has no country" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, country: nil) }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.signature_count }
+      end
     end
 
-    it "increments the signature_count of the existing instance by 1" do
-      existing = described_class.for(signature.petition, signature.country)
-      existing.update_attribute(:signature_count, 20)
+    context "when the supplied signature is not validated" do
+      let(:signature) { FactoryGirl.build(:pending_signature, petition: petition, country: country) }
 
-      described_class.record_new_signature_for(signature)
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.signature_count }
+      end
+    end
 
-      existing.reload
-      expect(existing.signature_count).to eq 21
+    context "when no journal exists" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, country: country) }
+
+      it "creates a new journal" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.to change(described_class, :count).by(1)
+      end
     end
   end
 

--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe CountryPetitionJournal, type: :model do
         expect(fetched).to be_a described_class
       end
 
-      it "does not persist the new instance in the DB" do
+      it "persists the new instance in the DB" do
         expect {
           described_class.for(petition, country)
-        }.to change(described_class, :count).by(0)
+        }.to change(described_class, :count).by(1)
       end
 
       it "sets the petition of the new instance to the supplied petition" do


### PR DESCRIPTION
In 97b9839 the find_or_create_by was changed to find_or_initialize_by in an attempt to save a query but unfortunately this introduced a race condition which was supposed to be fixed by 1b07b99. However it wasn't fixed properly because the id would be nil when the query was constructed.

Also refactored the journal code to remove some unnecessary complications.