### PR TITLE
Remove sponsors from rejection email

### DIFF
--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -33,8 +33,7 @@ class PetitionMailer < ApplicationMailer
 
   def petition_rejected(petition)
     @petition, @rejection, @creator = petition, petition.rejection, petition.creator_signature
-    bcc = @petition.sponsor_signatures.validated.map(&:email)
-    mail to: @creator.email, bcc: bcc, subject: subject_for(:petition_rejected)
+    mail to: @creator.email, subject: subject_for(:petition_rejected)
   end
 
   def notify_signer_of_threshold_response(petition, signature)

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -109,16 +109,12 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
             expect(email.to).to eq([petition.creator_signature.email])
             expect(email.subject).to match(/We rejected your petition “[^"]+”/)
           end
-          it "sends an email to validated petition sponsors" do
-            validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
-            validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
+          it "does not sends any emails to petition sponsors" do
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
-          end
-          it "does not send an email to pending petition sponsors" do
-            pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
-            do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).to be_blank
           end
         end
 
@@ -149,16 +145,12 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
             expect(email.to).to eq([petition.creator_signature.email])
             expect(email.subject).to match(/We rejected your petition “[^"]+”/)
           end
-          it "sends an email to validated petition sponsors" do
-            validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
-            validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
+          it "does not sends any emails to petition sponsors" do
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
-          end
-          it "does not send an email to pending petition sponsors" do
-            pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
-            do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).to be_blank
           end
         end
 

--- a/spec/controllers/admin/take_down_controller_spec.rb
+++ b/spec/controllers/admin/take_down_controller_spec.rb
@@ -131,17 +131,12 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             expect(email.subject).to match(/We rejected your petition/)
           end
 
-          it "sends an email to validated petition sponsors" do
-            validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
-            validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
+          it "does not sends any emails to petition sponsors" do
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
-          end
-
-          it "does not send an email to pending petition sponsors" do
-            pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
-            do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).to be_blank
           end
         end
 
@@ -176,17 +171,12 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             expect(email.subject).to match(/We rejected your petition/)
           end
 
-          it "sends an email to validated petition sponsors" do
-            validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
-            validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
+          it "does not sends any emails to petition sponsors" do
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :validated, petition: petition)
+            FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
-          end
-
-          it "does not send an email to pending petition sponsors" do
-            pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
-            do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).to be_blank
           end
         end
 


### PR DESCRIPTION
The rejection email is blind-copied to all of the validated sponsors which reveals the creator's email address. One way of preventing this information disclosure is to not copy the email to the sponsors.

Fixes #450.