### PR TITLE
Revert "Remove debate scheduled emails"

### DIFF
--- a/app/controllers/admin/schedule_debate_controller.rb
+++ b/app/controllers/admin/schedule_debate_controller.rb
@@ -8,7 +8,13 @@ class Admin::ScheduleDebateController < Admin::AdminController
 
   def update
     if @petition.update_attributes(params_for_update)
-      message = 'Updated the scheduled debate date successfully'
+      if send_email_to_petitioners?
+        EmailDebateScheduledJob.run_later_tonight(petition: @petition)
+        message = 'Email will be sent overnight'
+      else
+        message = 'Updated the scheduled debate date successfully'
+      end
+
       redirect_to [:admin, @petition], notice: message
     else
       render 'admin/petitions/show'
@@ -23,5 +29,9 @@ class Admin::ScheduleDebateController < Admin::AdminController
 
   def params_for_update
     params.require(:petition).permit(:scheduled_debate_date)
+  end
+
+  def send_email_to_petitioners?
+    params.key?(:save_and_email)
   end
 end

--- a/app/jobs/deliver_debate_scheduled_email_job.rb
+++ b/app/jobs/deliver_debate_scheduled_email_job.rb
@@ -1,0 +1,11 @@
+class DeliverDebateScheduledEmailJob < ActiveJob::Base
+  include EmailDelivery
+
+  def create_email
+    if signature.creator?
+      mailer.notify_creator_of_debate_scheduled signature.petition, signature
+    else
+      mailer.notify_signer_of_debate_scheduled signature.petition, signature
+    end
+  end
+end

--- a/app/jobs/email_debate_scheduled_job.rb
+++ b/app/jobs/email_debate_scheduled_job.rb
@@ -1,0 +1,6 @@
+class EmailDebateScheduledJob < ActiveJob::Base
+  include EmailAllPetitionSignatories
+
+  self.email_delivery_job_class = DeliverDebateScheduledEmailJob
+  self.timestamp_name = 'debate_scheduled'
+end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -77,6 +77,16 @@ class PetitionMailer < ApplicationMailer
     end
   end
 
+  def notify_signer_of_debate_scheduled(petition, signature)
+    @petition, @signature = petition, signature
+    mail to: @signature.email, subject: subject_for(:notify_signer_of_debate_scheduled)
+  end
+
+  def notify_creator_of_debate_scheduled(petition, signature)
+    @petition, @signature = petition, signature
+    mail to: @signature.email, subject: subject_for(:notify_creator_of_debate_scheduled)
+  end
+
   private
 
   def subject_for(key, options = {})

--- a/app/views/admin/schedule_debate/_petition_action_debate_date.html.erb
+++ b/app/views/admin/schedule_debate/_petition_action_debate_date.html.erb
@@ -6,5 +6,6 @@
     <%= f.date_field :scheduled_debate_date, tabindex: increment, class: 'form-control' %>
   <% end %>
 
-  <%= f.submit "Save", name: 'save', class: 'button' %>
+  <%= email_petitioners_with_count_submit_button(f, petition) %>
+  <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
 <% end %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -90,6 +90,8 @@ en-GB:
           Parliament debated “%{action}”
         notify_signer_of_negative_debate_outcome: |-
           Parliament didn’t debate “%{action}”
+        notify_signer_of_debate_scheduled: |-
+          Parliament will debate “%{action}”
         notify_signer_of_threshold_response: |-
           Government responded to “%{action}”
 
@@ -100,6 +102,8 @@ en-GB:
           Parliament debated “%{action}”
         notify_creator_of_negative_debate_outcome: |-
           Parliament didn’t debate “%{action}”
+        notify_creator_of_debate_scheduled: |-
+          Parliament will debate “%{action}”
         notify_creator_of_threshold_response: |-
           Government responded to “%{action}”
 

--- a/features/admin/moderator_updates_petition_scheduled_debate_date.feature
+++ b/features/admin/moderator_updates_petition_scheduled_debate_date.feature
@@ -7,8 +7,8 @@ Feature: Moderator updates petition scheduled debate date
     When I view all petitions
     And I follow "More money for charities"
     And I follow "Scheduled debate date"
