### PR TITLE
Use memcache for counter

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -24,8 +24,8 @@ module AdminHelper
 
   def email_petitioners_with_count_submit_button(form, petition)
     i18n_options = {
-      scope: :admin, count: petition.signature_count,
-      formatted_count: number_with_delimiter(petition.signature_count)
+      scope: :admin, count: petition.cached_signature_count,
+      formatted_count: number_with_delimiter(petition.cached_signature_count)
     }
 
     html_options = {

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -20,7 +20,7 @@ module PetitionHelper
 
   def signatures_threshold_percentage(petition)
     threshold = current_threshold(petition).to_f
-    percentage = petition.signature_count / threshold * 100
+    percentage = petition.cached_signature_count / threshold * 100
     if percentage > 100
       percentage = 100
     elsif percentage < 1

--- a/app/jobs/cached_signature_count_reset_job.rb
+++ b/app/jobs/cached_signature_count_reset_job.rb
@@ -1,0 +1,15 @@
+class CachedSignatureCountResetJob < ActiveJob::Base
+  queue_as :highest_priority
+
+  def perform
+    Petition.updated_since(timestamp).each do |petition|
+      petition.save_cached_signature_count
+    end
+  end
+
+  private
+
+  def timestamp
+    Site.signature_count_updated_since_window.ago
+  end
+end

--- a/app/jobs/cached_signature_count_reset_job.rb
+++ b/app/jobs/cached_signature_count_reset_job.rb
@@ -10,6 +10,6 @@ class CachedSignatureCountResetJob < ActiveJob::Base
   private
 
   def timestamp
-    Site.signature_count_updated_since_window.ago
+    Site.signature_count_updated_since_window.ago - 1.minute
   end
 end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -102,8 +102,8 @@ class PetitionMailer < ApplicationMailer
       options[:scope] = :"petitions.emails.subjects"
 
       if defined?(@petition)
-        options[:count] = @petition.signature_count
-        options[:formatted_count] = number_to_delimited(@petition.signature_count)
+        options[:count] = @petition.cached_signature_count
+        options[:formatted_count] = number_to_delimited(@petition.cached_signature_count)
         options[:action] = @petition.action
       end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -110,7 +110,7 @@ class Signature < ActiveRecord::Base
         petition.validate_creator_signature! unless creator?
 
         update_columns(
-          number:       petition.signature_count + 1,
+          number:       petition.cached_signature_count + 1,
           state:        VALIDATED_STATE,
           validated_at: Time.current,
           updated_at:   Time.current

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -84,6 +84,10 @@ class Site < ActiveRecord::Base
       instance.closed_at_for_opening(time)
     end
 
+    def signature_count_updated_since_window
+      5.minutes
+    end
+
     def port
       instance.port
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -84,6 +84,10 @@ class Site < ActiveRecord::Base
       instance.closed_at_for_opening(time)
     end
 
+    def show_trending_petitions?
+      false
+    end
+
     def signature_count_updated_since_window
       5.minutes
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -89,7 +89,7 @@ class Site < ActiveRecord::Base
     end
 
     def signature_count_updated_since_window
-      5.minutes
+      15.minutes
     end
 
     def port

--- a/app/presenters/petition_csv_presenter.rb
+++ b/app/presenters/petition_csv_presenter.rb
@@ -27,7 +27,7 @@ class PetitionCSVPresenter
   def self.attributes
     [:id,
       :action, :background, :additional_details, :state,
-      :creator_name, :creator_email, :signature_count, :rejection_code, :rejection_details,
+      :creator_name, :creator_email, :cached_signature_count, :rejection_code, :rejection_details,
       :government_response_summary, :government_response_details,
       :debate_date, :debate_transcript_url, :debate_video_url, :debate_overview
     ]

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -4,7 +4,7 @@
 
 <% unless @petition.in_todo_list? %>
   <dt>Signatures</dt>
-  <dd class="petition-meta-signature-count"><%= number_with_delimiter(@petition.signature_count) %> </dd>
+  <dd class="petition-meta-signature-count"><%= number_with_delimiter(@petition.cached_signature_count) %> </dd>
 <% end %>
 
 <dt>Creator</dt>

--- a/app/views/admin/petitions/_published_petition_details.html.erb
+++ b/app/views/admin/petitions/_published_petition_details.html.erb
@@ -10,7 +10,7 @@
 
 <div class="row">
   <label>Signature count:</label>
-  <p class="text_block"><%= number_with_delimiter(@petition.signature_count) %> </p>
+  <p class="text_block"><%= number_with_delimiter(@petition.cached_signature_count) %> </p>
 </div>
 
 <div class="row">

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -40,7 +40,7 @@
         <td class="petition-list-petition-id"><%= petition.id %></td>
         <td><%= petition.state.humanize %></td>
         <td class="date"><%= date_format(petition.deadline) %></td>
-        <td class="numeric last"><%= number_with_delimiter(petition.signature_count) %></td>
+        <td class="numeric last"><%= number_with_delimiter(petition.cached_signature_count) %></td>
       </tr>
     <% end -%>
   </tbody>

--- a/app/views/local_petitions/show.html.erb
+++ b/app/views/local_petitions/show.html.erb
@@ -15,7 +15,7 @@
         <li class="petition-item petition-<%= petition.state %>">
           <h3><%= link_to petition.action, petition_path(petition) %></h3>
           <p><%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
-          (<%= signature_count(:in_total, petition.signature_count) %>)</p>
+          (<%= signature_count(:in_total, petition.cached_signature_count) %>)</p>
         </li>
       <% end -%>
     </ol>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -22,15 +22,17 @@
 
   <% unless no_petitions_yet? %>
     <div class="section-panel-borderless">
-      <% trending_petitions do |petitions| %>
-        <section class="trending" aria-labelledby="trending-heading">
-          <h2 id="trending-heading">Popular petitions</h2>
-          <ul>
-            <% petitions.each do |petition| %>
-              <%= render 'petitions/trending_petition', :trending_petition => petition %>
-            <% end -%>
-          </ul>
-        </section>
+      <% if Site.show_trending_petitions? %>
+        <% trending_petitions do |petitions| %>
+          <section class="trending" aria-labelledby="trending-heading">
+            <h2 id="trending-heading">Popular petitions</h2>
+            <ul>
+              <% petitions.each do |petition| %>
+                <%= render 'petitions/trending_petition', :trending_petition => petition %>
+              <% end -%>
+            </ul>
+          </section>
+        <% end %>
       <% end %>
       <%= link_to 'View all open petitions', petitions_path(state: 'open'), :class => 'view-all' %>
     </div>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -16,7 +16,7 @@
 
 <p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
 
-<% if @petition.signature_count < Site.threshold_for_debate %>
+<% if @petition.cached_signature_count < Site.threshold_for_debate %>
 <p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
 <% else %>
 <p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -16,7 +16,7 @@ Click this link to view the response online:
 
 <%= petition_url(@petition, reveal_response: "yes") %>
 
-<% if @petition.signature_count < Site.threshold_for_debate %>
+<% if @petition.cached_signature_count < Site.threshold_for_debate %>
 The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
 <% else %>
 This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -16,7 +16,7 @@
 
 <p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
 
-<% if @petition.signature_count < Site.threshold_for_debate %>
+<% if @petition.cached_signature_count < Site.threshold_for_debate %>
 <p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
 <% else %>
 <p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -16,7 +16,7 @@ Click this link to view the response online:
 
 <%= petition_url(@petition, reveal_response: "yes") %>
 
-<% if @petition.signature_count < Site.threshold_for_debate %>
+<% if @petition.cached_signature_count < Site.threshold_for_debate %>
 The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
 <% else %>
 This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.

--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -18,7 +18,7 @@
   </p>
 
   <div class="signature-count">
-    <p class="signature-count-number"><%= signature_count(:default, petition.signature_count) %></p>
+    <p class="signature-count-number"><%= signature_count(:default, petition.cached_signature_count) %></p>
     <div class="signature-count-graph" aria-hidden="true">
       <span class="signature-count-current" style="width: <%= signatures_threshold_percentage(petition) %>"></span>
     </div>

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -16,7 +16,7 @@
 
   <div class="signature-count">
     <p class="signature-count-number">
-      <%= signature_count(:default, petition.signature_count) %>
+      <%= signature_count(:default, petition.cached_signature_count) %>
     </p>
     <div class="signature-count-graph" aria-hidden="true">
       <span class="signature-count-current" style="width: <%= signatures_threshold_percentage(petition) %>"></span>

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -10,7 +10,7 @@ json.attributes do
   json.background petition.background
   json.additional_details petition.additional_details
   json.state petition.state
-  json.signature_count petition.signature_count
+  json.signature_count petition.cached_signature_count
 
   json.created_at api_date_format(petition.created_at)
   json.updated_at api_date_format(petition.updated_at)

--- a/app/views/petitions/search/_results_for_pre_create_petition.html.erb
+++ b/app/views/petitions/search/_results_for_pre_create_petition.html.erb
@@ -3,7 +3,7 @@
     <li class="petition-item petition-item-existing panel-indent">
       <h3><%= link_to petition.action, petition_path(petition) %></h3>
       <% unless petition.rejected? -%>
-        <p><%= signature_count(:default, petition.signature_count) %></p>
+        <p><%= signature_count(:default, petition.cached_signature_count) %></p>
       <% end %>
       <p><%= petition.background %></p>
     </li>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
@@ -1,9 +1,9 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
 <% case petition.state %>
 <% when "open" %>
-  <p><%= signature_count(:default, petition.signature_count) %></p>
+  <p><%= signature_count(:default, petition.cached_signature_count) %></p>
 <% when "closed" %>
-  <p><%= signature_count(:default, petition.signature_count) %>, now closed</p>
+  <p><%= signature_count(:default, petition.cached_signature_count) %>, now closed</p>
 <% when "rejected" %>
   <p>Rejected</p>
 <% end %>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
@@ -1,5 +1,5 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>
 <p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
 <% if petition.scheduled_debate_date? %>
   <p><%= scheduled_for_debate_in_words(petition.scheduled_debate_date) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_response.html.erb
@@ -1,3 +1,3 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>
 <p><%= waiting_for_in_words(petition.response_threshold_reached_at) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_closed.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_closed.html.erb
@@ -1,2 +1,2 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_debated.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_debated.html.erb
@@ -1,5 +1,5 @@
 <h3><%= link_to petition.action, petition_path(petition, anchor: 'debate-threshold') %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>
 <% if debate_outcome = petition.debate_outcome %>
 <p>Debated <%= short_date_format(debate_outcome.debated_on) %></p>
 <% else %>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_not_debated.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_not_debated.html.erb
@@ -1,2 +1,2 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_open.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_open.html.erb
@@ -1,2 +1,2 @@
 <h3><%= link_to petition.action, petition_path(petition) %></h3>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
@@ -1,4 +1,4 @@
 <h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></h3>
 <p>Government responded – <%= short_date_format(petition.government_response_at) %></p>
 <p><%= petition.government_response.summary %></p>
-<p><%= signature_count(:default, petition.signature_count) %></p>
+<p><%= signature_count(:default, petition.cached_signature_count) %></p>

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -46,7 +46,7 @@ module Delayed
   module Backend
     module ActiveRecord
       class Job < ::ActiveRecord::Base
-        QUEUE_PRIORITIES = { "high_priority" => 0, "low_priority" => 50 }
+        QUEUE_PRIORITIES = { "highest_priority" => -10, "high_priority" => 0, "low_priority" => 50 }
         QUEUE_PRIORITIES.default = 25
 
         before_create do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,7 @@
 
 # Learn more: http://github.com/javan/whenever
 
-every 5.minutes do
+every 15.minutes do
   runner "CachedSignatureCountResetJob.perform_now"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,10 @@
 
 # Learn more: http://github.com/javan/whenever
 
+every 5.minutes do
+  runner "CachedSignatureCountResetJob.perform_now"
+end
+
 every :weekday, at: '7am' do
   rake "epets:admin_email_reminder", output: nil
 end

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -149,6 +149,6 @@ Given(/^a moderator responds to the petition$/) do
     And I follow "Government response"
     And I fill in "Summary quote" with "Get ready"
     And I fill in "Response in full" with "Parliament here it comes"
-    And I press "Email #{NumberHelpers.number_with_delimiter(@petition.signature_count)} petitioners"
+    And I press "Email #{NumberHelpers.number_with_delimiter(@petition.cached_signature_count)} petitioners"
   )
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -399,6 +399,10 @@ Given(/^there are (\d+) petitions with enough signatures to require a debate$/) 
   end
 end
 
+Given(/^the site is showing trending petitions$/) do
+  allow(Site).to receive(:show_trending_petitions?).and_return(true)
+end
+
 Given(/^a petition "(.*?)" has other parliamentary business$/) do |petition_action|
   @petition = FactoryGirl.create(:open_petition, action: petition_action)
   @email = FactoryGirl.create(:petition_email,

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -182,11 +182,12 @@ end
 
 Then(/^I should see the vote count, closed and open dates$/) do
   @petition.reload
-  expect(page).to have_css("p.signature-count-number", :text => "#{@petition.signature_count} #{'signature'.pluralize(@petition.signature_count)}")
 
   if @petition.is_a?(ArchivedPetition)
+    expect(page).to have_css("p.signature-count-number", :text => "#{@petition.signature_count} #{'signature'.pluralize(@petition.signature_count)}")
     expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.closed_at.strftime("%e %B %Y").squish)
   else
+    expect(page).to have_css("p.signature-count-number", :text => "#{@petition.cached_signature_count} #{'signature'.pluralize(@petition.cached_signature_count)}")
     expect(page).to have_css("li.meta-deadline", :text => "Deadline " + @petition.deadline.strftime("%e %B %Y").squish)
     expect(page).to have_css("li.meta-created-by", :text => "Created by " + @petition.creator_signature.name)
   end
@@ -194,7 +195,7 @@ end
 
 Then(/^I should not see the vote count$/) do
   @petition.reload
-  expect(page).to_not have_css("p.signature-count-number", :text => @petition.signature_count.to_s + " signatures")
+  expect(page).to_not have_css("p.signature-count-number", :text => @petition.cached_signature_count.to_s + " signatures")
 end
 
 Then(/^I should see submitted date$/) do
@@ -350,7 +351,10 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |
     state: petition_state
   }
   @petition = FactoryGirl.create(:open_petition, petition_args)
