### PR TITLE
Run specs on Ruby 2.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-- 2.2.2
+- 2.2.4
 services:
 - memcached
 before_install:


### PR DESCRIPTION
Servers are running on Ruby 2.2.4 so update the Travis config to match.