### PR TITLE
Search for emails case-insensitively in the admin

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -35,7 +35,7 @@ class Signature < ActiveRecord::Base
   scope :validated, -> { where(state: VALIDATED_STATE) }
   scope :pending, -> { where(state: PENDING_STATE) }
   scope :notify_by_email, -> { where(notify_by_email: true) }
-  scope :for_email, ->(email) { where(email: email) }
+  scope :for_email, ->(email) { where(email: email.downcase) }
   def self.need_emailing_for(name, since:)
     receipts_table = EmailSentReceipt.arel_table
     validated.

--- a/features/admin/search_for_signatures_by_email.feature
+++ b/features/admin/search_for_signatures_by_email.feature
@@ -10,6 +10,12 @@ Feature: Searching for signatures as Terry
     When I search for petitions signed by "bob@example.com"
     Then I should see 2 petitions associated with the email address
 
+  Scenario: A user can search for signatures by email case-insensitively
+    Given 2 petitions signed by "bob.jones@example.com"
+    And I am logged in as a moderator
+    When I search for petitions signed by "Bob.Jones@example.com"
+    Then I should see 2 petitions associated with the email address
+
   Scenario: A user can search for signatures by email from the admin hub
     Given 2 petitions signed by "bob@example.com"
     And I am logged in as a moderator

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -332,6 +332,12 @@ RSpec.describe Signature, type: :model do
           [signature3, other_signature]
         )
       end
+
+      it "searches case-insensitively" do
+        expect(Signature.for_email("Person3@example.com")).to match_array(
+          [signature3, other_signature]
+        )
+      end
     end
 
     describe "checking whether the signature is the creator" do


### PR DESCRIPTION
The default behaviour of PostgreSQL is for varchar columns to be case sensitive so to prevent people signing petitions again by altering the case of their email address we force it to lowercase when we create the signature record. Since this is not visible to the signer when they raise a query with the moderation team they give their upper/lower version of the email address and when it's copied and pasted into the search box in the admin it returns no results because the search is case sensitive.

One way to fix this would be to put a case-insensitive collation on the email address column in the signatures table but given the number of rows we have in the table it could mean taking the website down. So the simplest fix is just to make the `for_email` method convert the email address to lowercase before performing the search.

https://www.pivotaltracker.com/story/show/120103205