### PR TITLE
Disallow plus addressing in emails

### DIFF
--- a/app/models/staged/validations/email.rb
+++ b/app/models/staged/validations/email.rb
@@ -4,31 +4,7 @@ module Staged
       extend ActiveSupport::Concern
 
       included do
-        validates :email, presence: true, format: { with: EMAIL_REGEX, allow_blank: true }
-
-        validate do
-          errors.add :email, :disposable if disposable_domain?
-        end
-      end
-
-      private
-
-      def disposable_domain?
-        return false unless email?
-
-        begin
-          disposable_domains.include?(parsed_email.domain)
-        rescue Mail::Field::ParseError
-          false
-        end
-      end
-
-      def parsed_email
-        Mail::Address.new(email)
-      end
-
-      def disposable_domains
-        Rails.application.config.x.disposable_domains
+        validates :email, presence: true, email: { allow_blank: true }
       end
     end
   end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,29 @@
+class EmailValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value =~ EMAIL_REGEX
+      email = parsed_email(value)
+      record.errors.add :email, :disposable if disposable_domain?(email)
+      record.errors.add :email, :plus_address if plus_address?(email)
+    else
+      record.errors.add attribute, :invalid
+    end
+  rescue Mail::Field::ParseError
+    record.errors.add attribute, :invalid
+  end
+
+  def plus_address?(parsed_email)
+    parsed_email.local.include? '+'
+  end
+
+  def disposable_domain?(parsed_email)
+    disposable_domains.include?(parsed_email.domain)
+  end
+
+  def parsed_email(email)
+    Mail::Address.new(email)
+  end
+
+  def disposable_domains
+    Rails.application.config.x.disposable_domains
+  end
+end

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -51,6 +51,7 @@ en-GB:
         blank: "Email must be completed"
         invalid: "Email '%{value}' not recognised"
         disposable: "You can’t use a disposable email address"
+        plus_address: "You can't use 'plus addressing' in your email address"
       action:
         blank: "Action must be completed"
         too_long: "Action is too long"

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe Signature, type: :model do
       expect(signature.errors.full_messages).to include("You can’t use a disposable email address")
     end
 
+    it "does not allow emails using plus addresses" do
+      signature = FactoryGirl.build(:signature, email: 'foobar+petitions@example.com')
+      expect(signature).not_to have_valid(:email)
+      expect(signature.errors.full_messages).to include("You can't use 'plus addressing' in your email address")
+    end
+
     describe "uniqueness of email" do
       let(:petition) { FactoryGirl.create(:open_petition) }
       let(:other_petition) { FactoryGirl.create(:open_petition) }


### PR DESCRIPTION
We'd wanted to leave this in as there are legitimate usecases, but plus addresses make it trivial to sign multiple times from the same email account.

This commit refactors the inline validations from the staged validations into a activemodel validator.