### PR TITLE
Use a string instead of a symbol

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -334,7 +334,7 @@ class PackageBuilder
   end
 
   def website_url
-    if environment == :production
+    if environment == "production"
       "https://petition.parliament.uk/"
     else
       "https://#{environment}.epetitions.website/"


### PR DESCRIPTION
The environment is converted to a string in the initialize method so use a string to check for production deploy notifications.