-  5.times { FactoryGirl.create(:validated_signature, petition: @petition) }
+  5.times do
+    signature = FactoryGirl.create(:pending_signature, petition: @petition)
+    signature.validate!
+  end
 end
 
 Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -110,23 +110,29 @@ And "I have already signed the petition but not validated my email" do
 end
 
 Given /^Suzie has already signed the petition$/ do
-  @suzies_signature = FactoryGirl.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
+  @suzies_signature = FactoryGirl.create(:pending_signature, :petition => @petition, :email => "womboid@wimbledon.com",
          :postcode => "SW14 9RQ", :name => "Womboid Wibbledon")
+  @suzies_signature.validate!
 end
 
 Given /^Eric has already signed the petition with Suzies email$/ do
-  FactoryGirl.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
+  signature = FactoryGirl.create(:pending_signature, :petition => @petition, :email => "womboid@wimbledon.com",
          :postcode => "SW14 9RQ", :name => "Eric Wibbledon")
+  signature.validate!
 end
 
 Given /^I have signed the petition with a second name$/ do
-  FactoryGirl.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
+  signature = FactoryGirl.create(:pending_signature, :petition => @petition, :email => "womboid@wimbledon.com",
          :postcode => "SW14 9RQ", :name => "Sam Wibbledon")
+  signature.validate!
 end
 
 Given(/^Suzie has already signed the petition and validated her email$/) do
