### PR TITLE
Cache phantomjs download and use our own copy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: ruby
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - /home/travis/.phantomjs
 rvm:
 - 2.2.4
 services:
@@ -11,6 +14,7 @@ before_script:
 - bundle install
 - psql -c 'create database epets_test;' -U postgres
 - RAILS_ENV=test bundle exec rake db:structure:load
+- bin/install_phantomjs
 script: bundle exec rake
 after_success: bundle exec rake deploy:preview
 env:

--- a/bin/install_phantomjs
+++ b/bin/install_phantomjs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+set -e
+
+if [ ! -e /home/travis/.phantomjs/1.9.7/x86_64-linux/bin/phantomjs ]; then
+  mkdir -p /home/travis/.phantomjs/1.9.7/x86_64-linux/bin
+  pip install --user awscli
+  aws s3 cp s3://epetitions-ci/phantomjs /home/travis/.phantomjs/1.9.7/x86_64-linux/bin/phantomjs
+  chmod ugo+x /home/travis/.phantomjs/1.9.7/x86_64-linux/bin/phantomjs
+fi


### PR DESCRIPTION
The phantomjs project uses BitBucket for hosting their downloads which is subject to rate-limiting and causes intermittent build failures. This script downloads a copy from an authenticated S3 bucket and uses the new arbitrary directory caching feature now available for open source repositories to improve the build times.