### PR TITLE
Add the ability to search by name in the admin area

### DIFF
--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -5,6 +5,8 @@ class Admin::SearchesController < Admin::AdminController
       find_petition_by_id
     elsif query_is_email?
       find_signatures_by_email
+    elsif query_is_name?
+      find_signatures_by_name
     elsif query_is_tag?
       find_petitions_by_tag
     else
@@ -15,6 +17,10 @@ class Admin::SearchesController < Admin::AdminController
   private
   def query
     @query ||= params.fetch(:q, '')
+  end
+
+  def name
+    @name ||= @query.gsub(/\A"|"\Z/, '')
   end
 
   def tag
@@ -33,6 +39,10 @@ class Admin::SearchesController < Admin::AdminController
     @signatures = Signature.for_email(query).paginate(page: params[:page], per_page: 50)
   end
 
+  def find_signatures_by_name
+    @signatures = Signature.for_name(name).paginate(page: params[:page], per_page: 50)
+  end
+
   def find_petitions_by_keyword
     redirect_to(controller: 'admin/petitions', action: 'index', q: query)
   end
@@ -47,6 +57,10 @@ class Admin::SearchesController < Admin::AdminController
 
   def query_is_email?
     query.include?('@')
+  end
+
+  def query_is_name?
+    query.starts_with?('"') && query.ends_with?('"')
   end
 
   def query_is_tag?

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -36,6 +36,8 @@ class Signature < ActiveRecord::Base
   scope :pending, -> { where(state: PENDING_STATE) }
   scope :notify_by_email, -> { where(notify_by_email: true) }
   scope :for_email, ->(email) { where(email: email.downcase) }
+  scope :for_name, ->(name) { where("lower(name) = ?", name.downcase) }
+
   def self.need_emailing_for(name, since:)
     receipts_table = EmailSentReceipt.arel_table
     validated.

--- a/app/views/admin/searches/_form.html.erb
+++ b/app/views/admin/searches/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag [:admin, :search], class: 'search-inline search-petitions', method: 'get' do %>
   <%= label_tag :q, "Search all petitions", class: "visuallyhidden" %>
-  <%= search_field_tag 'q', query, class: 'form-control', placeholder:"Keywords, email address, petition ID or [tag]" %>
+  <%= search_field_tag 'q', query, class: 'form-control', placeholder:"Keywords, name, email address, petition ID or [tag]" %>
   <%= submit_tag 'Search', class: 'inline-submit' %>
 <% end %>

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -15,9 +15,10 @@
       <tr>
         <th>Petition Id</th>
         <th>Petition Action</th>
-        <th>Signature Status</th>
-        <th>Signature Last Updated</th>
-        <th>Petition Creator?</th>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Last Updated</th>
+        <th>Creator?</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -30,7 +31,10 @@
 
 <% else %>
   <p>
-    No signatures found for email address
-    <%= mail_to @query %>
+    <% if @name %>
+      No signatures found for name <%= @query %>
+    <% else %>
+      No signatures found for email address <%= mail_to @query %>
+    <% end %>
   </p>
 <% end %>

--- a/app/views/admin/signatures/_signature.html.erb
+++ b/app/views/admin/signatures/_signature.html.erb
@@ -1,6 +1,7 @@
 <tr>
   <td class="petition_id"><%= signature.petition.id %></td>
   <td><%= link_to signature.petition.action, admin_petition_path(signature.petition) %></td>
+  <td><%= mail_to signature.email, signature.name %></td>
   <td><%= signature.state %></td>
   <td><%= date_time_format(signature.updated_at) %></td>
   <% if signature.creator? %>

--- a/db/migrate/20160527112417_add_index_to_signature_name.rb
+++ b/db/migrate/20160527112417_add_index_to_signature_name.rb
@@ -1,0 +1,24 @@
+class AddIndexToSignatureName < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:signatures, :name)
+      execute <<-SQL
+        CREATE INDEX CONCURRENTLY index_signatures_on_name
+        ON signatures USING btree ((lower(name)));
+      SQL
+    end
+  end
+
+  def down
+    if index_exists?(:signatures, :name)
+      remove_index :signatures, :name
+    end
+  end
+
+  private
+
+  def index_exists?(table, names)
+    select_value("SELECT to_regclass('index_#{table}_on_#{Array(names).join('_and_')}')")
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1281,6 +1281,13 @@ CREATE UNIQUE INDEX index_signatures_on_email_and_petition_id_and_name ON signat
 
 
 --
+-- Name: index_signatures_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_name ON signatures USING btree (lower((name)::text));
+
+
+--
 -- Name: index_signatures_on_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1554,4 +1561,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160214133749');
 INSERT INTO schema_migrations (version) VALUES ('20160214233414');
 
 INSERT INTO schema_migrations (version) VALUES ('20160217192016');
+
+INSERT INTO schema_migrations (version) VALUES ('20160527112417');
 

--- a/features/admin/search_for_signatures_by_name.feature
+++ b/features/admin/search_for_signatures_by_name.feature
@@ -1,0 +1,23 @@
+@admin
+Feature: Searching for signatures as Terry
+  In order to easily find out if someone's signed a petition
+  As Terry
+  I would like to be able to enter a name, and see all signatures associated with it
+
+  Scenario: A user can search for signatures by name
+    Given 2 petitions signed by "Bob Jones"
+    And I am logged in as a moderator
+    When I search for petitions signed by "Bob Jones"
+    Then I should see 2 petitions associated with the name
+
+  Scenario: A user can search for signatures by name from the admin hub
+    Given 2 petitions signed by "Bob Jones"
+    And I am logged in as a moderator
+    When I search for petitions signed by "Bob Jones" from the admin hub
+    Then I should see 2 petitions associated with the name
+
+  Scenario: A user can search for signatures by name case insensitively
+    Given 2 petitions signed by "Bob Jones"
+    And I am logged in as a moderator
+    When I search for petitions signed by "BOB JONES"
+    Then I should see 2 petitions associated with the name


### PR DESCRIPTION
Since we have to preserve the case of the name we can't just lowercase it like we do with the email so to achieve case-insensitiveness we need to create an expression index on the name. Since support for these indexes isn't available until Rails 5.0 we need to use SQL to generate the index and override `index_exists?` because it doesn't appear in the list of indexes returned by Active Record.

https://www.pivotaltracker.com/story/show/120103125