### PR TITLE
Temporarily reduce db writes on signing

### DIFF
--- a/app/models/country_petition_journal.rb
+++ b/app/models/country_petition_journal.rb
@@ -45,7 +45,7 @@ class CountryPetitionJournal < ActiveRecord::Base
     private
 
     def unrecordable?(signature)
-      signature.nil? || signature.petition.nil? || signature.location_code.blank? || !signature.validated?
+      signature.nil? || signature.petition.nil? || signature.location_code.blank? || !signature.validated? || signature.location_code == 'GB'
     end
   end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -350,7 +350,7 @@ class Petition < ActiveRecord::Base
   end
 
   def update_timestamps?
-    signature_count < 10000 || last_signed_at && last_signed_at > 10.seconds.ago
+    signature_count < 10000 #|| last_signed_at && last_signed_at > 10.seconds.ago
   end
 
   def increment_signature_count!(time = Time.current)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -349,10 +349,12 @@ class Petition < ActiveRecord::Base
     super
   end
 
+  def update_timestamps?
+    signature_count < 10000 || last_signed_at && last_signed_at > 10.seconds.ago
+  end
+
   def increment_signature_count!(time = Time.current)
     updates = []
-    updates << "last_signed_at = :now"
-    updates << "updated_at = :now"
 
     if pending?
       updates << "state = 'validated'"
@@ -372,10 +374,17 @@ class Petition < ActiveRecord::Base
       updates << "debate_state = 'awaiting'"
     end
 
-    if update_all([updates.join(", "), now: time]) > 0
-      Rails.cache.increment(cached_signature_count_key)
-      self.reload
+    if updates.size > 0 || update_timestamps?
+      updates << "last_signed_at = :now"
+      updates << "updated_at = :now"
     end
+
+    if updates.size > 0
+      update_all([updates.join(", "), now: time])
+    end
+
+    Rails.cache.increment(cached_signature_count_key)
+    self.reload
   end
 
   def at_threshold_for_moderation?

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -319,7 +319,7 @@ class Petition < ActiveRecord::Base
 
     if update_all([sql, query, Time.current]) > 0
       self.reload
-      Rails.cache.write(cached_signature_count_key, signature_count)
+      Rails.cache.write(cached_signature_count_key, signature_count, raw: true)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -338,6 +338,28 @@ FactoryGirl.define do
     trait :expired do
       end_date { 2.years.ago }
     end
+
+    trait :non_gb do
+      code do
+        country_code = Faker::Address.country_code
+        until country_code != 'GB'
+          country_code = Faker::Address.country_code
+        end
+        country_code
+      end
+      name do
+        country_name = Faker::Address.country
+        until country_name != 'United Kingdom'
+          country_name = Faker::Address.country
+        end
+        country_name
+      end
+    end
+
+    trait :gb do
+      code { 'GB' }
+      name { 'United Kingdom' }
+    end
   end
 
   factory :feedback do

--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe CountryPetitionJournal, type: :model do
   end
 
   describe ".record_new_signature_for" do
-    let!(:petition) { FactoryGirl.create(:open_petition) }
-    let!(:location) { FactoryGirl.create(:location) }
-    let!(:location_code) { location.code }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:location) { FactoryGirl.create(:location, :non_gb) }
+    let(:location_code) { location.code }
 
     def journal
       described_class.for(petition, location_code)
@@ -114,6 +114,17 @@ RSpec.describe CountryPetitionJournal, type: :model do
 
     context "when the supplied signature has no country" do
       let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, location_code: nil) }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.signature_count }
+      end
+    end
+
+    context "when the supplied signature is from the UK" do
+      let(:location) { FactoryGirl.create(:location, :gb) }
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: petition, location_code: location_code) }
 
       it "does nothing" do
         expect {

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1148,6 +1148,11 @@ RSpec.describe Petition, type: :model do
       })
     end
 
+    describe 'writes to the db are throttled' do
+      it 'never if the petition has 10,000 signatures or less'
+      it 'never if the petition was last signed more than 10 seconds ago'
+    end
+
     it "increases the signature count by 1" do
       expect{
         petition.increment_signature_count!


### PR DESCRIPTION
See commits for history.  We're reducing some of the writes issued during signature verification temporarily to reduce db locking under high load.