### PR TITLE
Move tokens from a path param to a query param

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -45,20 +45,24 @@ class SignaturesController < ApplicationController
   end
 
   def unsubscribe
-    @signature.unsubscribe!(params[:token])
+    @signature.unsubscribe!(token_param)
   end
 
   private
 
+  def token_param
+    @token_param ||= (params[:token] || params[:legacy_token]).to_s
+  end
+
   def verify_token
-    unless @signature.perishable_token == params[:token]
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with token: #{params[:token].inspect}"
+    unless @signature.perishable_token == token_param
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with token: token_param.inspect}"
     end
   end
 
   def verify_unsubscribe_token
-    unless @signature.unsubscribe_token == params[:token]
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with unsubscribe token: #{params[:token].inspect}"
+    unless @signature.unsubscribe_token == token_param
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with unsubscribe token: #{token_param.inspect}"
     end
   end
 

--- a/app/views/petition_mailer/email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.html.erb
@@ -1,6 +1,6 @@
 <p>Click this link to sign the petition "<%= @petition.action %>"</p>
 
-<p><%= link_to nil, verify_signature_url(@signature, @signature.perishable_token) %></p>
+<p><%= link_to nil, verify_signature_url(@signature, token: @signature.perishable_token) %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.text.erb
@@ -1,6 +1,6 @@
 Click this link to sign the petition "<%= @petition.action %>"
 
-<%= verify_signature_url(@signature, @signature.perishable_token) %>
+<%= verify_signature_url(@signature, token: @signature.perishable_token) %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petition_mailer/email_creator.html.erb
+++ b/app/views/petition_mailer/email_creator.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -15,4 +15,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/email_creator.text.erb
+++ b/app/views/petition_mailer/email_creator.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -15,4 +15,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/email_signer.html.erb
+++ b/app/views/petition_mailer/email_signer.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -15,4 +15,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/email_signer.text.erb
+++ b/app/views/petition_mailer/email_signer.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -15,4 +15,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -38,4 +38,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -39,4 +39,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -18,4 +18,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -18,4 +18,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -30,4 +30,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -30,4 +30,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -39,4 +39,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -18,4 +18,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -18,4 +18,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -30,4 +30,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -30,4 +30,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %>
+To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.html.erb
@@ -4,7 +4,7 @@
 
 <p>Click this link to sign the petition:</p>
 
-<p><%= link_to nil, verify_signature_url(@signature, @signature.perishable_token) %></p>
+<p><%= link_to nil, verify_signature_url(@signature, token: @signature.perishable_token) %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
+++ b/app/views/petition_mailer/special_resend_of_email_confirmation_for_signer.text.erb
@@ -4,7 +4,7 @@ We noticed that you tried to sign the petition "<%= @petition.action %>" but hav
 
 Click this link to sign the petition:
 
-<%= verify_signature_url(@signature, @signature.perishable_token) %>
+<%= verify_signature_url(@signature, token: @signature.perishable_token) %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.html.erb
+++ b/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.html.erb
@@ -1,6 +1,6 @@
 <p>Click this link to sign the petition “<%= @petition.action %>”</p>
 
-<p><%= link_to nil, verify_signature_url(@signature, @signature.perishable_token) %></p>
+<p><%= link_to nil, verify_signature_url(@signature, token: @signature.perishable_token) %></p>
 
 <hr />
 
@@ -17,4 +17,4 @@
 <hr />
 
 <p>Click this link to sign the petition:<br />
-<%= link_to nil, verify_signature_url(@signature, @signature.perishable_token) %></p>
+<%= link_to nil, verify_signature_url(@signature, token: @signature.perishable_token) %></p>

--- a/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.text.erb
+++ b/app/views/sponsor_mailer/petition_and_email_confirmation_for_sponsor.text.erb
@@ -1,6 +1,6 @@
 Click this link to sign the petition "<%= @petition.action %>"
 
-<%= verify_signature_url(@signature, @signature.perishable_token) %>
+<%= verify_signature_url(@signature, token: @signature.perishable_token) %>
 
 --
 
@@ -17,4 +17,4 @@ Click this link to sign the petition "<%= @petition.action %>"
 --
 
 Click this link to sign the petition:
-<%= verify_signature_url(@signature, @signature.perishable_token) %>
+<%= verify_signature_url(@signature, token: @signature.perishable_token) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,9 +39,9 @@ Rails.application.routes.draw do
     post 'petitions/new' => 'petitions#create', :as => :create_petition
 
     scope 'signatures/:id' do
-      get 'verify/:token' => 'signatures#verify', :as => :verify_signature
-      get 'unsubscribe/:unsubscribe_token' => 'signatures#unsubscribe', :as => :unsubscribe_signature
-      get 'signed/:token' => 'signatures#signed', :as => :signed_signature
+      get 'verify' => 'signatures#verify', :as => :verify_signature
+      get 'unsubscribe' => 'signatures#unsubscribe', :as => :unsubscribe_signature
+      get 'signed' => 'signatures#signed', :as => :signed_signature
     end
 
     namespace :archived do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,9 +39,9 @@ Rails.application.routes.draw do
     post 'petitions/new' => 'petitions#create', :as => :create_petition
 
     scope 'signatures/:id' do
