### PR TITLE
Fix RSpec warning about false positives

### DIFF
--- a/spec/jobs/petition_signed_data_update_job_spec.rb
+++ b/spec/jobs/petition_signed_data_update_job_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe PetitionSignedDataUpdateJob, type: :job do
     end
 
     it 'does not raise the deserialization problem (which would cause the worker to requeue the job)' do
-      expect {
-        running_the_job
-      }.not_to raise_error(ActiveJob::DeserializationError)
+      expect { running_the_job }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
Using `not_to raise_error` with a specific class can hide problems with the code causing errors of another kind so follow the recommended practice of not using a specific class.