### PR TITLE
Fix ActiveRecord::RecordNotUnique errors

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -149,6 +149,8 @@ class SignaturesController < ApplicationController
         format.html { render :new }
       end
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    redirect_to thank_you_petition_signatures_url(petition)
   end
 
   def validate_sponsor

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -430,6 +430,19 @@ RSpec.describe SignaturesController, type: :controller do
           expect(response).to render_template(:new)
         end
       end
+
+      context "when a race condition occurs" do
+        let(:exception) { ActiveRecord::RecordNotUnique.new("PG::UniqueViolation") }
+        before do
+          FactoryGirl.create(:validated_signature, signature_params.merge(petition_id: petition.id))
+          allow_any_instance_of(Signature).to receive(:save).and_raise(exception)
+        end
+
+        it "redirects to the thank you page" do
+          do_post(stage: 'done')
+          expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/signatures/thank-you")
+        end
+      end
     end
 
     context "when the petition is closed" do


### PR DESCRIPTION
When someone does a double submit we can get uniqueness exceptions from the database. In these circumstances just redirect to the thank you page as the first request will have sent the email.