-      get 'verify' => 'signatures#verify', :as => :verify_signature
-      get 'unsubscribe' => 'signatures#unsubscribe', :as => :unsubscribe_signature
-      get 'signed' => 'signatures#signed', :as => :signed_signature
+      get 'verify(/:legacy_token)' => 'signatures#verify', :as => :verify_signature
+      get 'unsubscribe(/:legacy_token)' => 'signatures#unsubscribe', :as => :unsubscribe_signature
+      get 'signed(/:legacy_token)' => 'signatures#signed', :as => :signed_signature
     end
 
     namespace :archived do

--- a/features/step_definitions/unsubscription_steps.rb
+++ b/features/step_definitions/unsubscription_steps.rb
@@ -1,7 +1,7 @@
 Then /^Suzie should have received a petition response email with an unsubscription link$/ do
   expect(unread_emails_for(@suzies_signature.email).size).to eq 1
   open_email(@suzies_signature.email)
-  unsubscription_url = unsubscribe_signature_url(@suzies_signature, @suzies_signature.unsubscribe_token)
+  unsubscription_url = unsubscribe_signature_url(@suzies_signature, token: @suzies_signature.unsubscribe_token)
   expect(current_email.default_part_body.to_s).to include(unsubscription_url)
 end
 

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SignaturesController, type: :controller do
       it "redirects to the petition signed page" do
         get :verify, :id => signature.id, :token => signature.perishable_token
         expect(assigns[:signature]).to eq(signature)
-        expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.to_param}/signed/#{signature.perishable_token}")
+        expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.to_param}/signed?token=#{signature.perishable_token}")
       end
 
       it "raises exception if id not found" do
@@ -97,7 +97,7 @@ RSpec.describe SignaturesController, type: :controller do
         it "redirects to the petition signed page" do
           get :verify, :id => signature.id, :token => signature.perishable_token
           expect(assigns[:signature]).to eq(signature)
-          expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.to_param}/signed/#{signature.perishable_token}")
+          expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.to_param}/signed?token=#{signature.perishable_token}")
         end
 
         it "does not send an email to the creator" do
@@ -178,7 +178,7 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "redirects to the signature verify page" do
         make_signed_request
-        expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.id}/verify/#{signature.perishable_token}")
+        expect(response).to redirect_to("https://petition.parliament.uk/signatures/#{signature.id}/verify?token=#{signature.perishable_token}")
       end
 
       it "raises exception if token does not match" do
@@ -439,7 +439,7 @@ RSpec.describe SignaturesController, type: :controller do
   end
 
   describe '#unsubscribe' do
-    let(:signature) { double(:signature) }
+    let(:signature) { double(:signature, id: 1, unsubscribe_token: "token") }
     let(:petition) { double(:petition) }
 
     before do
@@ -447,7 +447,7 @@ RSpec.describe SignaturesController, type: :controller do
       expect(signature).to receive(:petition).and_return(petition)
       expect(signature).to receive(:unsubscribe!).with("token")
 
-      get :unsubscribe, id: "1", unsubscribe_token: "token"
+      get :unsubscribe, id: "1", token: "token"
     end
 
     it "renders the action template" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -221,6 +221,10 @@ FactoryGirl.define do
     state                         Signature::VALIDATED_STATE
     validated_at                  { Time.current }
     seen_signed_confirmation_page true
+
+    trait :just_signed do
+      seen_signed_confirmation_page false
+    end
   end
 
   sequence(:sponsor_email) { |n| "sponsor#{n}@example.com" }

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe PetitionMailer, type: :mailer do
         end
 
         it "includes an unsubscribe link" do
-          expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
         end
       end
 
@@ -277,7 +277,7 @@ RSpec.describe PetitionMailer, type: :mailer do
         end
 
         it "includes an unsubscribe link" do
-          expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
         end
       end
 
@@ -388,7 +388,7 @@ RSpec.describe PetitionMailer, type: :mailer do
       end
 
       it "includes an unsubscribe link" do
-        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
       end
     end
 
@@ -447,7 +447,7 @@ RSpec.describe PetitionMailer, type: :mailer do
       end
 
       it "includes an unsubscribe link" do
-        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
       end
 
       it "includes the message body" do

--- a/spec/mailers/sponsor_mailer_spec.rb
+++ b/spec/mailers/sponsor_mailer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SponsorMailer, type: :mailer do
     end
 
     it "includes the verification url for the sponsor's signature" do
-      expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{sponsor.signature.id}/verify/#{sponsor.signature.perishable_token}])
+      expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{sponsor.signature.id}/verify\?token=#{sponsor.signature.perishable_token}])
     end
 
     it "includes the petition action" do

