### PR TITLE
Fix migrations task for country petition journals

### DIFF
--- a/db/migrate/20160217192016_add_location_code_index_to_country_petition_journal.rb
+++ b/db/migrate/20160217192016_add_location_code_index_to_country_petition_journal.rb
@@ -1,0 +1,15 @@
+class AddLocationCodeIndexToCountryPetitionJournal < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:signatures, [:petition_id, :location_code])
+      add_index :signatures, [:petition_id, :location_code], algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:signatures, [:petition_id, :location_code])
+      remove_index :signatures, [:petition_id, :location_code]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1241,6 +1241,13 @@ CREATE INDEX index_signatures_on_petition_id ON signatures USING btree (petition
 
 
 --
+-- Name: index_signatures_on_petition_id_and_location_code; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_petition_id_and_location_code ON signatures USING btree (petition_id, location_code);
+
+
+--
 -- Name: index_signatures_on_updated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1496,4 +1503,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160211002731');
 INSERT INTO schema_migrations (version) VALUES ('20160211003703');
 
 INSERT INTO schema_migrations (version) VALUES ('20160211020341');
+
+INSERT INTO schema_migrations (version) VALUES ('20160217192016');
 


### PR DESCRIPTION
A `TRUNCATE` followed by an `INSERT ... FROM` doesn't really work that well on a busy site like the petitions website because new journals will start to appear before the `INSERT` completes. Fix this by doing it in Ruby and locking the journals before calculating the signatures.

To do this in a performant manner we need an index on the petition_id and location_code for the signatures table. We need to do this concurrently otherwise it will block writes to the table, preventing
anyone from signing any petitions.