### PR TITLE
Sort moderation queue by the most recent threshold reached

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -54,7 +54,7 @@ class Petition < ActiveRecord::Base
   facet :not_debated,          -> { not_debated.by_most_recent_debate_outcome }
 
   facet :collecting_sponsors,  -> { collecting_sponsors.by_most_recent }
-  facet :in_moderation,        -> { in_moderation.by_most_recent }
+  facet :in_moderation,        -> { in_moderation.by_most_recent_moderation_threshold_reached }
   facet :in_debate_queue,      -> { in_debate_queue.by_waiting_for_debate_longest }
 
   belongs_to :creator_signature, class_name: 'Signature'
@@ -96,6 +96,10 @@ class Petition < ActiveRecord::Base
 
     def by_most_recent_debate_outcome
       reorder(debate_outcome_at: :desc, created_at: :desc)
+    end
+
+    def by_most_recent_moderation_threshold_reached
+      reorder(moderation_threshold_reached_at: :desc, created_at: :desc)
     end
 
     def by_most_recent_response

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -22,8 +22,9 @@ Feature: A moderator user views all petitions
   Scenario: Filter list by state
     Given a pending petition "My pending petition"
     And a validated petition "My validated petition"
-    And a sponsored petition "My sponsored petition"
-    And a flagged petition "My flagged petition"
+    And a sponsored petition "My sponsored petition" reached threshold 2 days ago
+    And a sponsored petition "My other sponsored petition" reached threshold 1 day ago
+    And a flagged petition "My flagged petition" reached threshold 3 days ago
 
     And an open petition exists with action: "My open petition"
     And a closed petition exists with action: "My closed petition"
@@ -34,7 +35,6 @@ Feature: A moderator user views all petitions
     And a petition "My open petition awaiting debate date" exists awaiting debate date
     And a petition "My open petition with government response" exists with government response
     And a petition "My open petition awaiting government response" exists awaiting government response
-
     And a petition "My open petition with scheduled debate date" with scheduled debate date of "23/10/2010"
 
     When I view all petitions
@@ -49,6 +49,7 @@ Feature: A moderator user views all petitions
      | My closed petition                            |
      | My open petition                              |
      | My flagged petition                           |
+     | My other sponsored petition                   |
      | My sponsored petition                         |
      | My validated petition                         |
      | My pending petition                           |
@@ -60,8 +61,9 @@ Feature: A moderator user views all petitions
 
     And I filter the list to show "Awaiting moderation" petitions
     Then I should see the following list of petitions:
-     | My flagged petition    |
-     | My sponsored petition  |
+     | My other sponsored petition |
+     | My sponsored petition       |
+     | My flagged petition         |
 
     And I filter the list to show "Open" petitions
     Then I should see the following list of petitions:

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -13,10 +13,13 @@ Given(/^a(n)? ?(pending|validated|sponsored|flagged|open)? petition "([^"]*)"$/)
   @petition = FactoryGirl.create(:open_petition, petition_args)
 end
 
+Given(/^a (sponsored|flagged) petition "(.*?)" reached threshold (\d+) days? ago$/) do |state, action, age|
+  @petition = FactoryGirl.create(:petition, action: action, state: state, moderation_threshold_reached_at: age.days.ago)
+end
+
 Given(/^a petition "([^"]*)" with a negative debate outcome$/) do |action|
   @petition = FactoryGirl.create(:not_debated_petition, action: action)
 end
-
 
 Given(/^a(n)? ?(pending|validated|sponsored|open)? petition "([^"]*)" with scheduled debate date of "(.*?)"$/) do |_, state, petition_title, scheduled_debate_date|
   step "an #{state} petition \"#{petition_title}\""

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -313,6 +313,15 @@ RSpec.describe Petition, type: :model do
       end
     end
 
+    context "by_most_recent_moderation_threshold_reached" do
+      let!(:p1) { FactoryGirl.create(:sponsored_petition, moderation_threshold_reached_at: 2.days.ago) }
+      let!(:p2) { FactoryGirl.create(:sponsored_petition, moderation_threshold_reached_at: 1.day.ago) }
+
+      it "returns the petitions in the correct order" do
+        expect(Petition.by_most_recent_moderation_threshold_reached.to_a).to eq([p2, p1])
+      end
+    end
+
     context "by_most_relevant_debate_date" do
       before do
         @p1 = FactoryGirl.create(:awaiting_debate_petition, debate_threshold_reached_at: 2.weeks.ago)


### PR DESCRIPTION
Petitions in the moderation queue were being sorted by the most recently created which meant that petitions that were created some time ago but had for some reason take some time to gather enough sponsors ended up at the bottom of the list.

It makes more sense to sort by the most recent ones to have passed the moderation threshold first because petitions that have been waiting a while for moderation are likely to have been flagged or contentious in some way and are awaiting feedback before moderation takes place.

https://www.pivotaltracker.com/story/show/120102803