### PR TITLE
Add scheduled debate date to awaiting debate petitions view

### DIFF
--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -46,7 +46,7 @@ module DateTimeHelper
     end
   end
 
-  def to_be_debated_on_in_words(date, today = Date.today)
+  def to_be_debated_on_in_words(date, today = Date.current)
     return unless date.present?
 
     scope = :"petitions.to_be_debated_on_in_words"

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -47,8 +47,6 @@ module DateTimeHelper
   end
 
   def to_be_debated_on_in_words(date, today = Date.current)
-    return unless date.present?
-
     scope = :"petitions.to_be_debated_on_in_words"
     days  = (date - today).to_i
     key   = TO_BE_DEBATED_KEYS[days]

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -44,4 +44,13 @@ module DateTimeHelper
       end
     end
   end
+
+  def to_be_debated_on_in_words(date)
+    return unless date.present?
+
+    scope = :"petitions.to_be_debated_on_in_words"
+    key   = :all
+
+    t(key, scope: scope, formatted_date: short_date_format(date))
+  end
 end

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,5 +1,6 @@
 module DateTimeHelper
   WAITING_FOR_KEYS = Hash.new(:other).merge(0 => :zero, 1 => :one)
+  TO_BE_DEBATED_KEYS = Hash.new(:other).merge(0 => :today, 1 => :tomorrow)
 
   def short_date_format(date_time)
     date_time && date_time.strftime("%-d %B %Y")
@@ -45,11 +46,12 @@ module DateTimeHelper
     end
   end
 
-  def to_be_debated_on_in_words(date)
+  def to_be_debated_on_in_words(date, today = Date.today)
     return unless date.present?
 
     scope = :"petitions.to_be_debated_on_in_words"
-    key   = :all
+    days  = (date - today).to_i
+    key   = TO_BE_DEBATED_KEYS[days]
 
     t(key, scope: scope, formatted_date: short_date_format(date))
   end

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
@@ -1,4 +1,6 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
 <p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
-<p><%= to_be_debated_on_in_words(petition.scheduled_debate_date) %></p>
+<% if petition.scheduled_debate_date? %>
+  <p><%= to_be_debated_on_in_words(petition.scheduled_debate_date) %></p>
+<% end %>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
@@ -1,3 +1,4 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
 <p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
+<p><%= to_be_debated_on_in_words(petition.scheduled_debate_date) %></p>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -130,6 +130,9 @@ en-GB:
       one: "Waiting for 1 day"
       other: "Waiting for %{formatted_count} days"
 
+    to_be_debated_on_in_words:
+      all: "To be debated on %{formatted_date}"
+
     signature_counts:
       default:
         html:

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -131,7 +131,9 @@ en-GB:
       other: "Waiting for %{formatted_count} days"
 
     to_be_debated_on_in_words:
-      all: "To be debated on %{formatted_date}"
+      today: "To be debated today"
+      tomorrow: "To be debated tomorrow"
+      other: "To be debated on %{formatted_date}"
 
     signature_counts:
       default:

--- a/spec/helpers/date_time_helper_spec.rb
+++ b/spec/helpers/date_time_helper_spec.rb
@@ -108,4 +108,20 @@ RSpec.describe DateTimeHelper, type: :helper do
       end
     end
   end
+
+  describe "#to_be_debated_on_in_words" do
+    context "when the date is nil" do
+      it "returns nil" do
+        expect(helper.to_be_debated_on_in_words(nil)).to be_nil
+      end
+    end
+
+    context "when the date is today" do
+      let(:date) { Date.parse("11/11/2016") }
+
+      it "returns 'To be debated on 11 November 2016'" do
+        expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated on 11 November 2016")
+      end
+    end
+  end
 end

--- a/spec/helpers/date_time_helper_spec.rb
+++ b/spec/helpers/date_time_helper_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe DateTimeHelper, type: :helper do
     end
 
     context "when the date is today" do
-      let(:date) { Date.today }
+      let(:date) { Date.current }
 
       it "returns 'To be debated today'" do
         expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated today")

--- a/spec/helpers/date_time_helper_spec.rb
+++ b/spec/helpers/date_time_helper_spec.rb
@@ -110,17 +110,27 @@ RSpec.describe DateTimeHelper, type: :helper do
   end
 
   describe "#to_be_debated_on_in_words" do
-    context "when the date is nil" do
-      it "returns nil" do
-        expect(helper.to_be_debated_on_in_words(nil)).to be_nil
-      end
-    end
-
     context "when the date is today" do
       let(:date) { Date.parse("11/11/2016") }
 
       it "returns 'To be debated on 11 November 2016'" do
         expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated on 11 November 2016")
+      end
+    end
+
+    context "when the date is today" do
+      let(:date) { Date.today }
+
+      it "returns 'To be debated today'" do
+        expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated today")
+      end
+    end
+
+    context "when the date is tomorrow" do
+      let(:date) { Date.tomorrow }
+
+      it "returns 'To be debated tomorrow'" do
+        expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated tomorrow")
       end
     end
   end


### PR DESCRIPTION
Hi people,

I've added the debate schedule date to the awaiting debate petitions view. Useful to check the debate date before clicking on the petition.

![image](https://cloud.githubusercontent.com/assets/3020581/14524312/a475b620-022f-11e6-99de-9ab032e1ad6c.png)

