### PR TITLE
Send individual emails to sponsors

### DIFF
--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -4,12 +4,7 @@ class Admin::ModerationController < Admin::AdminController
 
   def update
     if @petition.moderate(moderation_params)
-      if @petition.published?
-        send_published_email
-      elsif @petition.rejected? || @petition.hidden?
-        send_rejected_email
-      end
-
+      send_notifications
       redirect_to [:admin, @petition]
     else
       render 'admin/petitions/show'
@@ -26,16 +21,7 @@ class Admin::ModerationController < Admin::AdminController
     params.require(:petition).permit(:moderation, rejection: [:code, :details])
   end
 
-  def send_published_email
-    NotifyCreatorThatPetitionIsPublishedEmailJob.perform_later(@petition.creator_signature)
-
-    @petition.sponsor_signatures.each do |signature|
-      next unless signature.validated?
-      NotifySponsorThatPetitionIsPublishedEmailJob.perform_later(signature)
-    end
-  end
-
-  def send_rejected_email
-    PetitionMailer.petition_rejected(@petition).deliver_now
+  def send_notifications
+    NotifyEveryoneOfModerationDecisionJob.perform_later(@petition)
   end
 end

--- a/app/controllers/admin/take_down_controller.rb
+++ b/app/controllers/admin/take_down_controller.rb
@@ -8,7 +8,7 @@ class Admin::TakeDownController < Admin::AdminController
 
   def update
     if @petition.reject(rejection_params[:rejection])
-      send_rejection_email
+      send_notifications
       redirect_to [:admin, @petition]
     else
       render 'admin/petitions/show'
@@ -25,7 +25,7 @@ class Admin::TakeDownController < Admin::AdminController
     params.require(:petition).permit(rejection: [:code, :details])
   end
 
-  def send_rejection_email
-    PetitionMailer.petition_rejected(@petition).deliver_now
+  def send_notifications
+    NotifyEveryoneOfModerationDecisionJob.perform_later(@petition)
   end
 end

--- a/app/jobs/notify_creator_that_petition_was_rejected_email_job.rb
+++ b/app/jobs/notify_creator_that_petition_was_rejected_email_job.rb
@@ -1,0 +1,4 @@
+class NotifyCreatorThatPetitionWasRejectedEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_creator_that_petition_was_rejected
+end

--- a/app/jobs/notify_everyone_of_moderation_decision_job.rb
+++ b/app/jobs/notify_everyone_of_moderation_decision_job.rb
@@ -1,0 +1,34 @@
+class NotifyEveryoneOfModerationDecisionJob < ActiveJob::Base
+  rescue_from StandardError do |exception|
+    Appsignal.send_exception exception
+  end
+
+  def perform(petition)
+    creator = petition.creator_signature
+    sponsors = petition.sponsor_signatures.select(&:validated?)
+
+    if petition.published?
+      notify_everyone_of_publication(creator, sponsors)
+    elsif petition.rejected? || petition.hidden?
+      notify_everyone_of_rejection(creator, sponsors)
+    end
+  end
+
+  private
+
+  def notify_everyone_of_publication(creator, sponsors)
+    NotifyCreatorThatPetitionIsPublishedEmailJob.perform_later(creator)
+
+    sponsors.each do |sponsor|
+      NotifySponsorThatPetitionIsPublishedEmailJob.perform_later(sponsor)
+    end
+  end
+
+  def notify_everyone_of_rejection(creator, sponsors)
+    NotifyCreatorThatPetitionWasRejectedEmailJob.perform_later(creator)
+
+    sponsors.each do |sponsor|
+      NotifySponsorThatPetitionWasRejectedEmailJob.perform_later(sponsor)
+    end
+  end
+end

--- a/app/jobs/notify_sponsor_that_petition_was_rejected_email_job.rb
+++ b/app/jobs/notify_sponsor_that_petition_was_rejected_email_job.rb
@@ -1,0 +1,4 @@
+class NotifySponsorThatPetitionWasRejectedEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_sponsor_that_petition_was_rejected
+end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -31,10 +31,14 @@ class PetitionMailer < ApplicationMailer
     mail to: @signature.email, subject: subject_for(:notify_sponsor_that_petition_is_published)
   end
 
