### PR TITLE
Increase signal to noise ratio on exceptions

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -3,7 +3,7 @@ class FeedbackController < ApplicationController
 
   before_action :build_feedback, only: [:new, :create]
 
-  def index
+  def new
     respond_with @feedback
   end
 
@@ -16,6 +16,9 @@ class FeedbackController < ApplicationController
   end
 
   def thanks
+    respond_to do |format|
+      format.html
+    end
   end
 
   private

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -10,6 +10,9 @@ class LocalPetitionsController < ApplicationController
   before_action :redirect_to_constituency, if: :constituency?, only: :index
 
   def index
+    respond_to do |format|
+      format.html
+    end
   end
 
   def show

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -13,6 +13,7 @@ class PetitionsController < ApplicationController
 
   def index
     @petitions = Petition.visible.search(params)
+    respond_with @petitions
   end
 
   def show
@@ -35,19 +36,36 @@ class PetitionsController < ApplicationController
       send_email_to_gather_sponsors(@stage_manager.petition)
       redirect_to thank_you_petition_url(@stage_manager.petition)
     else
-      render :new
+      respond_to do |format|
+        format.html { render :new }
+      end
     end
   end
 
   def check
+    respond_to do |format|
+      format.html
+    end
   end
 
   def check_results
     @petitions = Petition.visible.search(params.merge(count: 3))
+    respond_to do |format|
+      format.html
+    end
   end
 
   def moderation_info
     @petition = Petition.find(params[:id])
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def thank_you
+    respond_to do |format|
+      format.html
+    end
   end
 
   protected

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -33,6 +33,9 @@ class SignaturesController < ApplicationController
     else
       @signature.mark_seen_signed_confirmation_page!
       @petition = @signature.petition
+      respond_to do |format|
+        format.html
+      end
     end
   end
 
@@ -46,6 +49,15 @@ class SignaturesController < ApplicationController
 
   def unsubscribe
     @signature.unsubscribe!(token_param)
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def thank_you
+    respond_to do |format|
+      format.html
+    end
   end
 
   private
@@ -133,7 +145,9 @@ class SignaturesController < ApplicationController
       send_email_to_petition_signer(@stage_manager.signature)
       respond_with @stage_manager.stage_object, :location => thank_you_petition_signatures_url(petition)
     else
-      render :new
+      respond_to do |format|
+        format.html { render :new }
+      end
     end
   end
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -13,6 +13,7 @@ class SponsorsController < ApplicationController
     assign_stage
     @sponsor = @petition.sponsors.build
     @stage_manager = Staged::PetitionSigner.manage(signature_params_for_new, request, @petition, params[:stage], params[:move])
+    respond_with @sponsor
   end
 
   def update
@@ -26,14 +27,22 @@ class SponsorsController < ApplicationController
       send_email_to_sponsor(@sponsor)
       redirect_to thank_you_petition_sponsor_url(@petition, token: @petition.sponsor_token)
     else
-      render :show
+      respond_to do |format|
+        format.html { render :show }
+      end
     end
   end
 
   def thank_you
+    respond_to do |format|
+      format.html
+    end
   end
 
   def sponsored
+    respond_to do |format|
+      format.html
+    end
   end
 
   private

--- a/app/jobs/petition_signed_data_update_job.rb
+++ b/app/jobs/petition_signed_data_update_job.rb
@@ -1,6 +1,10 @@
 class PetitionSignedDataUpdateJob < ActiveJob::Base
   queue_as :highest_priority
 
+  rescue_from(ActiveJob::DeserializationError) do |exception|
+    Appsignal.send_exception exception
+  end
+
   def perform(signature)
     ConstituencyPetitionJournal.record_new_signature_for(signature)
     CountryPetitionJournal.record_new_signature_for(signature)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
     get '/' => 'pages#index', :as => :home
     get 'help' => 'pages#help', :as => :help
     get 'privacy' => 'pages#privacy', :as => :privacy
