### PR TITLE
Fix intermittent spec errors

### DIFF
--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CountryPetitionJournal, type: :model do
     let(:petition) { FactoryGirl.create(:petition) }
 
     context "when there is a journal for the requested petition and country" do
-      let!(:existing_record) { FactoryGirl.create(:country_petition_journal, petition: petition, location_code: location_code, signature_count: 30) }
+      let!(:existing_record) { FactoryGirl.create(:country_petition_journal, petition: petition, location: location, signature_count: 30) }
 
       it "doesn't create a new record" do
         expect {

--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CountryPetitionJournal, type: :model do
 
   describe ".for" do
     let!(:location) { FactoryGirl.create(:location) }
-    let!(:location_code) { location.code }
+    let(:location_code) { location.code }
     let(:petition) { FactoryGirl.create(:petition) }
 
     context "when there is a journal for the requested petition and country" do


### PR DESCRIPTION
Using the attribute rather than the association when constructing the existing record would sometimes cause duplicate record errors depending on the order of spec execution.