-  @suzies_signature = FactoryGirl.create(:validated_signature, :petition => @petition, :email => "womboid@wimbledon.com",
+  stub_api_request_for("SW149RQ").to_return(api_response(:ok, "no_results"))
+
+  @suzies_signature = FactoryGirl.create(:pending_signature, :petition => @petition, :email => "womboid@wimbledon.com",
          :postcode => "SW14 9RQ", :name => "Womboid Wibbledon")
+  @suzies_signature.validate!
 end
 
 When(/^Suzie shares the signatory confirmation link with Eric$/) do

--- a/features/support/custom_env.rb
+++ b/features/support/custom_env.rb
@@ -1,5 +1,6 @@
 require 'email_spec/cucumber'
 require 'rspec/core/pending'
+require 'cucumber/rspec/doubles'
 require 'capybara/poltergeist'
 require 'webrick/httpproxy'
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -25,3 +25,7 @@ Before('~@admin') do
   Capybara.app_host = 'https://petition.parliament.uk'
   Capybara.default_host = 'https://petition.parliament.uk'
 end
+
+Before do
+  Rails.cache.clear
+end

--- a/features/suzie_sees_trending_petitions.feature
+++ b/features/suzie_sees_trending_petitions.feature
@@ -9,5 +9,6 @@ Feature: Suzie sees trending petitions
 
   Scenario: Seeing a number of trending petitions
     Given there has been activity on a number of petitions in the last hour
+    And the site is showing trending petitions
     And I am on the home page
     Then I should see the most popular petitions listed on the front page

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PetitionHelper, type: :helper do
 
   describe "#current_threshold" do
 
-    context "when the response threshold has never been reached" do 
+    context "when the response threshold has never been reached" do
       let(:petition) { FactoryGirl.create(:petition) }
 
       it "returns the response threshold" do
@@ -77,7 +77,6 @@ RSpec.describe PetitionHelper, type: :helper do
   end
 
   describe "#signatures_threshold_percentage" do
-
     context "when the signature count is less than the response threshold" do
       let(:petition) { FactoryGirl.create(:petition, signature_count: 239) }
 

--- a/spec/jobs/cached_signature_count_reset_job_spec.rb
+++ b/spec/jobs/cached_signature_count_reset_job_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe CachedSignatureCountResetJob, type: :job do
+  context "when there are no petitions updated in the last time period" do
+    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 10.minutes.ago) }
+
+    it "doesn't update the signature count" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.signature_count }
+    end
+
+    it "doesn't change the updated_at timestamp" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.updated_at }
+    end
+  end
+
+  context "when there are are petitions updated in the last time period" do
+    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 2.minutes.ago) }
+
+    before do
+      Rails.cache.write("signature_counts/#{petition.id}", 2000, raw: true)
+    end
+
+    it "has an out of sync signature count" do
+      expect(petition.signature_count).to eq(1000)
+      expect(petition.cached_signature_count).to eq(2000)
+    end
+
+    it "updates the signature count" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.to change{ petition.reload.signature_count }.from(1000).to(2000)
+    end
+
+    it "doesn't change the updated_at timestamp" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.updated_at }
+    end
+  end
+end

