### PR TITLE
Allow moderators to edit creator's name

### DIFF
--- a/app/controllers/admin/petition_details_controller.rb
+++ b/app/controllers/admin/petition_details_controller.rb
@@ -21,6 +21,6 @@ class Admin::PetitionDetailsController < Admin::AdminController
   end
 
   def petition_params
-    params.require(:petition).permit(:action, :background, :additional_details)
+    params.require(:petition).permit(:action, :background, :additional_details, :creator_signature_attributes => [:name])
   end
 end

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -25,6 +25,14 @@
         <%= f.text_area :additional_details, tabindex: increment, rows: 7, class: 'form-control' %>
       <% end %>
 
+      <%= form_row for: [f.object, :creator_signature_name] do %>
+        <%= f.fields_for :creator_signature do |c| %>
+          <%= c.label :name, "Creator", class: 'form-label' %>
+          <%= error_messages_for_field @petition.creator_signature, :name %>
+          <%= c.text_field :name, tabindex: increment, rows: 8, class: 'form-control' %>
+        <% end %>
+      <% end %>
+
       <%= f.submit 'Save', class: 'button' %>
 
       <%= link_to 'Cancel', admin_petition_path(@petition) %>

--- a/spec/controllers/admin/petition_details_controller_spec.rb
+++ b/spec/controllers/admin/petition_details_controller_spec.rb
@@ -103,13 +103,14 @@ RSpec.describe Admin::PetitionDetailsController, type: :controller, admin: true 
             petition: {
               action: 'New action',
               background: 'New background',
-              additional_details: 'New additional_details'
+              additional_details: 'New additional_details',
+              creator_signature_attributes: { name: 'Jo Public' }
             }
           }
         end
 
-        it "are limited to action, background and additional_details" do
-          is_expected.to permit(:action, :background, :additional_details).for(:update, params: params).on(:petition)
+        it "are limited to action, background, additional_details and creator name" do
+          is_expected.to permit(:action, :background, :additional_details, :creator_signature_attributes => [:name]).for(:update, params: params).on(:petition)
         end
       end
 
@@ -118,7 +119,8 @@ RSpec.describe Admin::PetitionDetailsController, type: :controller, admin: true 
           {
               action: 'New action',
               background: 'New background',
-              additional_details: 'New additional_details'
+              additional_details: 'New additional_details',
+              creator_signature_attributes: { name: 'New Creator' }
           }
         end
 
@@ -136,6 +138,7 @@ RSpec.describe Admin::PetitionDetailsController, type: :controller, admin: true 
             expect(petition.action).to eq('New action')
             expect(petition.background).to eq('New background')
             expect(petition.additional_details).to eq('New additional_details')
+            expect(petition.creator_signature.name).to eq('New Creator')
           end
         end
 


### PR DESCRIPTION
One of the requirements is that creator's proper name is published with the petition so rather than forcing people to resubmit and get their sponsors to resign allow moderators to update the petition with the correct name.

https://www.pivotaltracker.com/story/show/120103355