### PR TITLE
Don't load all petitions on the home page

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -52,6 +52,10 @@ module HomeHelper
   end
   private :actioned_petitions_decorator
 
+  def no_petitions_yet?
+    @_no_petitions_yet ||= Petition.visible.empty?
+  end
+
   def petition_count(key, count)
     t(:"#{key}.html", scope: :"petitions.counts", count: count, formatted_count: number_with_delimiter(count))
   end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,8 +1,7 @@
 <%= cache_for :home_page do %>
   <h1 class="visuallyhidden">Petitions – UK Government and Parliament</h1>
 
-  <% no_petitions_yet = Petition.visible.none? %>
-  <% if no_petitions_yet %>
+  <% if no_petitions_yet? %>
     <div class="section-panel-borderless no-petitions-yet">
       <p class="lede">The new Petitions service launched today</p>
       <p class="lede">We're expecting the first petitions to go live in the next few hours</p>
@@ -21,7 +20,7 @@
     </div>
   <% end %>
 
-  <% unless no_petitions_yet %>
+  <% unless no_petitions_yet? %>
     <div class="section-panel-borderless">
       <% trending_petitions do |petitions| %>
         <section class="trending" aria-labelledby="trending-heading">
@@ -73,7 +72,7 @@
     </section>
   <% end %>
 
-  <% unless no_petitions_yet %>
+  <% unless no_petitions_yet? %>
     <section class="section-panel local-to-you" aria-labelledby="local-to-you-heading">
       <h2 id="local-to-you-heading">Local to you</h2>
       <p>Find petitions being signed by people near you</p>

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -1,6 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe HomeHelper, type: :helper do
+  describe "#no_petitions_yet?" do
+    let(:connection) { Petition.connection }
+    let(:sql) { /^SELECT COUNT/ }
+
+    it "performs a count query" do
+      expect(connection).to receive(:select).with(sql, any_args).and_call_original
+      expect(helper.no_petitions_yet?).to be true
+    end
+
+    it "it caches the result" do
+      expect(connection).to receive(:select).once.with(sql, any_args).and_call_original
+      expect(helper.no_petitions_yet?).to be true
+      expect(helper.no_petitions_yet?).to be true
+    end
+
+    context "when there are no published petitions" do
+      before do
+        FactoryGirl.create(:pending_petition)
+      end
+
+      it "returns true" do
+        expect(helper.no_petitions_yet?).to be true
+      end
+    end
+
+    Petition::VISIBLE_STATES.each do |state|
+      context "when there is a #{state} petition" do
+        before do
+          FactoryGirl.create(:"#{state}_petition")
+        end
+
+        it "returns false" do
+          expect(helper.no_petitions_yet?).to be false
+        end
+      end
+    end
+  end
+
   describe "#petition_count" do
     describe "for counting government responses" do
       it "returns a HTML-safe string" do


### PR DESCRIPTION
The none? method on relations isn't optimised until Rails 5.0 so use the alternative method empty? which is optimised.