-  def petition_rejected(petition)
-    @petition, @rejection, @creator = petition, petition.rejection, petition.creator_signature
-    bcc = @petition.sponsor_signatures.validated.map(&:email)
-    mail to: @creator.email, bcc: bcc, subject: subject_for(:petition_rejected)
+  def notify_creator_that_petition_was_rejected(signature)
+    @signature, @petition, @rejection = signature, signature.petition, signature.petition.rejection
+    mail to: @signature.email, subject: subject_for(:notify_creator_that_petition_was_rejected)
+  end
+
+  def notify_sponsor_that_petition_was_rejected(signature)
+    @signature, @petition, @rejection = signature, signature.petition, signature.petition.rejection
+    mail to: @signature.email, subject: subject_for(:notify_sponsor_that_petition_was_rejected)
   end
 
   def notify_signer_of_threshold_response(petition, signature)

--- a/app/views/petition_mailer/notify_creator_that_petition_was_rejected.html.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_was_rejected.html.erb
@@ -1,0 +1,24 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>We rejected the petition you created – “<%= @petition.action %>”.
+
+<%= rejection_description(@rejection.code) %>
+<% if @rejection.details? -%>
+
+<p><%= auto_link(h(@rejection.details)) %></p>
+<% end -%>
+<% unless @petition.hidden? -%>
+
+<p>Click this link to see your rejected petition:<br />
+<%= link_to 'View your rejected petition', petition_url(@petition) %></p>
+<% end -%>
+
+<p>We only reject petitions that don’t meet the petition standards:<br />
+<%= link_to nil, help_url(anchor: 'standards') %></p>
+
+<p>If you want to try again, click here to start a petition:<br />
+<%= link_to nil, check_petitions_url %></p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_creator_that_petition_was_rejected.text.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_was_rejected.text.erb
@@ -1,0 +1,24 @@
+Dear <%= @signature.name %>,
+
+We rejected the petition you created – "<%= @petition.action %>".
+
+<%= strip_tags(rejection_description(@rejection.code)) %>
+<% if @rejection.details? -%>
+
+<%= @rejection.details %>
+<% end -%>
+<% unless @petition.hidden? -%>
+
+Click this link to see your rejected petition:
+<%= petition_url(@petition) %>
+<% end -%>
+
+We only reject petitions that don’t meet the petition standards:
+<%= help_url(anchor: 'standards') %>
+
+If you want to try again, click here to start a petition:
+<%= check_petitions_url %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/notify_sponsor_that_petition_was_rejected.html.erb
+++ b/app/views/petition_mailer/notify_sponsor_that_petition_was_rejected.html.erb
@@ -1,6 +1,6 @@
-<p>Dear <%= @petition.creator_signature.name %>,</p>
+<p>Dear <%= @signature.name %>,</p>
 
-<p>We rejected the petition you created – “<%= @petition.action %>”.
+<p>We rejected the petition you supported – “<%= @petition.action %>”.
 
 <%= rejection_description(@rejection.code) %>
 <% if @rejection.details? -%>
@@ -9,15 +9,12 @@
 <% end -%>
 <% unless @petition.hidden? -%>
 
-<p>Click this link to see your rejected petition:<br />
-<%= link_to 'View your rejected petition', petition_url(@petition) %></p>
+<p>Click this link to see the rejected petition:<br />
+<%= link_to 'View the rejected petition', petition_url(@petition) %></p>
 <% end -%>
 
 <p>We only reject petitions that don’t meet the petition standards:<br />
 <%= link_to nil, help_url(anchor: 'standards') %></p>
-
-<p>If you want to try again, click here to start a petition:<br />
-<%= link_to nil, check_petitions_url %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/notify_sponsor_that_petition_was_rejected.text.erb
+++ b/app/views/petition_mailer/notify_sponsor_that_petition_was_rejected.text.erb
@@ -1,6 +1,6 @@
-Dear <%= @creator.name %>,
+Dear <%= @signature.name %>,
 
