### PR TITLE
Retry email jobs when we receive an EOFError

### DIFF
--- a/app/jobs/concerns/email_delivery.rb
+++ b/app/jobs/concerns/email_delivery.rb
@@ -17,7 +17,8 @@ module EmailDelivery
     Errno::ECONNRESET,
     Errno::ECONNREFUSED,
     Errno::ETIMEDOUT,
-    Timeout::Error
+    Timeout::Error,
+    EOFError
   ]
 
   included do

--- a/app/jobs/email_job.rb
+++ b/app/jobs/email_job.rb
@@ -13,7 +13,8 @@ class EmailJob < ActiveJob::Base
     Errno::ECONNRESET,
     Errno::ECONNREFUSED,
     Errno::ETIMEDOUT,
-    Timeout::Error
+    Timeout::Error,
+    EOFError
   ]
 
   queue_as :high_priority


### PR DESCRIPTION
Every now and again the SES SMTP gives an EOFError for a variety of reasons. When this happens we should just retry the job.