### PR TITLE
Calculate GB count for signatures_by_country in json

### DIFF
--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -37,6 +37,19 @@ module PetitionHelper
     petition_list_header.present?
   end
 
+  def api_signatures_by_country(petition)
+    signatures_by_country = petition.signatures_by_country
+    # remove 'GB' if it's there
+    signatures_without_gb = signatures_by_country.reject { |country| country.code == 'GB' }
+    signatures_without_gb + [
+      CountryPetitionJournal.new(
+        petition: petition,
+        location_code: 'GB',
+        signature_count: petition.cached_signature_count - signatures_without_gb.reduce(0) { |sum, country| sum + country.signature_count }
+      )
+    ]
+  end
+
   private
 
   def render_petition_hidden_details(stage_manager, form)

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -62,7 +62,7 @@ json.attributes do
   end
 
   if petition_page?
-    json.signatures_by_country petition.signatures_by_country do |country|
+    json.signatures_by_country api_signatures_by_country(petition) do |country|
       json.name country.name
       json.code country.code
       json.signature_count country.signature_count

--- a/spec/helpers/petition_helper_spec.rb
+++ b/spec/helpers/petition_helper_spec.rb
@@ -117,4 +117,79 @@ RSpec.describe PetitionHelper, type: :helper do
       end
     end
   end
+
+  describe '#api_signatures_by_country' do
+    before do
+      FactoryGirl.create(:location, :gb)
+    end
+
+    let(:petition) { FactoryGirl.create(:open_petition, signature_count: 22) }
+    subject { helper.api_signatures_by_country(petition) }
+
+    context 'when the petition has no country petition journals' do
+      it 'returns a single "GB" entry claiming all the signatures' do
+        expect(subject.size).to eq 1
+        expect(subject.first.code).to eq 'GB'
+        expect(subject.first.signature_count).to eq 22
+      end
+    end
+
+    context 'when the petition has country petition journals created by validating signatures' do
+      before do
+        fr = FactoryGirl.create(:location, code: 'FR')
+        de = FactoryGirl.create(:location, code: 'DE')
+        es = FactoryGirl.create(:location, code: 'ES')
+        FactoryGirl.create(:pending_signature, petition: petition, location_code: 'FR').validate!
+        FactoryGirl.create(:pending_signature, petition: petition, location_code: 'DE').validate!
+        # Note: these 2 GB sigs don't create a country petition journal as GB sigs are unrecorded (for now)
+        FactoryGirl.create(:pending_signature, petition: petition, location_code: 'GB').validate!
+        FactoryGirl.create(:pending_signature, petition: petition, location_code: 'GB').validate!
+        FactoryGirl.create(:pending_signature, petition: petition, location_code: 'FR').validate!
+
+        expect(CountryPetitionJournal.find_by(petition_id: petition.id, location_code: 'FR')).to be_present
+        expect(CountryPetitionJournal.find_by(petition_id: petition.id, location_code: 'DE')).to be_present
+        expect(CountryPetitionJournal.find_by(petition_id: petition.id, location_code: 'GB')).to be_nil
+
+        expect(petition.cached_signature_count).to eq 27
+      end
+
+      it 'returns an entry for each country with signatures' do
+        fr_data = subject.detect { |country| country.code == 'FR' }
+        expect(fr_data).to be_present
+        expect(fr_data.signature_count).to eq 2
+
+        de_data = subject.detect { |country| country.code == 'DE' }
+        expect(de_data).to be_present
+        expect(de_data.signature_count).to eq 1
+      end
+
+      it 'does not include an entry for a country with no signatures' do
+        es_data = subject.detect { |country| country.code == 'ES' }
+        expect(es_data).to be_nil
+      end
+
+      it 'calculates a value for the "GB" entry by subtracting the counts from the other countries' do
+        gb_data = subject.detect { |country| country.code == 'GB' }
+
+        expect(gb_data.signature_count).to eq 24
+      end
+
+      context 'when there is a country petition journal recorded before we stopped doing so' do
+        before do
+          CountryPetitionJournal.for(petition, 'GB').update_column(:signature_count, 10)
+        end
+
+        it 'only includes 1 GB entry' do
+          gb_data = subject.select { |country| country.code == 'GB' }
+          expect(gb_data.count).to eq 1
+        end
+
+        it 'ignores the jounral in the db and exposes the calculated value' do
+          gb_data = subject.detect { |country| country.code == 'GB' }
+          expect(gb_data.signature_count).to eq 24
+          expect(gb_data).not_to be_persisted
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api_request_helpers.rb
+++ b/spec/requests/api_request_helpers.rb
@@ -40,6 +40,21 @@ module ApiRequestHelpers
     end
   end
 
+  def assert_serialized_signatures_by_country(petition, attributes)
+    expect(attributes["signatures_by_country"]).to be_a Array
+    attributes["signatures_by_country"].each do |signatures_by_country|
+      expect(signatures_by_country).to be_a Hash
+      expect(signatures_by_country['code']).to be_in(petition.signatures_by_country.map(&:code) + ['GB'])
+      if signatures_by_country['code'] != 'GB'
+        petition_signatures_by_country = petition.signatures_by_country.detect { |country| country.name == signatures_by_country['name']}
+        expect(signatures_by_country['name']).to eq petition_signatures_by_country.name
+        expect(signatures_by_country['signature_count']).to eq petition_signatures_by_country.signature_count
+      else
+        calculated_gb_count = petition.cached_signature_count - petition.signatures_by_country.reject { |country| country.code == 'GB'}.reduce(0) { |sum, country| sum + country.signature_count }
+        expect(signatures_by_country['signature_count']).to eq calculated_gb_count
+      end
+    end
+  end
 
   def assert_serialized_petition(petition, serialized)
     # petition attributes

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -151,6 +151,21 @@ RSpec.describe 'API request to list petitions', type: :request, show_exceptions:
 
       assert_serialized_debate petition, json["data"][0]["attributes"]
     end
+
+    it 'does not include signatures_by_country' do
+      fr = FactoryGirl.create(:location, code: 'FR')
+      de = FactoryGirl.create(:location, code: 'DE')
+      gb = FactoryGirl.create(:location, :gb)
+      petition = FactoryGirl.create(:open_petition)
+      FactoryGirl.create(:pending_signature, petition: petition, location_code: 'FR').validate!
+      FactoryGirl.create(:pending_signature, petition: petition, location_code: 'DE').validate!
+      FactoryGirl.create(:pending_signature, petition: petition, location_code: 'GB').validate!
+      FactoryGirl.create(:pending_signature, petition: petition, location_code: 'GB').validate!
+      FactoryGirl.create(:pending_signature, petition: petition, location_code: 'FR').validate!
+      make_successful_request
+
+      expect(json['data'][0]['attributes']).not_to have_key('signatures_by_country')
+    end
   end
 end
 


### PR DESCRIPTION
In 8ae55cc26209e7ac1c7308c607d8cc7553f90af4 we stopped recording the country petition journal entries for 'GB' when people signed.  This meant the data in the JSON api response for a petition looked suspicious as the counts in signatures_by_country did not add up to the total signature_count.  To fix this we calculate the count for GB by subtracting the other country counts from the total count.

We take care to reject any existing GB entry to avoid duplicate entries in the feed.  Note that showing the API will now break if there is no GB Location instance as we'll end up trying to delegate the name of the GB to that instance.

Inserting the GB entry with the correct count is done in a helper method for the api.  Maybe it should be done in Petition#signatures_by_country directly?