-We rejected the petition you created – "<%= @petition.action %>".
+We rejected the petition you supported – "<%= @petition.action %>".
 
 <%= strip_tags(rejection_description(@rejection.code)) %>
 <% if @rejection.details? -%>
@@ -9,15 +9,12 @@ We rejected the petition you created – "<%= @petition.action %>".
 <% end -%>
 <% unless @petition.hidden? -%>
 
-Click this link to see your rejected petition:
+Click this link to see the rejected petition:
 <%= petition_url(@petition) %>
 <% end -%>
 
 We only reject petitions that don’t meet the petition standards:
 <%= help_url(anchor: 'standards') %>
-
-If you want to try again, click here to start a petition:
-<%= check_petitions_url %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -114,8 +114,10 @@ en-GB:
           We published your petition “%{action}”
         notify_sponsor_that_petition_is_published: |-
           We published the petition “%{action}” that you supported
-        petition_rejected: |-
+        notify_creator_that_petition_was_rejected: |-
           We rejected your petition “%{action}”
+        notify_sponsor_that_petition_was_rejected: |-
+          We rejected the petition “%{action}” that you supported
 
         # Re-send confirmation emails
         special_resend_of_email_confirmation_for_signer: |-

--- a/spec/jobs/email_job_spec.rb
+++ b/spec/jobs/email_job_spec.rb
@@ -164,6 +164,32 @@ RSpec.describe NotifySponsorThatPetitionIsPublishedEmailJob, type: :job do
   end
 end
 
+RSpec.describe NotifyCreatorThatPetitionWasRejectedEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:rejected_petition) }
+  let(:signature) { FactoryGirl.create(:signature, petition: petition) }
+
+  it "sends the PetitionMailer#notify_creator_that_petition_was_rejected email" do
+    expect(PetitionMailer).to receive(:notify_creator_that_petition_was_rejected).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
+RSpec.describe NotifySponsorThatPetitionWasRejectedEmailJob, type: :job do
+  let(:petition) { FactoryGirl.create(:rejected_petition) }
+  let(:signature) { FactoryGirl.create(:validated_signature, petition: petition) }
+
+  it "sends the PetitionMailer#notify_sponsor_that_petition_was_rejected email" do
+    expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_rejected).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
 RSpec.describe PetitionAndEmailConfirmationForSponsorEmailJob, type: :job do
   let(:petition) { FactoryGirl.create(:petition) }
   let(:sponsor) { FactoryGirl.create(:sponsor, :pending, petition: petition) }

--- a/spec/jobs/notify_everyone_of_moderation_decision_job_spec.rb
+++ b/spec/jobs/notify_everyone_of_moderation_decision_job_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
+  let(:petition) { FactoryGirl.create(:pending_petition, sponsor_count: 0) }
+  let(:creator) { petition.creator_signature }
+  let(:validated_sponsor) { FactoryGirl.create(:sponsor, :validated, petition: petition).signature }
+  let(:pending_sponsor) { FactoryGirl.create(:sponsor, :pending, petition: petition).signature }
+
+  context "when the petition is published" do
+    before do
+      petition.publish
+    end
+
+    it "notifies the creator" do
+      expect(PetitionMailer).to receive(:notify_creator_that_petition_is_published).with(creator).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+
+    it "notifies the validated sponsors" do
+      expect(PetitionMailer).to receive(:notify_sponsor_that_petition_is_published).with(validated_sponsor).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+
+    it "doesn't notify the pending sponsors" do
+      expect(PetitionMailer).not_to receive(:notify_sponsor_that_petition_is_published).with(pending_sponsor)
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+  end
+
+  context "when the petition is rejected" do
+    before do
+      petition.reject(code: "duplicate")
+    end
+
+    it "notifies the creator" do
+      expect(PetitionMailer).to receive(:notify_creator_that_petition_was_rejected).with(creator).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+
+    it "notifies the validated sponsors" do
+      expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_rejected).with(validated_sponsor).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+
+    it "doesn't notify the pending sponsors" do
+      expect(PetitionMailer).not_to receive(:notify_sponsor_that_petition_was_rejected).with(pending_sponsor)
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+  end
+
+  context "when the petition is hidden" do
+    before do
+      petition.reject(code: "offensive")
+    end
+
+    it "notifies the creator" do
+      expect(PetitionMailer).to receive(:notify_creator_that_petition_was_rejected).with(creator).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+
+    it "notifies the validated sponsors" do
+      expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_rejected).with(validated_sponsor).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+
+    it "doesn't notify the pending sponsors" do
+      expect(PetitionMailer).not_to receive(:notify_sponsor_that_petition_was_rejected).with(pending_sponsor)
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition)
+      end
+    end
+  end
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -77,6 +77,109 @@ RSpec.describe PetitionMailer, type: :mailer do
     end
   end
 
