### PR TITLE
Move petition updating to background

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -112,16 +112,6 @@ class SignaturesController < ApplicationController
                :postcode, :location_code, :uk_citizenship)
   end
 
-  def send_sponsor_support_notification_email_to_petition_owner(petition, signature)
-    sponsor = petition.sponsors.for(signature)
-
-    if petition.in_moderation?
-      SponsorSignedEmailOnThresholdEmailJob.perform_later(petition, sponsor)
-    elsif petition.collecting_sponsors?
-      SponsorSignedEmailBelowThresholdEmailJob.perform_later(petition, sponsor)
-    end
-  end
-
   def find_existing_pending_signatures
     @signature = Signature.new(signature_params_for_create)
     @signature.email.strip!
@@ -153,7 +143,6 @@ class SignaturesController < ApplicationController
       redirect_to sponsored_petition_sponsor_url(@signature.petition, token: @signature.petition.sponsor_token)
     else
       @signature.validate!
-      send_sponsor_support_notification_email_to_petition_owner(@signature.petition, @signature)
 
       if @signature.petition.open?
         redirect_to signed_signature_url(@signature, token: @signature.perishable_token)

--- a/app/jobs/petition_signed_data_update_job.rb
+++ b/app/jobs/petition_signed_data_update_job.rb
@@ -1,0 +1,23 @@
+class PetitionSignedDataUpdateJob < ActiveJob::Base
+  queue_as :high_priority
+
+  def perform(signature)
+    ConstituencyPetitionJournal.record_new_signature_for(signature)
+    CountryPetitionJournal.record_new_signature_for(signature)
+    signature.petition.increment_signature_count!
+
+    if signature.sponsor?
+      send_sponsor_support_notification_email_to_petition_owner(signature)
+    end
+  end
+
+  def send_sponsor_support_notification_email_to_petition_owner(signature)
+    petition = signature.petition
+
+    if petition.in_moderation?
+      SponsorSignedEmailOnThresholdEmailJob.perform_later(petition, signature.sponsor)
+    elsif petition.collecting_sponsors?
+      SponsorSignedEmailBelowThresholdEmailJob.perform_later(petition, signature.sponsor)
+    end
+  end
+end

--- a/app/jobs/petition_signed_data_update_job.rb
+++ b/app/jobs/petition_signed_data_update_job.rb
@@ -1,5 +1,5 @@
 class PetitionSignedDataUpdateJob < ActiveJob::Base
-  queue_as :high_priority
+  queue_as :highest_priority
 
   def perform(signature)
     ConstituencyPetitionJournal.record_new_signature_for(signature)

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -122,9 +122,7 @@ class Signature < ActiveRecord::Base
     end
 
     if update_signature_counts
-      ConstituencyPetitionJournal.record_new_signature_for(self)
-      CountryPetitionJournal.record_new_signature_for(self)
-      petition.increment_signature_count!
+      PetitionSignedDataUpdateJob.perform_later(self)
     end
   end
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -88,7 +88,8 @@ class Signature < ActiveRecord::Base
   end
 
   def sponsor?
-    petition.sponsor_signatures.exists? self.id
+    # avoid loading the object just to check if it's there
+    association(:sponsor).scope.exists? # petition.sponsor_signatures.exists? self.id
   end
 
   def pending?

--- a/config/disposable_domains.yml
+++ b/config/disposable_domains.yml
@@ -516,7 +516,7 @@ production:
   - forecastertests.com
   - forgetmail.com
   - forspam.net
-  - forward.net
+  - forward.cat
   - fr33mail.info
   - francanet.com.br
   - frapmail.com

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -46,7 +46,7 @@ module Delayed
   module Backend
     module ActiveRecord
       class Job < ::ActiveRecord::Base
-        QUEUE_PRIORITIES = { "high_priority" => 0, "low_priority" => 50 }
+        QUEUE_PRIORITIES = { "highest_priority" => 0, "high_priority" => 10, "low_priority" => 50 }
         QUEUE_PRIORITIES.default = 25
 
         before_create do

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
       context "when moderation param is 'approve'" do
         let(:now) { Time.current }
         let(:deliveries) { ActionMailer::Base.deliveries }
-        let(:creator_email) { deliveries.detect{ |m| m.to == %w[bazbutler@gmail.com] } }
+        let(:creator_email) { deliveries.select{ |m| m.to == %w[bazbutler@gmail.com] }.last }
         let(:sponsor_email) { deliveries.detect{ |m| m.to == %w[laurapalmer@gmail.com] } }
         let(:pending_email) { deliveries.detect{ |m| m.to == %w[sandyfisher@hotmail.com] } }
         let(:duration) { Site.petition_duration.months }

--- a/spec/jobs/job_priority_spec.rb
+++ b/spec/jobs/job_priority_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe "setting job priorities" do
       job_class.perform_later
     end
 
+    describe 'the highest priority job' do
+      let(:job_class) do
+        Class.new(ActiveJob::Base) do
+          queue_as :highest_priority
+
+          def perform
+            logger.info("Highest priority job")
+          end
+        end
+      end
+
+      it "is queued with a priority of 0" do
+        expect(priority).to eq(0)
+      end
+    end
+
     describe "a high priority job" do
       let(:job_class) do
         Class.new(ActiveJob::Base) do
@@ -30,8 +46,8 @@ RSpec.describe "setting job priorities" do
         end
       end
 
-      it "is queued with a priority of 0" do
-        expect(priority).to eq(0)
+      it "is queued with a priority of 10" do
+        expect(priority).to eq(10)
       end
     end
 