--- a/spec/requests/legacy_token_spec.rb
+++ b/spec/requests/legacy_token_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "legacy tokens", type: :request do
+  let(:petition) { FactoryGirl.create(:open_petition) }
+
+  before do
+    stub_any_api_request
+  end
+
+  describe "when verifying the signature" do
+    let(:signature) { FactoryGirl.create(:pending_signature, petition: petition) }
+
+    before do
+      get "/signatures/#{signature.id}/verify/#{signature.perishable_token}"
+    end
+
+    it "verifies the signature" do
+      expect(signature.reload).to be_validated
+    end
+  end
+
+  describe "when viewing the signed page" do
+    let(:signature) { FactoryGirl.create(:validated_signature, :just_signed, petition: petition) }
+
+    before do
+      get "/signatures/#{signature.id}/signed/#{signature.perishable_token}"
+    end
+
+    it "shows the signed page" do
+      expect(response.body).to match(/We've added your signature to the petition/)
+    end
+  end
+
+  describe "when unsubscribing" do
+    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition) }
+
+    before do
+      get "/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}"
+    end
+
+    it "unsubscribes the signer" do
+      expect(signature.reload).to be_unsubscribed
+    end
+  end
+end

--- a/spec/requests/missing_tokens_spec.rb
+++ b/spec/requests/missing_tokens_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "missing a 'token'", type: :request, show_exceptions: true do
+  let(:petition) { FactoryGirl.create(:open_petition) }
+
+  describe "when verifying the signature" do
+    let(:signature) { FactoryGirl.create(:pending_signature, petition: petition) }
+
+    before do
+      get "/signatures/#{signature.id}/verify"
+    end
+
+    it "returns 404 Not Found" do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "when viewing the signed page" do
+    let(:signature) { FactoryGirl.create(:validated_signature, :just_signed, petition: petition) }
+
+    before do
+      get "/signatures/#{signature.id}/signed"
+    end
+
+    it "returns 404 Not Found" do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "when unsubscribing" do
+    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition) }
+
+    before do
+      get "/signatures/#{signature.id}/unsubscribe"
+    end
+
+    it "returns 404 Not Found" do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/routing/signatures_spec.rb
+++ b/spec/routing/signatures_spec.rb
@@ -40,24 +40,24 @@ RSpec.describe "routes for signatures", type: :routes do
 
   # un-nested routes
   it "routes GET /signatures/:id/verify/:token to signatures#verify" do
-    expect({:get => "/signatures/1/verify/abcdef1234567890"}).
+    expect({:get => "/signatures/1/verify?token=abcdef1234567890"}).
       to route_to("signatures#verify", id: '1', token: 'abcdef1234567890')
 
-    expect(verify_signature_path('1', 'abcdef1234567890')).to eq('/signatures/1/verify/abcdef1234567890')
+    expect(verify_signature_path('1', token: 'abcdef1234567890')).to eq('/signatures/1/verify?token=abcdef1234567890')
   end
 
   it "routes GET /signatures/:id/unsubscribe/:token to signatures#unsubscribe" do
-    expect({:get => "/signatures/1/unsubscribe/abcdef1234567890"}).
-      to route_to("signatures#unsubscribe", id: '1', unsubscribe_token: 'abcdef1234567890')
+    expect({:get => "/signatures/1/unsubscribe?token=abcdef1234567890"}).
+      to route_to("signatures#unsubscribe", id: '1', token: 'abcdef1234567890')
 
-    expect(unsubscribe_signature_path('1', 'abcdef1234567890')).to eq('/signatures/1/unsubscribe/abcdef1234567890')
+    expect(unsubscribe_signature_path('1', token: 'abcdef1234567890')).to eq('/signatures/1/unsubscribe?token=abcdef1234567890')
   end
 
   it "routes GET /signatures/:id/signed/:token to signatures#signed" do
-    expect({:get => "/signatures/1/signed/abcdef1234567890"}).
+    expect({:get => "/signatures/1/signed?token=abcdef1234567890"}).
       to route_to("signatures#signed", id: '1', token: 'abcdef1234567890')
 
-    expect(signed_signature_path('1', 'abcdef1234567890')).to eq('/signatures/1/signed/abcdef1234567890')
+    expect(signed_signature_path('1', token: 'abcdef1234567890')).to eq('/signatures/1/signed?token=abcdef1234567890')
   end
 
   it "doesn't route GET /signatures" do


### PR DESCRIPTION
When we get more than 50,000+ signatures in a day Google Analytics will send a 'Too many URLs' alert because the tokens are embedded in the path, thus making each one a unique URL.

We can't tell GA to ignore parts of the URL but it can [ignore named query parameters][1], so by moving the token to a query parameter we can ignore it and prevent any future alerts.

Fixes #448.

[1]: https://support.google.com/analytics/answer/1010249?hl=en