+  describe "notifying creator of rejection" do
+    let(:mail) { PetitionMailer.notify_creator_that_petition_was_rejected(creator) }
+
+    context "when rejecting for normal reasons" do
+      before do
+        petition.reject(code: "duplicate")
+      end
+
+      it "is sent to the right address" do
+        expect(mail.to).to eq(%w[bazbutler@gmail.com])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "has an appropriate subject heading" do
+        expect(mail).to have_subject('We rejected your petition “Allow organic vegetable vans to use red diesel”')
+      end
+
+      it "is addressed to the creator" do
+        expect(mail).to have_body_text("Dear Barry Butler,")
+      end
+
+      it "informs the creator of the rejection" do
+        expect(mail).to have_body_text("We rejected the petition you created")
+      end
+    end
+
+    context "when there are further details" do
+      before do
+        petition.reject(code: "irrelevant", details: "Please stop trolling us" )
+      end
+
+      it "includes those details in the email" do
+        expect(mail).to have_body_text("Please stop trolling us")
+      end
+    end
+
+    context "when rejecting for reason that cause the petition to be hidden" do
+      before do
+        petition.reject(code: "offensive")
+      end
+
+      it "doesn't include a link to the petition" do
+        expect(mail).not_to have_body_text("Click this link to see the rejected petition")
+      end
+    end
+  end
+
+  describe "notifying sponsor of rejection" do
+    let(:mail) { PetitionMailer.notify_sponsor_that_petition_was_rejected(sponsor) }
+    let(:sponsor) do
+      FactoryGirl.create(:validated_signature,
+        name: "Laura Palmer",
+        email: "laura@red-room.example.com",
+        petition: petition
+      )
+    end
+
+    context "when rejecting for normal reasons" do
+      before do
+        petition.reject(code: "duplicate")
+      end
+
+      it "is sent to the right address" do
+        expect(mail.to).to eq(%w[laura@red-room.example.com])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "has an appropriate subject heading" do
+        expect(mail).to have_subject('We rejected the petition “Allow organic vegetable vans to use red diesel” that you supported')
+      end
+
+      it "is addressed to the sponsor" do
+        expect(mail).to have_body_text("Dear Laura Palmer,")
+      end
+
+      it "informs the sponsor of the publication" do
+        expect(mail).to have_body_text("We rejected the petition you supported")
+      end
+    end
+
+    context "when there are further details" do
+      before do
+        petition.reject(code: "irrelevant", details: "Please stop trolling us" )
+      end
+
+      it "includes those details in the email" do
+        expect(mail).to have_body_text("Please stop trolling us")
+      end
+    end
+
+    context "when rejecting for reason that cause the petition to be hidden" do
+      before do
+        petition.reject(code: "offensive")
+      end
+
+      it "doesn't include a link to the petition" do
+        expect(mail).not_to have_body_text("Click this link to see the rejected petition")
+      end
+    end
+  end
+
   describe "notifying creator of closing date change" do
     let(:mail) { PetitionMailer.notify_creator_of_closing_date_change(creator) }
 


### PR DESCRIPTION
Rather than send the rejection email to sponsors as a bcc list send them a dedicated email instead. This has the benefit of allowing us to use more appropriate language when addressing then sponsors and also not leaking the email address of the petition create to them. This also mirrors how we do things when sending emails that a petition has been published.

Fixes #450.