### PR TITLE
Increase the time the script will wait to enter standby

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -546,10 +546,10 @@ class PackageBuilder
       DEBUG=true
 
       # Number of times to check for a resouce to be in the desired state.
-      WAITER_ATTEMPTS=60
+      WAITER_ATTEMPTS=100
 
       # Number of seconds to wait between attempts for resource to be in a state.
-      WAITER_INTERVAL=1
+      WAITER_INTERVAL=3
 
       # AutoScaling Standby features at minimum require this version to work.
       MIN_CLI_VERSION='1.3.25'


### PR DESCRIPTION
A number of deploys recently have failed to deregister from the ELB properly so the ApplicationStop phase fails but the deploy carrying on leading to the app serving requests from stale code.

The ELB connection draining timeout was reduced but didn't resolve the problem so seeing whether increasing the timeout in the script instead to see if that eliminates the problem.