### PR TITLE
Refine debate states

### DIFF
--- a/app/models/debate_outcome.rb
+++ b/app/models/debate_outcome.rb
@@ -36,7 +36,7 @@ class DebateOutcome < ActiveRecord::Base
   private
 
   def debate_state
-    debated? ? 'debated' : 'none'
+    debated? ? 'debated' : 'not_debated'
   end
 
   def image_ratio(width, height)

--- a/db/migrate/20160210001632_update_petition_debate_states.rb
+++ b/db/migrate/20160210001632_update_petition_debate_states.rb
@@ -1,0 +1,74 @@
+class UpdatePetitionDebateStates < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'awaiting'
+      WHERE debate_threshold_reached_at IS NOT NULL
+      AND scheduled_debate_date IS NULL
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'scheduled'
+      WHERE scheduled_debate_date >= CURRENT_DATE
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'debated'
+      WHERE scheduled_debate_date < CURRENT_DATE
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'debated'
+      WHERE debate_outcome_at IS NOT NULL
+      AND id IN (SELECT id FROM debate_outcomes WHERE debated = 't')
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'not_debated'
+      WHERE debate_outcome_at IS NOT NULL
+      AND id IN (SELECT id FROM debate_outcomes WHERE debated = 'f')
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'pending'
+      WHERE debate_state = 'closed'
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'pending'
+      WHERE debate_threshold_reached_at IS NOT NULL
+      AND scheduled_debate_date IS NULL
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'awaiting'
+      WHERE scheduled_debate_date >= CURRENT_DATE
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'debated'
+      WHERE scheduled_debate_date < CURRENT_DATE
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'debated'
+      WHERE debate_outcome_at IS NOT NULL
+      AND id IN (SELECT id FROM debate_outcomes WHERE debated = 't')
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'none'
+      WHERE debate_outcome_at IS NOT NULL
+      AND id IN (SELECT id FROM debate_outcomes WHERE debated = 'f')
+    SQL
+
+    execute <<-SQL
+      UPDATE petitions SET debate_state = 'closed'
+      WHERE state = 'closed'
+      AND debate_threshold_reached_at IS NULL
+      AND scheduled_debate_date IS NULL
+      AND debate_outcome_at IS NULL
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1415,3 +1415,5 @@ INSERT INTO schema_migrations (version) VALUES ('20151014152929');
 
 INSERT INTO schema_migrations (version) VALUES ('20160104144458');
 
+INSERT INTO schema_migrations (version) VALUES ('20160210001632');
+

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -167,6 +167,11 @@ FactoryGirl.define do
     debate_state 'awaiting'
   end
 
+  factory :scheduled_debate_petition, :parent => :open_petition do
+    debate_threshold_reached_at { 1.week.ago }
+    debate_state 'scheduled'
+  end
+
   factory :debated_petition, :parent => :open_petition do
     transient do
       debated_on { 1.day.ago }

--- a/spec/jobs/debated_petitions_job_spec.rb
+++ b/spec/jobs/debated_petitions_job_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe DebatedPetitionsJob, type: :job do
-  context "when a petition is in the awaiting debate state and the debate date has not passed" do
+  context "when a petition is in the scheduled debate state and the debate date has not passed" do
     let(:petition) {
       FactoryGirl.build(:open_petition,
-        debate_state: 'awaiting',
+        debate_state: 'scheduled',
         scheduled_debate_date: Date.tomorrow
       )
     }
@@ -22,10 +22,10 @@ RSpec.describe DebatedPetitionsJob, type: :job do
     end
   end
 
-  context "when a petition is in the awaiting debate state and the debate date has passed" do
+  context "when a petition is in the scheduled debate state and the debate date has passed" do
     let(:petition) {
       FactoryGirl.build(:open_petition,
-        debate_state: 'awaiting',
+        debate_state: 'scheduled',
         scheduled_debate_date: Date.tomorrow
       )
     }
@@ -41,7 +41,7 @@ RSpec.describe DebatedPetitionsJob, type: :job do
         perform_enqueued_jobs {
           described_class.perform_later
         }
-      }.to change{ petition.reload.debate_state }.from("awaiting").to("debated")
+      }.to change{ petition.reload.debate_state }.from("scheduled").to("debated")
     end
   end
 end

--- a/spec/models/debate_outcome_spec.rb
+++ b/spec/models/debate_outcome_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe DebateOutcome, type: :model do
           debate_outcome.update!(debated: false)
         }.to change {
           petition.reload.debate_state
-        }.from("debated").to("none")
+        }.from("debated").to("not_debated")
       end
     end
   end


### PR DESCRIPTION
Even when petitions are closed they are still up for being debated, especially when they have the required 100,000 signatures so eliminate the 'closed' debate state and introduce a new 'scheduled' debate state for when petitions have a scheduled debate date and automatically move petitions to 'awaiting' once the threshold has been passed.