-    get 'browserconfig' => 'pages#browserconfig', format: 'xml'
-    get 'manifest' => 'pages#manifest', format: 'json'
+    get 'browserconfig' => 'pages#browserconfig', format: true, constraints: { format: 'xml' }
+    get 'manifest' => 'pages#manifest', format: true, constraints: { format: 'json' }
 
     get  'feedback', to: 'feedback#new', as: 'feedback'
     post 'feedback', to: 'feedback#create', as: nil

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -1,0 +1,341 @@
+require 'rails_helper'
+
+RSpec.describe 'Requests for pages when we do not support the format on that page', type: :request, show_exceptions: true do
+
+  let(:petition) { FactoryGirl.create :open_petition }
+
+  shared_examples 'a route that only supports html formats' do |headers_only: false|
+    unless headers_only
+      it 'does not support json via extension' do
+        get url + '.json', params
+        expect(response.status).to eq 406
+      end
+
+      it 'does not support xml via extension' do
+        get url + '.xml', params
+        expect(response.status).to eq 406
+      end
+    end
+
+    it 'supports html' do
+      get url, params
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :html
+    end
+
+    it 'does not support json via accepts header' do
+      get url, params, {'Accept' => 'application/json'}
+      expect(response.status).to eq 406
+    end
+
+    it 'does not support xml via accepts header' do
+      get url, params,  {'Accept' => 'application/xml'}
+      expect(response.status).to eq 406
+    end
+  end
+
+  shared_examples 'a route that supports html and json formats' do |headers_only: false|
+    unless headers_only
+      it 'supports json via extension' do
+        get url + '.json', params
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq :json
+      end
+
+      it 'does not support xml via extension' do
+        get url + '.xml', params
+        expect(response.status).to eq 406
+      end
+    end
+
+    it 'supports html' do
+      get url, params
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :html
+    end
+
+    it 'supports json via accepts header' do
+      get url, params, {'Accept' => 'application/json'}
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :json
+    end
+
+    it 'does not support xml via accepts header' do
+      get url, params,  {'Accept' => 'application/xml'}
+      expect(response.status).to eq 406
+    end
+  end
+
+  shared_examples 'a POST route where failure only supports html formats' do
+    around do |example|
+      begin
+        ActionController::Base.allow_forgery_protection = false
+        example.call
+      ensure
+        ActionController::Base.allow_forgery_protection = true
+      end
+    end
+
+    it 'does not support json via extension' do
+      post url + '.json', params
+      expect(response.status).to eq 406
+    end
+
+    it 'does not support xml via extension' do
+      post url + '.xml', params
+      expect(response.status).to eq 406
+    end
+
+    it 'supports html' do
+      post url, params
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :html
+    end
+
+    it 'does not support json via accepts header' do
+      post url, params, {'Accept' => 'application/json'}
+      expect(response.status).to eq 406
+    end
+
+    it 'does not support xml via accepts header' do
+      post url, params, {'Accept' => 'application/xml'}
+      expect(response.status).to eq 406
+    end
+  end
+
+  context 'the root url' do
+    let(:url) { '/' }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats', headers_only: true
+  end
+
+  simple_html_only_urls = [
+    'help', 'privacy', 'feedback', 'feedback/thanks', 'petitions/local',
+    'petitions/check', 'petitions/check_results', 'petitions/new'
+  ]
+  simple_html_only_urls.each do |simple_url|
+    context "the #{simple_url} url" do
+      let(:url) { "/#{simple_url}" }
+      let(:params) { {} }
+
+      it_behaves_like 'a route that only supports html formats'
+    end
+  end
+
+  simple_html_and_json_urls = [
+    'petitions', 'archived/petitions'
+  ]
+  simple_html_and_json_urls.each do |simple_url|
+    context "the #{simple_url} url" do
+      let(:url) { "/#{simple_url}" }
+      let(:params) { {} }
+
+      it_behaves_like 'a route that supports html and json formats'
+    end
+  end
+
+  context 'the petitions/local results url' do
+    let(:url) { "/petitions/local/#{constituency.slug}" }
+    let(:constituency) { FactoryGirl.create(:constituency) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions show url' do
+    let(:url) { "/petitions/#{petition.id}" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that supports html and json formats'
+  end
+
+  context 'the petitions/thank-you url' do
+    let(:url) { "/petitions/#{petition.id}/thank-you" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions/moderation-info url' do
+    let(:url) { "/petitions/#{petition.id}/moderation-info" }
+    let(:petition) { FactoryGirl.create(:sponsored_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions/sponsors show url' do
+    let(:url) { "/petitions/#{petition.id}/sponsors/#{petition.sponsor_token}" }
+    let(:petition) { FactoryGirl.create(:pending_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions/sponsors/thank-you url' do
+    let(:url) { "/petitions/#{petition.id}/sponsors/#{petition.sponsor_token}/thank-you" }
+    let(:petition) { FactoryGirl.create(:pending_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions/sponsors/sponsored url' do
+    let(:url) { "/petitions/#{petition.id}/sponsors/#{petition.sponsor_token}/sponsored" }
+    let(:petition) { FactoryGirl.create(:pending_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions/signatures/new url' do
+    let(:url) { "/petitions/#{petition.id}/signatures/new" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the petitions/signatures/thank-you url' do
+    let(:url) { "/petitions/#{petition.id}/signatures/thank-you" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the signatures/signed url' do
+    let(:url) { "/signatures/#{signature.id}/signed" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:signature) { FactoryGirl.create(:validated_signature, :just_signed, petition: petition) }
+    let(:params) {
+      {
+        'token' => signature.perishable_token
+      }
+    }
+    before do
+      allow(Constituency).to receive(:find_by_postcode).and_return(nil)
+    end
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  # NOTE: we don't have a context for the signatures/verify url
+  # because current implementation is that it *always* redirects, so no
+  # content negotiation is required
+
+  context 'the signatures/unsubscribe url' do
+    let(:url) { "/signatures/#{signature.id}/unsubscribe" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:signature) { FactoryGirl.create(:validated_signature, petition: petition) }
+    let(:params) {
+      {
+        'token' => signature.unsubscribe_token
+      }
+    }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
+  context 'the archived/petitions show url' do
+    let(:url) { "/archived/petitions/#{petition.id}" }
+    let(:petition) { FactoryGirl.create(:archived_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that supports html and json formats'
+  end
+
+  context 'the browserconfig url' do
+    let(:url) { '/browserconfig' }
+    let(:params) { {} }
+
+    it 'does not support json via extension' do
+      get url + '.json', params
+      expect(response.status).to eq 404
+    end
+
+    it 'supports xml via extension' do
+      get url + '.xml', params
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :xml
+    end
+
+    it 'does not response without an extension' do
+      get url, params
+      expect(response.status).to eq 404
+    end
+  end
+
+  context 'the manifest url' do
+    let(:url) { '/manifest' }
+    let(:params) { {} }
+
+    it 'does not support xml via extension' do
+      get url + '.xml', params
+      expect(response.status).to eq 404
+    end
+
+    it 'supports xml via extension' do
+      get url + '.json', params
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :json
+    end
+
+    it 'does not response without an extension' do
+      get url, params
+      expect(response.status).to eq 404
+    end
+  end
+
+  # NOTE: we only check failed posts for petitions/new, signatures/new, and
+  # feedback because the success case will redirect and no content-negotiation
+  # is required.
+  context 'a failed post to petitions/new' do
+    let(:url) { '/petitions/new' }
+    let(:params) {
+      {
+        'stage' => 'replay-email',
+        'move' => 'next',
+        'petition' => {
+          'background' => 'Limit temperature rise at two degrees',
+          'additional_details' => 'Global warming is upon us',
+          'creator_signature' => {
+            'name' => 'John Mcenroe', 'email' => 'john@example.com',
+            'postcode' => 'SE3 4LL', 'location_code' => 'GB',
+            'uk_citizenship' => '1'
+          }
+        }
+      }
+    }
+
+    it_behaves_like 'a POST route where failure only supports html formats'
+  end
+
+  context 'a failed post to signatures/new' do
+    let(:url) { "/petitions/#{petition.id}/signatures/new" }
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:params) {
+      {
+        'stage' => 'replay-email',
+        'move' => 'next',
+        'petition_id' => "#{petition.id}",
+        'signature' => {
+          'name' => 'John Mcenroe', 'email' => 'john@example.com',
+          'postcode' => 'SE3 4LL', 'location_code' => 'GB'
+        }
+      }
+    }
+
+    it_behaves_like 'a POST route where failure only supports html formats'
+  end
+
+  context 'a failed post to feedback' do
+    let(:url) { '/feedback' }
+    let(:params) { {} }
+
+    it_behaves_like 'a POST route where failure only supports html formats'
+  end
+end

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'API request to list petitions', type: :request, show_exceptions:
 
     it "does not respond to XML" do
       get petitions_url(format: 'xml')
-      expect(response.status).to eq(500)
+      expect(response.status).to eq(406)
     end
   end
 


### PR DESCRIPTION
We get some exceptions that we know we can ignore (MissingTemplate for formats we don't support), or that we only want to happen once not repeatedly (Deserialization errors in the new petition signed data update job caused by deleted signatures).  These commits aim to sort this out.