### PR TITLE
Fix redirect to login for delayed-web gem

### DIFF
--- a/config/initializers/delayed_web.rb
+++ b/config/initializers/delayed_web.rb
@@ -8,7 +8,7 @@ Delayed::Web::ApplicationController.class_eval do
   include Authentication
   before_filter :require_admin_and_check_for_password_change
 
-  def admin_login_path
-    main_app.admin_login_path
+  def admin_login_url
+    main_app.admin_login_url
   end
 end

--- a/features/admin/admin_access.feature
+++ b/features/admin/admin_access.feature
@@ -4,7 +4,13 @@ Feature: Restricted access to the admin console
   I can only access the admin area if I have logged on and my password does not need resetting
 
   Scenario: Accessing admin when not logged in
-    When I go to the Admin home page
+    When I go to the admin home page
+    Then I should be on the admin login page
+    And I should be connected to the server via an ssl connection
+    And the markup should be valid
+
+  Scenario: Accessing the job admin when not logged in
+    When I go to the admin delayed job page
     Then I should be on the admin login page
     And I should be connected to the server via an ssl connection
     And the markup should be valid

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -74,6 +74,9 @@ module NavigationHelpers
     when /^home ?page$/
       admin_root_url
 
+    when /^delayed job page$/
+      admin_delayed_web_url
+
     when /^petition page for "([^\"]*)"$/
       admin_petition_url(Petition.find_by(action: $1))
 


### PR DESCRIPTION
In 0bd5c2e the url helper used for authentication redirects was changed from admin_login_path to admin_login_url but as the delayed-web config was missed from that change it was generating a 500 error instead.