-    Then I should not see "Email 6 petitioners"
-    When I fill in "Scheduled debate date" with "06/12/2015"
-    And I press "Save"
-    Then I should see "Updated the scheduled debate date successfully"
-    And no emails have been sent
+    And I fill in "Scheduled debate date" with "06/12/2015"
+    And I press "Email 6 petitioners"
+    Then I should see "Email will be sent overnight"
+    And the petition creator should have been emailed about the scheduled debate
+    And all the signatories of the petition should have been emailed about the scheduled debate

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -49,7 +49,7 @@ World(EmailHelpers)
 # This is done automatically before each scenario.
 #
 
-Given /^(?:a clear email queue)$/ do
+Given /^(?:a clear email queue|no emails have been sent)$/ do
   reset_mailer
 end
 
@@ -71,10 +71,6 @@ end
 
 Then /^(?:I|they|"([^"]*?)") should receive an email with the following body:$/ do |address, expected_body|
   open_email(address, :with_text => expected_body)
-end
-
-Then(/^no emails have been sent$/) do
-  expect(all_emails).to be_empty
 end
 
 #

--- a/spec/controllers/admin/schedule_debate_controller_spec.rb
+++ b/spec/controllers/admin/schedule_debate_controller_spec.rb
@@ -94,6 +94,180 @@ RSpec.describe Admin::ScheduleDebateController, type: :controller, admin: true d
         }
       end
 
