### PR TITLE
Use typographic quotes and apostrophe in error msg

### DIFF
--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -51,7 +51,7 @@ en-GB:
         blank: "Email must be completed"
         invalid: "Email '%{value}' not recognised"
         disposable: "You can’t use a disposable email address"
-        plus_address: "You can't use 'plus addressing' in your email address"
+        plus_address: "You can’t use ‘plus addressing’ in your email address"
       action:
         blank: "Action must be completed"
         too_long: "Action is too long"

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Signature, type: :model do
     it "does not allow emails using plus addresses" do
       signature = FactoryGirl.build(:signature, email: 'foobar+petitions@example.com')
       expect(signature).not_to have_valid(:email)
-      expect(signature.errors.full_messages).to include("You can't use 'plus addressing' in your email address")
+      expect(signature.errors.full_messages).to include("You can’t use ‘plus addressing’ in your email address")
     end
 
     describe "uniqueness of email" do


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard

– http://smartquotesforsmartpeople.com

;)