### PR TITLE
Support new `/records` resource schema from country register

### DIFF
--- a/app/jobs/fetch_country_register_job.rb
+++ b/app/jobs/fetch_country_register_job.rb
@@ -26,7 +26,12 @@ class FetchCountryRegisterJob < ActiveJob::Base
   private
 
   def countries
-    fetch_register.body.map{ |r| r['entry'] }
+    items = fetch_register.body
+    if items.is_a?(Array)
+      items.map { |r| r['entry'] }
+    else
+      items.values
+    end
   end
 
   def faraday
@@ -34,7 +39,7 @@ class FetchCountryRegisterJob < ActiveJob::Base
       f.response :follow_redirects
       f.response :json
       f.response :raise_error
-      f.adapter  :net_http_persistent
+      f.adapter :net_http_persistent
     end
   end
 

--- a/spec/jobs/fetch_petition_register_job_spec.rb
+++ b/spec/jobs/fetch_petition_register_job_spec.rb
@@ -6,16 +6,17 @@ RSpec.describe FetchCountryRegisterJob, type: :job do
   end
 
   def json_response(body = "{}")
-    { status: 200, headers: { "Content-Type" => "application/json" }, body: body }
+    {status: 200, headers: {"Content-Type" => "application/json"}, body: body}
   end
 
   def json_error(status = 404, body = "{}")
-    { status: status, headers: { "Content-Type" => "application/json" }, body: body }
+    {status: status, headers: {"Content-Type" => "application/json"}, body: body}
   end
 
-  context "when a country does not exist" do
-    before do
-      stub_register.to_return json_response <<-JSON
+  context "old (array-based) record schema" do
+    context "when a country does not exist" do
+      before do
+        stub_register.to_return json_response <<-JSON
         [
             {
                 "serial-number": 6,
@@ -30,49 +31,49 @@ RSpec.describe FetchCountryRegisterJob, type: :job do
                 }
             }
         ]
-      JSON
+        JSON
+      end
+
+      it "creates a record" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.to change { Location.count }.by(1)
+      end
+
+      describe "attribute assignment" do
+        let(:location) { Location.find_by!(code: "GB") }
+
+        before do
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        end
+
+        it "assigns 'country' to Location#code" do
+          expect(location.code).to eq("GB")
+        end
+
+        it "assigns 'name' to Location#name" do
+          expect(location.name).to eq("United Kingdom")
+        end
+
+        it "assigns 'start-date' to Location#start_date" do
+          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
+        end
+
+        it "assigns 'end-date' to Location#end_date" do
+          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
+        end
+      end
     end
 
-    it "creates a record" do
-      expect {
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      }.to change { Location.count }.by(1)
-    end
-
-    describe "attribute assignment" do
-      let(:location) { Location.find_by!(code: "GB") }
-
+    context "when a country does exist" do
       before do
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      end
+        FactoryGirl.create(:location, code: "GB")
 
-      it "assigns 'country' to Location#code" do
-        expect(location.code).to eq("GB")
-      end
-
-      it "assigns 'name' to Location#name" do
-        expect(location.name).to eq("United Kingdom")
-      end
-
-      it "assigns 'start-date' to Location#start_date" do
-        expect(location.start_date).to eq(Date.civil(1707, 5, 1))
-      end
-
-      it "assigns 'end-date' to Location#end_date" do
-        expect(location.end_date).to eq(Date.civil(2017, 12, 31))
-      end
-    end
-  end
-
-  context "when a country does exist" do
-    before do
-      FactoryGirl.create(:location, code: "GB")
-
-      stub_register.to_return json_response <<-JSON
+        stub_register.to_return json_response <<-JSON
         [
             {
                 "serial-number": 6,
@@ -87,47 +88,47 @@ RSpec.describe FetchCountryRegisterJob, type: :job do
                 }
             }
         ]
-      JSON
+        JSON
+      end
+
+      it "updates an existing record" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.not_to change { Location.count }
+      end
+
+      describe "attribute assignment" do
+        let(:location) { Location.find_by!(code: "GB") }
+
+        before do
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        end
+
+        it "updates Location#name" do
+          expect(location.name).to eq("United Kingdom")
+        end
+
+        it "updates Location#start_date" do
+          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
+        end
+
+        it "updates Location#end_date" do
+          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
+        end
+      end
     end
 
-    it "updates an existing record" do
-      expect {
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      }.not_to change { Location.count }
-    end
-
-    describe "attribute assignment" do
+    context "when a country does not change" do
       let(:location) { Location.find_by!(code: "GB") }
 
       before do
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      end
+        FactoryGirl.create(:location, code: "GB", name: "United Kingdom")
 
