### PR TITLE
Send rejection email to creator via bcc

### DIFF
--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -33,8 +33,8 @@ class PetitionMailer < ApplicationMailer
 
   def petition_rejected(petition)
     @petition, @rejection, @creator = petition, petition.rejection, petition.creator_signature
-    bcc = @petition.sponsor_signatures.validated.map(&:email)
-    mail to: @creator.email, bcc: bcc, subject: subject_for(:petition_rejected)
+    bcc = [@creator.email] + @petition.sponsor_signatures.validated.map(&:email)
+    mail bcc: bcc, subject: subject_for(:petition_rejected)
   end
 
   def notify_signer_of_threshold_response(petition, signature)

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -103,22 +103,24 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
             do_patch
             expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
           end
-          it "sends an email to the petition creator" do
+          it "sends an email to the petition creator via Bcc: and not To:" do
             do_patch
             expect(email.from).to eq(["no-reply@petition.parliament.uk"])
-            expect(email.to).to eq([petition.creator_signature.email])
+            expect(email.to).to be_blank
+            expect(email.bcc).to include(petition.creator_signature.email)
             expect(email.subject).to match(/We rejected your petition “[^"]+”/)
           end
           it "sends an email to validated petition sponsors" do
             validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
+            expect(email.bcc).to include(validated_sponsor_1.signature.email)
+            expect(email.bcc).to include(validated_sponsor_2.signature.email)
           end
           it "does not send an email to pending petition sponsors" do
             pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).not_to include(pending_sponsor.signature.email)
           end
         end
 
@@ -143,22 +145,24 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
             do_patch
             expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
           end
-          it "sends an email to the petition creator" do
+          it "sends an email to the petition creator via Bcc: and not To:" do
             do_patch
             expect(email.from).to eq(["no-reply@petition.parliament.uk"])
-            expect(email.to).to eq([petition.creator_signature.email])
+            expect(email.to).to be_blank
+            expect(email.bcc).to include(petition.creator_signature.email)
             expect(email.subject).to match(/We rejected your petition “[^"]+”/)
           end
           it "sends an email to validated petition sponsors" do
             validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
+            expect(email.bcc).to include(validated_sponsor_1.signature.email)
+            expect(email.bcc).to include(validated_sponsor_2.signature.email)
           end
           it "does not send an email to pending petition sponsors" do
             pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).not_to include(pending_sponsor.signature.email)
           end
         end
 

--- a/spec/controllers/admin/take_down_controller_spec.rb
+++ b/spec/controllers/admin/take_down_controller_spec.rb
@@ -124,10 +124,11 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
           end
 
-          it "sends an email to the petition creator" do
+          it "sends an email to the petition creator using Bcc: and not To:" do
             do_patch
             expect(email.from).to eq(["no-reply@petition.parliament.uk"])
-            expect(email.to).to eq([petition.creator_signature.email])
+            expect(email.to).to be_blank
+            expect(email.bcc).to include(petition.creator_signature.email)
             expect(email.subject).to match(/We rejected your petition/)
           end
 
@@ -135,13 +136,14 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
+            expect(email.bcc).to include(validated_sponsor_1.signature.email)
+            expect(email.bcc).to include(validated_sponsor_2.signature.email)
           end
 
           it "does not send an email to pending petition sponsors" do
             pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).not_to include(pending_sponsor.signature.email)
           end
         end
 
@@ -169,10 +171,11 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
           end
 
-          it "sends an email to the petition creator" do
+          it "sends an email to the petition creator via Bcc: and not To:" do
             do_patch
             expect(email.from).to eq(["no-reply@petition.parliament.uk"])
-            expect(email.to).to eq([petition.creator_signature.email])
+            expect(email.to).to be_blank
+            expect(email.bcc).to include(petition.creator_signature.email)
             expect(email.subject).to match(/We rejected your petition/)
           end
 
@@ -180,13 +183,14 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             validated_sponsor_1  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             validated_sponsor_2  = FactoryGirl.create(:sponsor, :validated, petition: petition)
             do_patch
-            expect(email.bcc).to match_array([validated_sponsor_1.signature.email, validated_sponsor_2.signature.email])
+            expect(email.bcc).to include(validated_sponsor_1.signature.email)
+            expect(email.bcc).to include(validated_sponsor_2.signature.email)
           end
 
           it "does not send an email to pending petition sponsors" do
             pending_sponsor = FactoryGirl.create(:sponsor, :pending, petition: petition)
             do_patch
-            expect(email.bcc).not_to include([pending_sponsor.signature.email])
+            expect(email.bcc).not_to include(pending_sponsor.signature.email)
           end
         end
 


### PR DESCRIPTION
The rejection email is blind-copied to all of the validated sponsors which reveals the creator's email address. One way of preventing this information disclosure is to send to the creator via bcc as well.

Fixes #450.