--- a/spec/jobs/cached_signature_count_reset_job_spec.rb
+++ b/spec/jobs/cached_signature_count_reset_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CachedSignatureCountResetJob, type: :job do
   context "when there are no petitions updated in the last time period" do
-    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 10.minutes.ago) }
+    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 30.minutes.ago) }
 
     it "doesn't update the signature count" do
       expect{
@@ -22,7 +22,36 @@ RSpec.describe CachedSignatureCountResetJob, type: :job do
   end
 
   context "when there are are petitions updated in the last time period" do
-    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 2.minutes.ago) }
+    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 5.minutes.ago) }
+
+    before do
+      Rails.cache.write("signature_counts/#{petition.id}", 2000, raw: true)
+    end
+
+    it "has an out of sync signature count" do
+      expect(petition.signature_count).to eq(1000)
+      expect(petition.cached_signature_count).to eq(2000)
+    end
+
+    it "updates the signature count" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.to change{ petition.reload.signature_count }.from(1000).to(2000)
+    end
+
+    it "doesn't change the updated_at timestamp" do
+      expect{
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change{ petition.reload.updated_at }
+    end
+  end
+
+  context "when there are are petitions updated just outside last time period" do
+    let!(:petition) { FactoryGirl.create(:open_petition, signature_count: 1000, updated_at: 930.seconds.ago) }
 
     before do
       Rails.cache.write("signature_counts/#{petition.id}", 2000, raw: true)

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe Signature, type: :model do
 
           petition.reload
 
-          expect(petition.signature_count).to eq(7)
-          expect{ signature.destroy }.to change{ petition.reload.signature_count }.by(-1)
+          expect(petition.cached_signature_count).to eq(7)
+          expect{ signature.destroy }.to change{ petition.reload.cached_signature_count }.by(-1)
         end
       end
     end
@@ -406,7 +406,7 @@ RSpec.describe Signature, type: :model do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
 
-      expect(signature.petition.signature_count).to eq(7)
+      expect(signature.petition.cached_signature_count).to eq(7)
       expect(signature.number).to eq(7)
     end
 
@@ -417,10 +417,10 @@ RSpec.describe Signature, type: :model do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
 
-      expect(other_signature.petition.signature_count).to eq(7)
+      expect(other_signature.petition.cached_signature_count).to eq(7)
       expect(other_signature.number).to eq(7)
 
-      expect(signature.petition.signature_count).to eq(7)
+      expect(signature.petition.cached_signature_count).to eq(7)
       expect(signature.number).to eq(7)
     end
 
@@ -516,7 +516,7 @@ RSpec.describe Signature, type: :model do
       end
 
       it "increments the petition count" do
-        expect{ signature.validate! }.to change{ petition.reload.signature_count }.by(1)
+        expect{ signature.validate! }.to change{ petition.reload.cached_signature_count }.by(1)
       end
 
       it "updates the petition to say it was updated just now" do
@@ -531,7 +531,7 @@ RSpec.describe Signature, type: :model do
 
       it "doesn't increment the petition count twice" do
         signature.validate!
-        expect{ signature.validate! }.to change{ petition.reload.signature_count }.by(0)
+        expect{ signature.validate! }.to change{ petition.reload.cached_signature_count }.by(0)
       end
 
       it 'tells the relevant constituency petition journal to record a new signature' do

--- a/spec/presenters/petition_csv_presenter_spec.rb
+++ b/spec/presenters/petition_csv_presenter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PetitionCSVPresenter do
       petition.state,
       petition.creator_name,
       petition.creator_email,
-      petition.signature_count,
+      petition.cached_signature_count,
       petition.rejection_code,
       petition.rejection_details,
       petition.government_response_summary,

--- a/spec/requests/api_request_helpers.rb
+++ b/spec/requests/api_request_helpers.rb
@@ -52,7 +52,7 @@ module ApiRequestHelpers
       expect(attributes["background"]).to eq(petition.background)
       expect(attributes["additional_details"]).to eq(petition.additional_details)
       expect(attributes["state"]).to eq(petition.state)
-      expect(attributes["signature_count"]).to eq(petition.signature_count)
+      expect(attributes["signature_count"]).to eq(petition.cached_signature_count)
 
       # timestamps
       expect(attributes["created_at"]).to eq(timestampify petition.created_at)

--- a/spec/support/dalli.rb
+++ b/spec/support/dalli.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+
+  config.before(:each) do
+    Rails.cache.clear
+  end
+
+end


### PR DESCRIPTION
Also we allow turning off trending petitions for performance reasons.  Note that we default the new attributes in `Site` directly on the model, we need to back these up with db fields at a later date - not doing now as traffic is high and we don't want to run db migrations.