-      it "updates Location#name" do
-        expect(location.name).to eq("United Kingdom")
-      end
-
-      it "updates Location#start_date" do
-        expect(location.start_date).to eq(Date.civil(1707, 5, 1))
-      end
-
-      it "updates Location#end_date" do
-        expect(location.end_date).to eq(Date.civil(2017, 12, 31))
-      end
-    end
-  end
-
-  context "when a country does not change" do
-    let(:location) { Location.find_by!(code: "GB") }
-
-    before do
-      FactoryGirl.create(:location, code: "GB", name: "United Kingdom")
-
-      stub_register.to_return json_response <<-JSON
+        stub_register.to_return json_response <<-JSON
         [
             {
                 "serial-number": 6,
@@ -140,15 +141,155 @@ RSpec.describe FetchCountryRegisterJob, type: :job do
                 }
             }
         ]
-      JSON
+        JSON
+      end
+
+
+      it "doesn't update an existing record" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.not_to change { location.reload.updated_at }
+      end
+    end
+  end
+
+  context "new (map-based) record schema" do
+    context "when a country does not exist" do
+      before do
+        stub_register.to_return json_response <<-JSON
+        {
+            "GB" : {
+              "entry-number": "6",
+              "item-hash": "sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb",
+              "entry-timestamp": "2016-04-05T13:23:05Z",
+              "citizen-names": "Briton;British citizen",
+              "country": "GB",
+              "name": "United Kingdom",
+              "official-name": "The United Kingdom of Great Britain and Northern Ireland",
+              "start-date": "1707-05-01",
+              "end-date": "2017-12-31"
+            }
+        }
+        JSON
+      end
+
+      it "creates a record" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.to change { Location.count }.by(1)
+      end
+
+      describe "attribute assignment" do
+        let(:location) { Location.find_by!(code: "GB") }
+
+        before do
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        end
+
+        it "assigns 'country' to Location#code" do
+          expect(location.code).to eq("GB")
+        end
+
+        it "assigns 'name' to Location#name" do
+          expect(location.name).to eq("United Kingdom")
+        end
+
+        it "assigns 'start-date' to Location#start_date" do
+          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
+        end
+
+        it "assigns 'end-date' to Location#end_date" do
+          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
+        end
+      end
     end
 
-    it "doesn't update an existing record" do
-      expect {
-        perform_enqueued_jobs {
-          described_class.perform_later
+    context "when a country does exist" do
+      before do
+        FactoryGirl.create(:location, code: "GB")
+
+        stub_register.to_return json_response <<-JSON
+        {
+            "GB" : {
+              "entry-number": "6",
+              "item-hash": "sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb",
+              "entry-timestamp": "2016-04-05T13:23:05Z",
+              "citizen-names": "Briton;British citizen",
+              "country": "GB",
+              "name": "United Kingdom",
+              "official-name": "The United Kingdom of Great Britain and Northern Ireland",
+              "start-date": "1707-05-01",
+              "end-date": "2017-12-31"
+            }
         }
-      }.not_to change { location.reload.updated_at }
+        JSON
+      end
+
+      it "updates an existing record" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.not_to change { Location.count }
+      end
+
+      describe "attribute assignment" do
+        let(:location) { Location.find_by!(code: "GB") }
+
+        before do
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        end
+
+        it "updates Location#name" do
+          expect(location.name).to eq("United Kingdom")
+        end
+
+        it "updates Location#start_date" do
+          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
+        end
+
+        it "updates Location#end_date" do
+          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
+        end
+      end
+    end
+
+    context "when a country does not change" do
+      let(:location) { Location.find_by!(code: "GB") }
+
+      before do
+        FactoryGirl.create(:location, code: "GB", name: "United Kingdom")
+
+        stub_register.to_return json_response <<-JSON
+        {
+            "GB" : {
+              "entry-number": "6",
+              "item-hash": "sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb",
+              "entry-timestamp": "2016-04-05T13:23:05Z",
+              "citizen-names": "Briton;British citizen",
+              "country": "GB",
+              "name": "United Kingdom",
+              "official-name": "The United Kingdom of Great Britain and Northern Ireland"
+            }
+        }
+        JSON
+      end
+
+      it "doesn't update an existing record" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.not_to change { location.reload.updated_at }
+      end
     end
   end
 


### PR DESCRIPTION
 Response for `/records` resource from country register will be changed very soon. It will start returning new map based response specified in register specification `https://openregister.github.io/specification/#records-resource` rather than current array based response.

  Changes in the PR confirms that the e-petitions is forward compatible with the new-schema from country register. This will keep e-petitions code working for both new and old schema. It also allows country register to publish new response independently.

  Same set of tests are added for the new schema and implemented the solution to support both schemas. The old-schema tests/code can be  deleted after country register starts publishing the new-schema.