### PR TITLE
Change 'To be debated on' to 'Scheduled for debate on'

### DIFF
--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -46,8 +46,8 @@ module DateTimeHelper
     end
   end
 
-  def to_be_debated_on_in_words(date, today = Date.current)
-    scope = :"petitions.to_be_debated_on_in_words"
+  def scheduled_for_debate_in_words(date, today = Date.current)
+    scope = :"petitions.scheduled_for_debate_in_words"
     days  = (date - today).to_i
     key   = TO_BE_DEBATED_KEYS[days]
 

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
@@ -2,5 +2,5 @@
 <p><%= signature_count(:default, petition.signature_count) %></p>
 <p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
 <% if petition.scheduled_debate_date? %>
-  <p><%= to_be_debated_on_in_words(petition.scheduled_debate_date) %></p>
+  <p><%= scheduled_for_debate_in_words(petition.scheduled_debate_date) %></p>
 <% end %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -130,10 +130,10 @@ en-GB:
       one: "Waiting for 1 day"
       other: "Waiting for %{formatted_count} days"
 
-    to_be_debated_on_in_words:
-      today: "To be debated today"
-      tomorrow: "To be debated tomorrow"
-      other: "To be debated on %{formatted_date}"
+    scheduled_for_debate_in_words:
+      today: "Scheduled for debate today"
+      tomorrow: "Scheduled for debate tomorrow"
+      other: "Scheduled for debate on %{formatted_date}"
 
     signature_counts:
       default:

--- a/spec/helpers/date_time_helper_spec.rb
+++ b/spec/helpers/date_time_helper_spec.rb
@@ -109,28 +109,28 @@ RSpec.describe DateTimeHelper, type: :helper do
     end
   end
 
-  describe "#to_be_debated_on_in_words" do
+  describe "#scheduled_for_debate_in_words" do
     context "when the date is today" do
       let(:date) { Date.parse("11/11/2016") }
 
-      it "returns 'To be debated on 11 November 2016'" do
-        expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated on 11 November 2016")
+      it "returns 'Scheduled for debate on 11 November 2016'" do
+        expect(helper.scheduled_for_debate_in_words(date)).to eq("Scheduled for debate on 11 November 2016")
       end
     end
 
     context "when the date is today" do
       let(:date) { Date.current }
 
-      it "returns 'To be debated today'" do
-        expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated today")
+      it "returns 'Scheduled for debate today'" do
+        expect(helper.scheduled_for_debate_in_words(date)).to eq("Scheduled for debate today")
       end
     end
 
     context "when the date is tomorrow" do
       let(:date) { Date.tomorrow }
 
-      it "returns 'To be debated tomorrow'" do
-        expect(helper.to_be_debated_on_in_words(date)).to eq("To be debated tomorrow")
+      it "returns 'Scheduled for debate tomorrow'" do
+        expect(helper.scheduled_for_debate_in_words(date)).to eq("Scheduled for debate tomorrow")
       end
     end
   end


### PR DESCRIPTION
Sometimes things change at the last minute due to emergencies, etc. so clarify that the debate is scheduled and not a cast-iron guarantee that it will actually take place.