### PR TITLE
If there's no sitting MP hide the link

### DIFF
--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -39,6 +39,10 @@ class Constituency < ActiveRecord::Base
     end
   end
 
+  def sitting_mp?
+    mp_id?
+  end
+
   def mp_url
     "#{MP_URL}/#{mp_name.parameterize}/#{mp_id}"
   end

--- a/app/models/constituency/api_query.rb
+++ b/app/models/constituency/api_query.rb
@@ -10,7 +10,8 @@ class Constituency < ActiveRecord::Base
     CURRENT_MP = './RepresentingMembers/RepresentingMember[1]'
     MP_ID      = './Member_Id'
     MP_NAME    = './Member'
-    MP_DATE    = './StartDate'
+    MP_START   = './StartDate'
+    MP_END     = './EndDate'
 
     def fetch(postcode)
       response = client.call(postcode)
@@ -47,9 +48,13 @@ class Constituency < ActiveRecord::Base
           attrs[:ons_code]    = node.xpath(CONSTITUENCY_CODE).text
 
           if mp = node.at_xpath(CURRENT_MP)
-            attrs[:mp_id] = mp.xpath(MP_ID).text
-            attrs[:mp_name] = mp.xpath(MP_NAME).text
-            attrs[:mp_date] = mp.xpath(MP_DATE).text
+            if mp.at_xpath(MP_END).text.present?
+              attrs.merge!(mp_id: nil, mp_name: nil, mp_date: nil)
+            else
+              attrs[:mp_id] = mp.xpath(MP_ID).text
+              attrs[:mp_name] = mp.xpath(MP_NAME).text
+              attrs[:mp_date] = mp.xpath(MP_START).text
+            end
           end
         end
       end

--- a/app/views/local_petitions/show.html.erb
+++ b/app/views/local_petitions/show.html.erb
@@ -2,7 +2,7 @@
   Popular petitions in the constituency of <%= @constituency.name %>
 </h1>
 
-<% if @constituency.mp_id? %>
+<% if @constituency.sitting_mp? %>
   <p class="lede">Your member of parliament is <%= link_to @constituency.mp_name, @constituency.mp_url, rel: 'external' %></p>
 <% end %>
 

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -42,3 +42,11 @@ Feature: Freya searches petitions by constituency
     When I search for petitions local to me in "NN13 5QD"
     Then the markup should be valid
     But I should see an explanation that there are no petitions popular in my constituency
+
+  Scenario: Searching for local petitions when the mp has passed away
+    Given a constituency "Sheffield, Brightside and Hillsborough" with MP "Harry Harpham" is found by postcode "S4 8AA"
+    And the MP has passed away
+    When I am on the home page
+    And I search for petitions local to me in "S4 8AA"
+    Then the markup should be valid
+    And I should not see a link to the MP for my constituency

--- a/spec/fixtures/constituency_api/vacant.xml
+++ b/spec/fixtures/constituency_api/vacant.xml
@@ -1,0 +1,21 @@
+<Constituencies>
+  <Constituency>
+    <Constituency_Id>3724</Constituency_Id>
+    <Name>Sheffield, Brightside and Hillsborough</Name>
+    <ONSCode>E14000921</ONSCode>
+    <RepresentingMembers>
+      <RepresentingMember>
+        <Member_Id>4477</Member_Id>
+        <Member>Harry Harpham</Member>
+        <StartDate>2015-05-07T00:00:00</StartDate>
+        <EndDate>2016-02-04T00:00:00</EndDate>
+      </RepresentingMember>
+      <RepresentingMember>
+      <Member_Id>395</Member_Id>
+      <Member>The Rt Hon. the Lord Blunkett</Member>
+      <StartDate>2010-05-06T00:00:00</StartDate>
+      <EndDate>2015-03-30T00:00:00</EndDate>
+      </RepresentingMember>
+    </RepresentingMembers>
+  </Constituency>
+</Constituencies>

--- a/spec/models/constituency/api_query_spec.rb
+++ b/spec/models/constituency/api_query_spec.rb
@@ -88,6 +88,19 @@ RSpec.describe Constituency::ApiQuery, type: :model do
           }])
         end
       end
+
+      context "when the current MP has passed away" do
+        before do
+          stub_api_request_for("S48AA").to_return(api_response(:ok, "vacant"))
+        end
+
+        it "sets the MP details to nil" do
+          expect(query.fetch("S48AA")).to eq([{
+            name: "Sheffield, Brightside and Hillsborough", external_id: "3724",
+            ons_code: "E14000921", mp_id: nil, mp_name: nil, mp_date: nil
+          }])
+        end
+      end
     end
 
     context "when the request is unsuccessful" do


### PR DESCRIPTION
When the first MP in the API response has a non-empty `<EndDate>` element then either the MP has stepped down or passed away. In this scenario we should update the constituency record to clear the MP details and not show any link on the local search results page.