### PR TITLE
Avoid setting state twice in increment_signature_count!

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -357,12 +357,14 @@ class Petition < ActiveRecord::Base
     updates = []
 
     if pending?
-      updates << "state = 'validated'"
+      updates = ["state = '#{VALIDATED_STATE}'"]
     end
 
     if at_threshold_for_moderation? && collecting_sponsors?
-      updates << "moderation_threshold_reached_at = :now"
-      updates << "state = 'sponsored'"
+      updates = [
+        "moderation_threshold_reached_at = :now",
+        "state = '#{Petition::SPONSORED_STATE}'"
+      ]
     end
 
     if at_threshold_for_response?

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1190,29 +1190,54 @@ RSpec.describe Petition, type: :model do
     context "when the signature count crosses the threshold for moderation" do
       let(:signature_count) { 5 }
 
-      let(:petition) do
-        FactoryGirl.create(:validated_petition, {
-          signature_count: signature_count,
-          last_signed_at: 2.days.ago,
-          updated_at: 2.days.ago
-        })
-      end
-
       before do
         expect(Site).to receive(:threshold_for_response).and_return(5)
       end
 
-      it "records the time it happened" do
-        petition.increment_signature_count!
-        expect(petition.moderation_threshold_reached_at).to be_within(1.second).of(Time.current)
+      context 'having already been validated by the creator' do
+        let(:petition) do
+          FactoryGirl.create(:validated_petition, {
+            signature_count: signature_count,
+            last_signed_at: 2.days.ago,
+            updated_at: 2.days.ago
+          })
+        end
+
+        it "records the time it happened" do
+          petition.increment_signature_count!
+          expect(petition.moderation_threshold_reached_at).to be_within(1.second).of(Time.current)
+        end
+
+        it "records changes the state from 'validated' to 'sponsored'" do
+          expect {
+            petition.increment_signature_count!
+          }.to change{
+            petition.state
+          }.from(Petition::VALIDATED_STATE).to(Petition::SPONSORED_STATE)
+        end
       end
 
-      it "records changes the state from 'validated' to 'sponsored'" do
-        expect {
+      context 'without having been validated by the creator yet' do
+        let(:petition) do
+          FactoryGirl.create(:pending_petition, {
+            signature_count: signature_count,
+            last_signed_at: 2.days.ago,
+            updated_at: 2.days.ago
+          })
+        end
+
+        it "records the time it happened" do
           petition.increment_signature_count!
-        }.to change{
-          petition.state
-        }.from(Petition::VALIDATED_STATE).to(Petition::SPONSORED_STATE)
+          expect(petition.moderation_threshold_reached_at).to be_within(1.second).of(Time.current)
+        end
+
+        it "records changes the state from 'validated' to 'sponsored'" do
+          expect {
+            petition.increment_signature_count!
+          }.to change{
+            petition.state
+          }.from(Petition::PENDING_STATE).to(Petition::SPONSORED_STATE)
+        end
       end
     end
 


### PR DESCRIPTION
When a petition is collecting sponsors but the creator has not yet validated their own email and we get to the sponsorship threshold we were trying to set the state to both 'validated' and 'sponsored'.  Postgres will complain if you try to set the same column multiple times in a single update and so the update would fail.  Instead of trying to set it twice we make sure to only set it once.

Note that it's not a huge problem if a creator doesn't directly validate their signature.  We know that their email is real if sponsors start coming in as the link for sponsors only appear in the email we send the creator.  If people are hitting that url then we know the email has been delivered so it's ok to go from 'pending' straight to 'sponsored'.