--- a/spec/jobs/petition_signed_data_update_job_spec.rb
+++ b/spec/jobs/petition_signed_data_update_job_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe PetitionSignedDataUpdateJob, type: :job do
+  let(:signature) { FactoryGirl.create(:pending_signature, petition: petition, created_at: 2.days.ago, updated_at: 2.days.ago) }
+
+  def running_the_job
+    perform_enqueued_jobs {
+      described_class.perform_later(signature)
+    }
+  end
+  alias_method :run_the_job, :running_the_job
+
+  context "when the petition is open" do
+    let(:petition) { FactoryGirl.create(:open_petition, created_at: 2.days.ago, updated_at: 2.days.ago) }
+
+    it "increments the petition count" do
+      expect{ running_the_job }.to change{ petition.reload.signature_count }.by(1)
+    end
+
+    it "updates the petition to say it was updated just now" do
+      expect{ running_the_job }.to change { petition.reload.updated_at }
+      expect(petition.updated_at).to be_within(1.second).of(Time.current)
+    end
+
+    it "updates the petition to say it was last signed at just now" do
+      expect{ running_the_job }.to change { petition.reload.last_signed_at }
+      expect(petition.last_signed_at).to be_within(1.second).of(Time.current)
+    end
+
+    it 'tells the relevant constituency petition journal to record a new signature' do
+      expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(signature)
+      run_the_job
+    end
+
+    it 'tells the relevant country petition journal to record a new signature' do
+      expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
+      run_the_job
+    end
+  end
+
+  context "when the petition is pending" do
+    let(:petition) { FactoryGirl.create(:pending_petition, created_at: 2.days.ago, updated_at: 2.days.ago) }
+
+    it "increments the petition count" do
+      expect{ running_the_job }.to change{ petition.reload.signature_count }.by(1)
+    end
+
+    it "updates the petition to say it was updated just now" do
+      expect{ running_the_job }.to change { petition.reload.updated_at }
+      expect(petition.updated_at).to be_within(1.second).of(Time.current)
+    end
+
+    it "updates the petition to say it was last signed at just now" do
+      expect{ running_the_job }.to change { petition.reload.last_signed_at }
+      expect(petition.last_signed_at).to be_within(1.second).of(Time.current)
+    end
+
+    it 'tells the relevant constituency petition journal to record a new signature' do
+      expect(ConstituencyPetitionJournal).to receive(:record_new_signature_for).with(signature)
+      run_the_job
+    end
+
+    it 'tells the relevant country petition journal to record a new signature' do
+      expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
+      run_the_job
+    end
+
+    context 'and the signature is a sponsor' do
+      let(:petition) { FactoryGirl.create(:petition) }
+      let(:sponsor) { FactoryGirl.create(:sponsor, petition: petition) }
+      let(:signature) { sponsor.create_signature(FactoryGirl.attributes_for(:pending_signature, petition: petition)) }
+
+      it "sets petition state to validated" do
+        expect {
+          running_the_job
+        }.to change { petition.reload.state }.from(Petition::PENDING_STATE).to(Petition::VALIDATED_STATE)
+      end
+
+      it 'sends email notification to the petition creator' do
+        run_the_job
+        email = ActionMailer::Base.deliveries.last
+        expect(email.to).to eq([petition.creator_signature.email])
+      end
+
+      context "and the petition is published" do
+        before do
+          petition.publish
+          petition.reload
+          ActionMailer::Base.deliveries.clear
+        end
+
+        it "does not send an email to the creator" do
+          run_the_job
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -555,6 +555,12 @@ RSpec.describe Petition, type: :model do
     let(:petition) { FactoryGirl.create(:pending_petition) }
     let(:signature) { FactoryGirl.create(:pending_signature, petition: petition) }
 
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+
     before do
       petition.validate_creator_signature!
     end
@@ -1547,6 +1553,12 @@ RSpec.describe Petition, type: :model do
   describe "#validate_creator_signature!" do
     let(:petition) { FactoryGirl.create(:pending_petition, attributes) }
     let(:signature) { petition.creator_signature }
+
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
 
     let(:attributes) do
       { created_at: 2.days.ago, updated_at: 2.days.ago }

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Signature, type: :model do
     expect(FactoryGirl.build(:signature)).to be_valid
   end
 
+  around do |example|
+    perform_enqueued_jobs do
+      example.call
+    end
+  end
+
   context "defaults" do
     it "has pending as default state" do
       s = Signature.new
@@ -412,7 +418,7 @@ RSpec.describe Signature, type: :model do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
 
-      expect(signature.petition.signature_count).to eq(7)
+      expect(signature.petition.reload.signature_count).to eq(7)
       expect(signature.number).to eq(7)
     end
 
@@ -423,10 +429,10 @@ RSpec.describe Signature, type: :model do
       signature = FactoryGirl.create(:pending_signature, petition: petition)
       signature.validate!
 
-      expect(other_signature.petition.signature_count).to eq(7)
+      expect(other_signature.petition.reload.signature_count).to eq(7)
       expect(other_signature.number).to eq(7)
 
-      expect(signature.petition.signature_count).to eq(7)
+      expect(signature.petition.reload.signature_count).to eq(7)
       expect(signature.number).to eq(7)
     end
 


### PR DESCRIPTION
Move the calls to `Petition#increment_signature_count!` and writing to the petition journals into a background process.  This allows us to control write contention if we need to.  We also introduce a new priority queue (by demoting existing "high_priority" queue down a notch).

We also include the commit fixing the disposable domains that we did on the production-hotfixes-jun-2016 branch but not on master.