### PR TITLE
Use beginning of day for open_at_for_closing

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -320,7 +320,7 @@ class Site < ActiveRecord::Base
   end
 
   def opened_at_for_closing(time = Time.current)
-    time.end_of_day - petition_duration.months
+    time.beginning_of_day - petition_duration.months
   end
 
   def closed_at_for_opening(time = Time.current)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -758,7 +758,7 @@ RSpec.describe Site, type: :model do
     end
 
     it "returns the opening date at petition_duration months ago" do
-      expect(site.opened_at_for_closing).to eq(3.months.ago.end_of_day)
+      expect(site.opened_at_for_closing).to eq(3.months.ago.beginning_of_day)
     end
   end
 


### PR DESCRIPTION
Petitions should get the full six months so use the beginning of day when calculating the petitions that need closing. Previously we were effectively closing petitions a day early since they weren't opened at the beginning of the day.