+      context 'when clicking the Email button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            petition: scheduled_debate_date_attributes,
+            save_and_email: "Email"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'scheduling a debate date for a petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their email will be sent overnight' do
+              do_patch
+              expect(flash[:notice]).to eq 'Email will be sent overnight'
+            end
+
+            it 'stores the supplied scheduled debate date against the petition in the db' do
+              do_patch
+              petition.reload
+              expect(petition.scheduled_debate_date).to eq Date.parse('2014-12-01')
+            end
+
+            describe "emails out debate scheduled response" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+                  s = FactoryGirl.create(:pending_signature, attributes)
+                  s.validate!
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  s = FactoryGirl.create(:pending_signature, attributes)
+                  s.validate!
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+                  FactoryGirl.create(:pending_signature, attributes)
+                end
+                petition.reload
+              end
+
+              it "queues a job to process the emails" do
+                assert_enqueued_jobs 1 do
+                  do_patch
+                end
+              end
+
+              it "stamps the 'debate_scheduled' email sent receipt on each signature when the job runs" do
+                perform_enqueued_jobs do
+                  do_patch
+                  petition.reload
+                  petition_timestamp = petition.get_email_requested_at_for('debate_scheduled')
+                  expect(petition_timestamp).not_to be_nil
+                  petition.signatures.validated.notify_by_email.each do |signature|
+                    expect(signature.get_email_sent_at_for('debate_scheduled')).to eq(petition_timestamp)
+                  end
+                end
+              end
+
+              it "should email out to the validated signees who have opted in when the delayed job runs" do
+                ActionMailer::Base.deliveries.clear
+                perform_enqueued_jobs do
+                  do_patch
+                  expect(ActionMailer::Base.deliveries.length).to eq 4
+                  expect(ActionMailer::Base.deliveries.map(&:to)).to eq([
+                    [petition.creator_signature.email],
+                    ['laura_0@example.com'],
+                    ['laura_1@example.com'],
+                    ['laura_2@example.com']
+                  ])
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            before do
+              # NOTE this can't fail as there's no validation
+              allow_any_instance_of(Petition).to receive(:valid?) do |receiver|
+                receiver.errors.add(:base, 'this is all messed up')
+                false
+              end
+            end
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:petition).errors).to be_present
+            end
+
+            it 'does not store the supplied debate scheduled date in the db' do
+              do_patch
+              petition.reload
+              expect(petition.scheduled_debate_date).to be_nil
+            end
+          end
+        end
+
+        shared_examples_for 'scheduling a debate date' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'stores the supplied schedule date on the petition' do
+            do_patch
+            petition.reload
+            expect(petition.scheduled_debate_date).to eq Date.parse('2014-12-01')
+          end
+        end
+
+        describe 'for an open petition' do
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a pending petition' do
+          before { petition.update_column(:state, Petition::PENDING_STATE) }
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a validated petition' do
+          before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a sponsored petition' do
+          before { petition.update_column(:state, Petition::SPONSORED_STATE) }
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a rejected petition' do
+          before { petition.update_columns(state: Petition::REJECTED_STATE) }
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a hidden petition' do
+          before { petition.update_column(:state, Petition::HIDDEN_STATE) }
+          it_behaves_like 'scheduling a debate date'
+        end
+      end
+
       context 'when clicking the Save button' do
         def do_patch(overrides = {})
           params = {

--- a/spec/jobs/deliver_debate_scheduled_email_job_spec.rb
+++ b/spec/jobs/deliver_debate_scheduled_email_job_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require_relative 'shared_examples'
+
+RSpec.describe DeliverDebateScheduledEmailJob, type: :job do
+  let(:requested_at) { Time.current.change(usec: 0) }
+  let(:requested_at_as_string) { requested_at.getutc.iso8601(6) }
+
+  let(:petition) { FactoryGirl.create(:awaiting_debate_petition) }
+  let(:signature) { FactoryGirl.create(:validated_signature, petition: petition) }
+  let(:timestamp_name) { 'debate_scheduled' }
+
+  let :arguments do
+    {
+      signature: signature,
+      timestamp_name: timestamp_name,
+      petition: petition,
+      requested_at: requested_at_as_string
+    }
+  end
+
+  before do
+    petition.set_email_requested_at_for(timestamp_name, to: requested_at)
+  end
+
+  it_behaves_like "a job to send an signatory email"
+
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+end

--- a/spec/jobs/email_debate_scheduled_job_spec.rb
+++ b/spec/jobs/email_debate_scheduled_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require_relative 'shared_examples'
+
+RSpec.describe EmailDebateScheduledJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:open_petition) }
+  let(:signature) { FactoryGirl.create(:validated_signature, :petition => petition) }
+  let(:arguments) { { petition: petition } }
+
+  before do
+    petition.set_email_requested_at_for('debate_scheduled', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+  end
+
+  it_behaves_like "job to enqueue signatory mailing jobs"
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -369,6 +369,60 @@ RSpec.describe PetitionMailer, type: :mailer do
     end
   end
 
+  describe "notifying signature of debate scheduled" do
+    let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, creator_signature_attributes: { name: "Bob Jones", email: "bob@jones.com" }, action: "Allow organic vegetable vans to use red diesel") }
+
+    shared_examples_for "a debate scheduled email" do
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear #{signature.name},")
+      end
+
+      it "sends it only to the signatory" do
+        expect(mail.to).to eq([signature.email])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe/#{signature.unsubscribe_token}])
+      end
+    end
+
+    context "when the signature is the creator" do
+      let(:signature) { petition.creator_signature }
+      subject(:mail) { described_class.notify_creator_of_debate_scheduled(petition, signature) }
+
+      it_behaves_like "a debate scheduled email"
+
+      it "has the correct subject" do
+        expect(mail).to have_subject("Parliament will debate “Allow organic vegetable vans to use red diesel”")
+      end
+
+      it "identifies them as the creator" do
+        expect(mail).to have_body_text(%[Parliament is going to debate your petition])
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { FactoryGirl.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
+      subject(:mail) { described_class.notify_signer_of_debate_scheduled(petition, signature) }
+
+      it_behaves_like "a debate scheduled email"
+
+      it "has the correct subject" do
+        expect(mail).to have_subject("Parliament will debate “Allow organic vegetable vans to use red diesel”")
+      end
+
+      it "identifies them as a ordinary signature" do
+        expect(mail).to have_body_text(%[Parliament is going to debate the petition you signed])
+      end
+    end
+  end
+
   describe "emailing a signature" do
     let(:petition) { FactoryGirl.create(:open_petition, :scheduled_for_debate, creator_signature_attributes: { name: "Bob Jones", email: "bob@jones.com" }, action: "Allow organic vegetable vans to use red diesel") }
     let(:email) { FactoryGirl.create(:petition_email, petition: petition, subject: "This is a message from the committee", body: "Message body from the petition committee") }


### PR DESCRIPTION
Reverts alphagov/e-petitions#464 - this should not have been merged because we're not sure it's a good idea yet.