### PR TITLE
Add functionality to admin invalidations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     mime-types (2.99.1)
     mimemagic (0.3.0)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     multi_json (1.11.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -264,7 +264,7 @@ GEM
     scrypt (2.0.2)
       ffi-compiler (>= 0.0.2)
       rake
-    shoulda-matchers (3.0.1)
+    shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     slack-notifier (1.4.0)
     slop (3.6.0)

--- a/app/assets/stylesheets/petitions/_search-inline.scss
+++ b/app/assets/stylesheets/petitions/_search-inline.scss
@@ -1,7 +1,7 @@
 .search-inline {
   @extend %contain-floats;
 
-  .form-control {
+  input.form-control {
     @include appearance(none);
     @include box-sizing(content-box);
     float: left;
@@ -33,5 +33,13 @@
     &:hover, &:focus {
       background-color: darken($petitions-panel-colour, 5%);
     }
+  }
+
+  .inline-button {
+    @include bold-19;
+    width: auto;
+    height: 40px;
+    line-height: 40px;
+    padding: 0px em(19, 24);
   }
 }

--- a/app/assets/stylesheets/petitions/admin/_list.scss
+++ b/app/assets/stylesheets/petitions/admin/_list.scss
@@ -31,4 +31,17 @@
       text-align: left;
     }
   }
+
+  .invalidation-list {
+    th, td {
+      text-align: right;
+    }
+
+    th:first-child, td:first-child {
+      text-align: left;
+    }
+
+    th:last-child, td:last-child {
+    }
+  }
 }

--- a/app/assets/stylesheets/petitions/admin/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_shared.scss
@@ -23,7 +23,7 @@
     margin: 5px 0;
   }
 
-  .search-petitions {
+  .search-petitions, .search-invalidations {
     margin-bottom: $gutter-half;
   }
 
@@ -73,8 +73,12 @@
       line-height: 16px;
     }
   }
-  
+
   .edit-petition-link {
     margin-top: 15px;
+  }
+
+  .auto-width {
+    width: auto;
   }
 }

--- a/app/controllers/admin/invalidations_controller.rb
+++ b/app/controllers/admin/invalidations_controller.rb
@@ -1,0 +1,134 @@
+class Admin::InvalidationsController < Admin::AdminController
+  before_action :require_sysadmin
+  before_action :build_invalidation, only: [:new, :create]
+  before_action :find_invalidation, only: [:edit, :update, :destroy, :count, :cancel, :start]
+  before_action :find_invalidations, only: [:index]
+
+  def index
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def new
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def create
+    if @invalidation.save
+      redirect_to admin_invalidations_url, notice: "Invalidation created successfully"
+    else
+      respond_to do |format|
+        format.html { render :new }
+      end
+    end
+  end
+
+  def edit
+    if @invalidation.pending?
+      respond_to do |format|
+        format.html
+      end
+    else
+      redirect_to_index_url notice: "Can't edit invalidations that aren't pending"
+    end
+  end
+
+  def update
+    if @invalidation.pending?
+      if @invalidation.update(invalidation_params)
+        redirect_to admin_invalidations_url, notice: "Invalidation updated successfully"
+      else
+        respond_to do |format|
+          format.html { render :edit }
+        end
+      end
+    else
+      redirect_to_index_url notice: "Can't edit invalidations that aren't pending"
+    end
+  end
+
+  def destroy
+    if @invalidation.started?
+      redirect_to_index_url notice: "Can't remove invalidations that have started"
+    else
+      if @invalidation.destroy
+        redirect_to_index_url notice: "Invalidation removed successfully"
+      else
+        redirect_to_index_url alert: "Invalidation could not be removed - please contact support"
+      end
+    end
+  end
+
+  def cancel
+    if @invalidation.completed?
+      redirect_to_index_url notice: "Can't cancel invalidations that have completed"
+    else
+      if @invalidation.cancel!
+        redirect_to_index_url notice: "Invalidation cancelled successfully"
+      else
+        redirect_to_index_url alert: "Invalidation could not be cancelled - please contact support"
+      end
+    end
+  end
+
+  def count
+    if @invalidation.pending?
+      if @invalidation.count!
+        redirect_to_index_url notice: "Counted the matching signatures for invalidation #{@invalidation.summary.inspect}"
+      else
+        redirect_to_index_url alert: "Invalidation could not be counted - please contact support"
+      end
+    else
+      redirect_to_index_url notice: "Can't count invalidations that aren't pending"
+    end
+  end
+
+  def start
+    if @invalidation.pending?
+      if @invalidation.start!
+        redirect_to_index_url notice: "Enqueued the invalidation #{@invalidation.summary.inspect}"
+      else
+        redirect_to_index_url alert: "Invalidation could not be enqueued - please contact support"
+      end
+    else
+      redirect_to_index_url notice: "Can't start invalidations that aren't pending"
+    end
+  end
+
+  private
+
+  def invalidation_params
+    if params.key?(:invalidation)
+      params.require(:invalidation).permit(*invalidation_attributes)
+    else
+      {}
+    end
+  end
+
+  def invalidation_attributes
+    %i[summary details] + Invalidation::CONDITIONS
+  end
+
+  def build_invalidation
+    @invalidation = Invalidation.new(invalidation_params)
+  end
+
+  def find_invalidation
+    @invalidation = Invalidation.find(params[:id])
+  end
+
+  def find_invalidations
+    @invalidations = Invalidation.search(params)
+  end
+
+  def index_url
+    admin_invalidations_url(params.slice(:state, :q))
+  end
+
+  def redirect_to_index_url(options = {})
+    redirect_to index_url, options
+  end
+end

--- a/app/controllers/admin/signatures_controller.rb
+++ b/app/controllers/admin/signatures_controller.rb
@@ -4,18 +4,28 @@ class Admin::SignaturesController < Admin::AdminController
   def validate
     begin
       @signature.validate!
-      redirect_to admin_search_url(q: @signature.email), notice: "Signature validated successfully"
+      redirect_to admin_search_url(q: params[:q]), notice: "Signature validated successfully"
     rescue StandardError => e
       Appsignal.send_exception e
-      redirect_to admin_search_url(q: @signature.email), alert: "Signature could not be validated - please contact support"
+      redirect_to admin_search_url(q: params[:q]), alert: "Signature could not be validated - please contact support"
+    end
+  end
+
+  def invalidate
+    begin
+      @signature.invalidate!
+      redirect_to admin_search_url(q: params[:q]), notice: "Signature invalidated successfully"
+    rescue StandardError => e
+      Appsignal.send_exception e
+      redirect_to admin_search_url(q: @signature.email), alert: "Signature could not be invalidated - please contact support"
     end
   end
 
   def destroy
     if @signature.destroy
-      redirect_to admin_search_url(q: @signature.email), notice: "Signature removed successfully"
+      redirect_to admin_search_url(q: params[:q]), notice: "Signature removed successfully"
     else
-      redirect_to admin_search_url(q: @signature.email), alert: "Signature could not be removed - please contact support"
+      redirect_to admin_search_url(q: params[:q]), alert: "Signature could not be removed - please contact support"
     end
   end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -66,7 +66,12 @@ module Authentication
   def require_sysadmin
     unless current_user && current_user.is_a_sysadmin?
       flash[:error] = "You must be logged in as a system administrator to view this page."
-      redirect_to admin_login_url
+
+      if current_user.is_a_moderator?
+        redirect_to admin_root_url
+      else
+        redirect_to admin_login_url
+      end
     end
   end
 

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -85,6 +85,10 @@ class SignaturesController < ApplicationController
   def retrieve_signature
     @signature = Signature.find(params[:id])
     @petition = @signature.petition
+
+    if @signature.invalidated? || @signature.fraudulent?
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+    end
   end
 
   def redirect_to_petition_page

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -21,6 +21,14 @@ module AdminHelper
     options_for_select(options, selected)
   end
 
+  def admin_invalidation_facets_for_select(facets, selected)
+    options = admin_invalidation_facets.map do |facet|
+      [I18n.t(facet,  scope: :"admin.invalidations.facets.labels", quantity: facets[facet]), facet]
+    end
+
+    options_for_select(options, selected)
+  end
+
   def email_petitioners_with_count_submit_button(form, petition)
     i18n_options = {
       scope: :admin, count: petition.signature_count,
@@ -39,5 +47,9 @@ module AdminHelper
 
   def admin_petition_facets
     I18n.t(:admin, scope: :"petitions.facets")
+  end
+
+  def admin_invalidation_facets
+    I18n.t(:keys, scope: :"admin.invalidations.facets")
   end
 end

--- a/app/jobs/email_confirmation_for_signer_email_job.rb
+++ b/app/jobs/email_confirmation_for_signer_email_job.rb
@@ -1,4 +1,8 @@
 class EmailConfirmationForSignerEmailJob < EmailJob
   self.mailer = PetitionMailer
   self.email = :email_confirmation_for_signer
+
+  rescue_from(ActiveJob::DeserializationError) do |exception|
+    Appsignal.send_exception exception
+  end
 end

--- a/app/jobs/invalidate_signatures_job.rb
+++ b/app/jobs/invalidate_signatures_job.rb
@@ -1,0 +1,11 @@
+class InvalidateSignaturesJob < ActiveJob::Base
+  queue_as :high_priority
+
+  rescue_from(ActiveJob::DeserializationError) do |exception|
+    Appsignal.send_exception exception
+  end
+
+  def perform(invalidation)
+    invalidation.invalidate!
+  end
+end

--- a/app/models/invalidation.rb
+++ b/app/models/invalidation.rb
@@ -1,0 +1,238 @@
+class Invalidation < ActiveRecord::Base
+  extend Searchable(:id, :summary, :details, :petition_id)
+  include Browseable
+
+  belongs_to :petition
+  has_many :signatures
+
+  facet :all,       -> { by_most_recent }
+  facet :completed, -> { completed.by_most_recent }
+  facet :cancelled, -> { cancelled.by_most_recent }
+  facet :pending,   -> { pending.by_most_recent }
+  facet :enqueued,  -> { enqueued.by_most_recent }
+  facet :running,   -> { running.by_longest_running }
+
+  CONDITIONS = %i[
+    petition_id name postcode ip_address
+    email constituency_id location_code
+    created_before created_after
+  ]
+
+  validates :summary, presence: true, length: { maximum: 255 }
+  validates :details, length: { maximum: 10000 }
+  validates :petition_id, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 100000 }
+  validates :name, length: { maximum: 255, allow_blank: true }
+  validates :postcode, length: { maximum: 255, allow_blank: true }
+  validates :ip_address, length: { maximum: 20 }, format: { with: /\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/ }, allow_blank: true
+  validates :email, length: { maximum: 255, allow_blank: true }
+  validates :constituency_id, length: { maximum: 30, allow_blank: true }
+  validates :location_code, length: { maximum: 30, allow_blank: true }
+
+  validate do
+    if applied_conditions.empty?
+      errors.add :petition_id, "Please select some conditions, otherwise all signatures will be invalidated"
+    end
+
+    if petition_id?
+      errors.add :petition_id, "Petition doesn't exist" unless Petition.exists?(petition_id)
+    end
+
+    if constituency_id?
+      errors.add :constituency_id, "Constituency doesn't exist" unless Constituency.exists?(external_id: constituency_id)
+    end
+
+    if location_code?
+      errors.add :location_code, "Location doesn't exist" unless Location.exists?(code: location_code)
+    end
+
+    if created_before? && created_after?
+      errors.add :created_after, "Starting date is after the finishing date" unless created_before > created_after
+    end
+  end
+
+  before_destroy do
+    !started?
+  end
+
+  class << self
+    def by_most_recent
+      reorder(created_at: :desc)
+    end
+
+    def by_longest_running
+      reorder(started_at: :asc)
+    end
+
+    def cancelled
+      where(arel_table[:cancelled_at].not_eq(nil))
+    end
+
+    def completed
+      where(arel_table[:completed_at].not_eq(nil))
+    end
+
+    def enqueued
+      where(arel_table[:enqueued_at].not_eq(nil).and(arel_table[:started_at].eq(nil)))
+    end
+
+    def not_completed
+      where(arel_table[:completed_at].eq(nil))
+    end
+
+    def pending
+      where(enqueued_at: nil, started_at: nil, cancelled_at: nil, completed_at: nil)
+    end
+
+    def running
+      started.not_completed
+    end
+
+    def started
+      where(arel_table[:started_at].not_eq(nil))
+    end
+  end
+
+  def cancel!(now = Time.current)
+    return false if cancelled? || completed?
+
+    update(cancelled_at: now)
+  end
+
+  def cancelled?
+    cancelled_at?
+  end
+
+  def completed?
+    completed_at?
+  end
+
+  def count!
+    return false unless pending?
+
+    update(matching_count: matching_signatures.count, counted_at: Time.current)
+  end
+
+  def start!
+    return false unless pending?
+
+    InvalidateSignaturesJob.perform_later(self)
+    update(enqueued_at: Time.current)
+  end
+
+  def started?
+    started_at?
+  end
+
+  def enqueued?
+    enqueued_at?
+  end
+
+  def pending?
+    !(enqueued? || started? || cancelled? || completed?)
+  end
+
+  def running?
+    started? && !(completed? || cancelled?)
+  end
+
+  def percent_completed
+    if started? || completed?
+      matching_count.zero? ? 100 : calculate_percent_complete
+    else
+      matching_count.zero? ? 0 : calculate_percent_complete
+    end
+  end
+
+  def matching_signatures
+    scope = Signature.all
+    scope = petition_scope(scope) if petition_id?
+    scope = name_scope(scope) if name?
+    scope = postcode_scope(scope) if postcode?
+    scope = ip_address_scope(scope) if ip_address?
+    scope = email_scope(scope) if email?
+    scope = constituency_id_scope(scope) if constituency_id?
+    scope = location_code_scope(scope) if location_code?
+    scope = date_range_scope(scope) if date_range?
+
+    scope
+  end
+
+  def invalidate!
+    return if cancelled? || completed?
+
+    update(
+      started_at: Time.current,
+      matching_count: matching_signatures.count,
+      counted_at: Time.current
+    )
+
+    matching_signatures.find_in_batches(batch_size: 100) do |signatures|
+      signatures.each do |signature|
+        signature.invalidate!(Time.current, self)
+        increment!(:invalidated_count)
+      end
+
+      reload and return if cancelled?
+    end
+
+    update(completed_at: Time.current)
+  end
+
+  private
+
+  def petition_scope(scope)
+    scope.where(petition_id: petition_id)
+  end
+
+  def name_scope(scope)
+    scope.where("lower(name) LIKE ?", name.strip.downcase)
+  end
+
+  def postcode_scope(scope)
+    scope.where(postcode: postcode)
+  end
+
+  def ip_address_scope(scope)
+    scope.where(ip_address: ip_address)
+  end
+
+  def email_scope(scope)
+    scope.where("email LIKE ?", email)
+  end
+
+  def constituency_id_scope(scope)
+    scope.where(constituency_id: constituency_id)
+  end
+
+  def location_code_scope(scope)
+    scope.where(location_code: location_code)
+  end
+
+  def date_range?
+    created_before? || created_after?
+  end
+
+  def date_range_scope(scope)
+    if created_before?
+      scope = scope.where(table[:created_at].lt(created_before))
+    end
+
+    if created_after?
+      scope = scope.where(table[:created_at].gt(created_after))
+    end
+
+    scope
+  end
+
+  def table
+    Signature.arel_table
+  end
+
+  def calculate_percent_complete
+    [[0, ((invalidated_count.to_f / matching_count.to_f) * 100).floor].max, 100].min
+  end
+
+  def applied_conditions
+    CONDITIONS.select{ |c| read_attribute(c).present? }
+  end
+end

--- a/app/views/admin/invalidations/_form.html.erb
+++ b/app/views/admin/invalidations/_form.html.erb
@@ -1,0 +1,72 @@
+<h2>Reasons for this invalidation</h2>
+
+<%= form_row for: [form.object, :summary] do %>
+  <%= form.label :summary, class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :summary %>
+  <%= form.text_field :summary, tabindex: increment, maxlength: 255, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :details] do %>
+  <%= form.label :details, class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :details %>
+  <%= form.text_area :details, tabindex: increment, rows: 5, class: 'form-control' %>
+<% end %>
+
+<h2>Conditions for matching signatures</h2>
+
+<%= form_row for: [form.object, :petition_id] do %>
+  <%= form.label :petition_id, class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :petition_id %>
+  <%= form.text_field :petition_id, tabindex: increment, maxlength: 20, class: 'form-control', placeholder: 'The ID of the petition' %>
+<% end %>
+
+<%= form_row for: [form.object, :name] do %>
+  <%= form.label :name, class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :name %>
+  <%= form.text_field :name, tabindex: increment, maxlength: 255, class: 'form-control', placeholder: 'The name used when signing - the use of % wildcards is allowed' %>
+<% end %>
+
+<%= form_row for: [form.object, :email] do %>
+  <%= form.label :email, "Email address", class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :email %>
+  <%= form.text_field :email, tabindex: increment, maxlength: 255, class: 'form-control', placeholder: 'The email address used when signing - the use of % wildcards is allowed' %>
+<% end %>
+
+<%= form_row for: [form.object, :postcode] do %>
+  <%= form.label :postcode, class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :postcode %>
+  <%= form.text_field :postcode, tabindex: increment, maxlength: 255, class: 'form-control', placeholder: 'The postcode used when signing - all caps with spaces removed' %>
+<% end %>
+
+<%= form_row for: [form.object, :ip_address] do %>
+  <%= form.label :ip_address, "IP address", class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :ip_address %>
+  <%= form.text_field :ip_address, tabindex: increment, maxlength: 20, class: 'form-control', placeholder: 'The IP address used when signing - should look like 123.134.156.167' %>
+<% end %>
+
+<%= form_row for: [form.object, :constituency_id] do %>
+  <%= form.label :constituency_id, class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :constituency_id %>
+  <%= form.text_field :constituency_id, tabindex: increment, maxlength: 30, class: 'form-control', placeholder: 'The constituency ID returned by the parliament API for the postcode' %>
+<% end %>
+
+<%= form_row for: [form.object, :location_code] do %>
+  <%= form.label :location_code, "Location", class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :location_code %>
+  <%= form.text_field :location_code, tabindex: increment, maxlength: 30, class: 'form-control', placeholder: 'The location code used when signing - typically it would be GB' %>
+<% end %>
+
+<%= form_row for: [form.object, :created_after] do %>
+  <%= form.label :created_after, "Starting at", class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :created_after %>
+  <%= form.datetime_select :created_after, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>
+
+<%= form_row for: [form.object, :created_before] do %>
+  <%= form.label :created_before, "Finishing at", class: 'form-label' %>
+  <%= error_messages_for_field @invalidation, :created_before %>
+  <%= form.datetime_select :created_before, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>
+
+<%= form.submit 'Save', class: 'button' %>
+<%= link_to 'Cancel', admin_invalidations_path, class: 'button-secondary' %>

--- a/app/views/admin/invalidations/_invalidation.html.erb
+++ b/app/views/admin/invalidations/_invalidation.html.erb
@@ -1,0 +1,60 @@
+<tr>
+  <td>
+    <% if invalidation.pending? %>
+      <%= link_to invalidation.summary, edit_admin_invalidation_path(invalidation) %>
+    <% else %>
+      <%= invalidation.summary %>
+    <% end %>
+  </td>
+  <td nowrap="true">
+    <% if invalidation.completed? %>
+      <%= content_tag(:span, "Completed", title: "Completed at #{date_time_format(invalidation.completed_at)}") %>
+    <% elsif invalidation.cancelled? %>
+      <%= content_tag(:span, "Cancelled", title: "Completed at #{date_time_format(invalidation.cancelled_at)}") %>
+    <% elsif invalidation.started? %>
+      <%= content_tag(:span, "Started", title: "Completed at #{date_time_format(invalidation.started_at)}") %>
+    <% elsif invalidation.enqueued? %>
+      <%= content_tag(:span, "Enqueued", title: "Completed at #{date_time_format(invalidation.enqueued_at)}") %>
+    <% else %>
+      <%= content_tag(:span, "Created", title: "Created at #{date_time_format(invalidation.created_at)}") %>
+    <% end %>
+  </td>
+  <td>
+    <% if invalidation.counted_at? %>
+      <span title="<%= date_time_format(invalidation.counted_at) %>">
+        <%= invalidation.matching_count %>
+      </span>
+    <% else %>
+      –
+    <% end %>
+  </td>
+  <td>
+    <% if invalidation.started? %>
+      <%= invalidation.invalidated_count %>
+    <% else %>
+      –
+    <% end %>
+  </td>
+  <td>
+    <% if invalidation.started? %>
+      <%= number_to_percentage(invalidation.percent_completed, precision: 0) %>
+    <% else %>
+      –
+    <% end %>
+  </td>
+  <td nowrap="true">
+    &nbsp;
+    <% unless invalidation.completed? || invalidation.cancelled? %>
+      <%= button_to 'Cancel', cancel_admin_invalidation_path(invalidation, params.slice(:state, :q)), method: :post, class: 'button-secondary' %>
+    <% end %>
+    <% unless invalidation.started? || invalidation.cancelled? %>
+      <%= button_to 'Count', count_admin_invalidation_path(invalidation, params.slice(:state, :q)), method: :post, class: 'button-secondary' %>
+    <% end %>
+    <% unless invalidation.enqueued? || invalidation.cancelled? %>
+      <%= button_to 'Start', start_admin_invalidation_path(invalidation, params.slice(:state, :q)), method: :post, class: 'button' %>
+    <% end %>
+    <% unless invalidation.started? %>
+      <%= button_to 'Delete', admin_invalidation_path(invalidation, params.slice(:state, :q)), method: :delete, class: 'button-warning', data: { confirm: 'Delete invalidation?' } %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/admin/invalidations/edit.html.erb
+++ b/app/views/admin/invalidations/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>Edit Invalidation</h1>
+
+<div class="grid-row">
+  <div class="column-two-thirds extra-gutter">
+    <%= form_for [:admin, @invalidation] do |form| %>
+      <%= render 'form', form: form %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/invalidations/index.html.erb
+++ b/app/views/admin/invalidations/index.html.erb
@@ -1,0 +1,44 @@
+<h1>Signature invalidations</h1>
+
+<div class="grid-row">
+  <%= form_tag admin_invalidations_path, method: :get, class: 'search-inline search-invalidations' do -%>
+    <div class="column-third">
+      <%= label_tag :state, "Filter by status", class: "visuallyhidden" %>
+      <%= select_tag :state, admin_invalidation_facets_for_select(@invalidations.facets, params[:state]), class: "form-control" %>
+    </div>
+    <div class="column-third">
+      <%= label_tag :q, "Search invalidations", class: "visuallyhidden" %>
+      <%= search_field_tag 'q', params[:q], class: 'form-control', placeholder:"Enter a search query" %>
+      <%= submit_tag 'Search', class: 'inline-submit' %>
+    </div>
+    <div class="column-third actions-right">
+      <%= link_to "New Invalidation", new_admin_invalidation_path, class: 'button inline-button' %>
+    </div>
+  <% end -%>
+</div>
+
+<%= will_paginate @invalidations %>
+
+<table class="invalidation-list">
+  <thead>
+    <tr>
+      <th>Summary</th>
+      <th>Status</th>
+      <th>Matching</th>
+      <th>Invalidated</th>
+      <th nowrap="true">% Complete</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if @invalidations.present? %>
+      <%= render @invalidations.to_a %>
+    <% else %>
+      <tr>
+        <td colspan="6">No matching invalidations</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= will_paginate @invalidations %>

--- a/app/views/admin/invalidations/new.html.erb
+++ b/app/views/admin/invalidations/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New Invalidation</h1>
+
+<div class="grid-row">
+  <div class="column-two-thirds extra-gutter">
+    <%= form_for [:admin, @invalidation] do |form| %>
+      <%= render 'form', form: form %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/shared/_header_user_actions.html.erb
+++ b/app/views/admin/shared/_header_user_actions.html.erb
@@ -2,6 +2,7 @@
   <ul>
     <li><%= link_to current_user.pretty_name, edit_admin_profile_path(current_user) %></li>
     <% if current_user.is_a_sysadmin? %>
+      <li><%= link_to "Invalidations", admin_invalidations_path %></li>
       <li><%= link_to "Users", admin_admin_users_path %></li>
     <% end %>
     <li><%= link_to "Logout", admin_logout_path %></li>

--- a/app/views/admin/signatures/_signature.html.erb
+++ b/app/views/admin/signatures/_signature.html.erb
@@ -8,7 +8,7 @@
     <td>Yes</td>
     <td>
       <% if signature.pending? %>
-        <%= button_to 'Validate', validate_admin_signature_path(signature), method: :post, class: 'button', data: { confirm: 'Validate signature?' } %>
+        <%= button_to 'Validate', validate_admin_signature_path(signature, q: params[:q]), method: :post, class: 'button', data: { confirm: 'Validate signature?' } %>
       <% else %>
         &nbsp;
       <% end %>
@@ -17,10 +17,11 @@
     <td>No</td>
     <td>
       <% if signature.pending? %>
-        <%= button_to 'Validate', validate_admin_signature_path(signature), method: :post, class: 'button', data: { confirm: 'Validate signature?' } %>
-      <% else %>
-        <%= button_to 'Delete', admin_signature_path(signature), method: :delete, class: 'button-warning', data: { confirm: 'Delete signature?' } %>
+        <%= button_to 'Validate', validate_admin_signature_path(signature, q: params[:q]), method: :post, class: 'button', data: { confirm: 'Validate signature?' } %>
+      <% elsif signature.validated? %>
+        <%= button_to 'Invalidate', invalidate_admin_signature_path(signature, q: params[:q]), method: :post, class: 'button', data: { confirm: 'Invalidate signature?' } %>
       <% end %>
+      <%= button_to 'Delete', admin_signature_path(signature, q: params[:q]), method: :delete, class: 'button-warning', data: { confirm: 'Delete signature?' } %>
     </td>
   <% end %>
 </tr>

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -6,3 +6,20 @@ en-GB:
     email_confirm:
       one: "Are you sure you want to do this and email the petitioner?"
       other: "Are you sure you want to do this and email all %{formatted_count} petitioners?"
+
+    invalidations:
+      facets:
+        keys:
+          - :all
+          - :completed
+          - :cancelled
+          - :enqueued
+          - :pending
+          - :running
+        labels:
+          all: "All invalidations (%{quantity})"
+          completed: "Completed invalidations (%{quantity})"
+          cancelled: "Cancelled invalidations (%{quantity})"
+          enqueued: "Enqueued invalidations (%{quantity})"
+          pending: "Pending invalidations (%{quantity})"
+          running: "Running invalidations (%{quantity})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,13 @@ Rails.application.routes.draw do
       resource :search, :only => [:show]
 
       resources :admin_users
+      resources :profile, :only => [:edit, :update]
+      resources :user_sessions, :only => [:create]
+
+      resources :invalidations, :except => [:show] do
+        post :cancel, :count, :start, :on => :member
+      end
+
       resources :petitions, :only => [:show, :index] do
         resource 'debate-outcome', only: [:show, :update], as: :debate_outcome, controller: :debate_outcomes
         resources :emails, only: [:new, :create, :edit, :update, :destroy], controller: :petition_emails
@@ -84,11 +91,11 @@ Rails.application.routes.draw do
         resource 'government-response', :only => [:show, :update], as: :government_response, controller: :government_response
         resource 'schedule-debate', :only => [:show, :update], as: :schedule_debate, controller: :schedule_debate
       end
-      resources :profile, :only => [:edit, :update]
+
       resources :signatures, :only => [:destroy] do
-        post :validate, :on => :member
+        post :validate, :invalidate, :on => :member
       end
-      resources :user_sessions, :only => [:create]
+
       get 'logout' => 'user_sessions#destroy', :as => :logout
       get 'login' => 'user_sessions#new', :as => :login
     end

--- a/db/migrate/20160704152204_add_invalidation_columns_to_signatures.rb
+++ b/db/migrate/20160704152204_add_invalidation_columns_to_signatures.rb
@@ -1,0 +1,31 @@
+class AddInvalidationColumnsToSignatures < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    unless column_exists?(:signatures, :invalidated_at)
+      add_column :signatures, :invalidated_at, :datetime
+    end
+
+    unless column_exists?(:signatures, :invalidation_id)
+      add_column :signatures, :invalidation_id, :integer
+    end
+
+    unless index_exists?(:signatures, :invalidation_id)
+      add_index :signatures, :invalidation_id, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:signatures, :invalidation_id)
+      remove_index :signatures, :invalidation_id
+    end
+
+    if column_exists?(:signatures, :invalidation_id)
+      add_column :signatures, :invalidation_id, :datetime
+    end
+
+    if column_exists?(:signatures, :invalidated_at)
+      add_column :signatures, :invalidated_at, :integer
+    end
+  end
+end

--- a/db/migrate/20160704162920_increase_size_of_signature_state.rb
+++ b/db/migrate/20160704162920_increase_size_of_signature_state.rb
@@ -1,0 +1,9 @@
+class IncreaseSizeOfSignatureState < ActiveRecord::Migration
+  def up
+    change_column :signatures, :state, :string, limit: 20, null: false, default: 'pending'
+  end
+
+  def down
+    change_column :signatures, :state, :string, limit: 10, null: false, default: 'pending'
+  end
+end

--- a/db/migrate/20160704185825_create_invalidations.rb
+++ b/db/migrate/20160704185825_create_invalidations.rb
@@ -1,0 +1,30 @@
+class CreateInvalidations < ActiveRecord::Migration
+  def change
+    create_table :invalidations do |t|
+      t.string   :summary, limit: 255, null: false
+      t.string   :details, limit: 10000
+      t.integer  :petition_id
+      t.string   :name, limit: 255
+      t.string   :postcode, limit: 255
+      t.string   :ip_address, limit: 20
+      t.string   :email, limit: 255
+      t.datetime :created_after
+      t.datetime :created_before
+      t.string   :constituency_id, limit: 30
+      t.string   :location_code, limit: 30
+      t.integer  :matching_count, null: false, default: 0
+      t.integer  :invalidated_count, null: false, default: 0
+      t.datetime :enqueued_at, null: true
+      t.datetime :started_at, null: true
+      t.datetime :cancelled_at, null: true
+      t.datetime :completed_at, null: true
+      t.datetime :counted_at, null: true
+      t.timestamps null: false
+    end
+
+    add_index :invalidations, :petition_id
+    add_index :invalidations, :started_at
+    add_index :invalidations, :completed_at
+    add_index :invalidations, :cancelled_at
+  end
+end

--- a/db/migrate/20160706060256_add_search_indexes_for_invalidations.rb
+++ b/db/migrate/20160706060256_add_search_indexes_for_invalidations.rb
@@ -1,0 +1,30 @@
+class AddSearchIndexesForInvalidations < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE INDEX ft_index_invalidations_on_id ON invalidations
+      USING gin(to_tsvector('english', id::text));
+    SQL
+
+    execute <<-SQL
+      CREATE INDEX ft_index_invalidations_on_summary ON invalidations
+      USING gin(to_tsvector('english', summary));
+    SQL
+
+    execute <<-SQL
+      CREATE INDEX ft_index_invalidations_on_details ON invalidations
+      USING gin(to_tsvector('english', details));
+    SQL
+
+    execute <<-SQL
+      CREATE INDEX ft_index_invalidations_on_petition_id ON invalidations
+      USING gin(to_tsvector('english', petition_id::text));
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX ft_index_invalidations_on_id;"
+    execute "DROP INDEX ft_index_invalidations_on_summary;"
+    execute "DROP INDEX ft_index_invalidations_on_details;"
+    execute "DROP INDEX ft_index_invalidations_on_petition_id;"
+  end
+end

--- a/features/admin/invalidating_signatures.feature
+++ b/features/admin/invalidating_signatures.feature
@@ -1,0 +1,63 @@
+@admin
+Feature: Sysadmin invalidates some signatures
+  In order to improve the reputation of a petition
+  As a sysadmin
+  I want to invalidate fraudulent signatures
+
+  Scenario: Sysadmin invalidates signatures by email
+    Given 1 petition signed by "bob.jones@example.com"
+    When I am logged in as a sysadmin
+    And I am on the admin invalidations page
+    And I follow "New Invalidation"
+    Then I should see "Reasons for this invalidation"
+    When I press "Save"
+    Then I should see "Summary can't be blank"
+    And I should see "Please select some conditions, otherwise all signatures will be invalidated"
+    When I fill in "Summary" with "Bob Jones is a fraud"
+    And I fill in "Email address" with "bob.jones@example.com"
+    And I press "Save"
+    Then I should see "Invalidation created successfully"
+    When I press "Start"
+    Then I should see "Enqueued the invalidation"
+    When I search for petitions signed by "bob.jones@example.com" from the admin hub
+    Then I should see the email address is invalidated
+    When I am on the admin invalidations page
+    Then I should see a matching signature count of 1
+    And I should see a invalidated signature count of 1
+    And I should see an invalidation status of "Completed"
+
+  Scenario: Sysadmin counts matching signatures
+    Given 3 petition signed by "bob.jones@example.com"
+    When I am logged in as a sysadmin
+    And I am on the admin invalidations page
+    And I follow "New Invalidation"
+    And I fill in "Summary" with "Bob Jones is a fraud"
+    And I fill in "Email address" with "bob.jones@example.com"
+    And I press "Save"
+    Then I should see "Invalidation created successfully"
+    When I press "Count"
+    Then I should see "Counted the matching signatures for invalidation"
+    And I should see a matching signature count of 3
+
+  Scenario: Sysadmin deletes an invalidation
+    When I am logged in as a sysadmin
+    And I am on the admin invalidations page
+    And I follow "New Invalidation"
+    And I fill in "Summary" with "Bob Jones is a fraud"
+    And I fill in "Email address" with "bob.jones@example.com"
+    And I press "Save"
+    Then I should see "Invalidation created successfully"
+    When I press "Delete"
+    Then I should see "Invalidation removed successfully"
+
+  Scenario: Sysadmin cancels an invalidation
+    When I am logged in as a sysadmin
+    And I am on the admin invalidations page
+    And I follow "New Invalidation"
+    And I fill in "Summary" with "Bob Jones is a fraud"
+    And I fill in "Email address" with "bob.jones@example.com"
+    And I press "Save"
+    Then I should see "Invalidation created successfully"
+    When I press "Cancel"
+    Then I should see "Invalidation cancelled successfully"
+    And I should see an invalidation status of "Cancelled"

--- a/features/admin/search_for_signatures_by_email.feature
+++ b/features/admin/search_for_signatures_by_email.feature
@@ -30,6 +30,14 @@ Feature: Searching for signatures as Terry
     When I click the validate button
     Then I should see the email address is validated
 
+  Scenario: Invalidating a validated signature
+    Given 1 petition with a validated signature by "bob@example.com"
+    And I am logged in as a moderator
+    When I search for petitions signed by "bob@example.com" from the admin hub
+    Then I should see the email address is validated
+    When I click the invalidate button
+    Then I should see the email address is invalidated
+
   Scenario: Deleting a signature
     Given 1 petition signed by "bob@example.com"
     And I am logged in as a moderator

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -11,9 +11,9 @@ Given(/^(\d+) petitions? signed by "([^"]*)"$/) do |petition_count, name_or_emai
   end
 end
 
-Given(/^(\d+) petitions? with a pending signature by "([^"]*)"$/) do |petition_count, email|
+Given(/^(\d+) petitions? with a (pending|validated) signature by "([^"]*)"$/) do |petition_count, state, email|
   petition_count.times do
-    FactoryGirl.create(:pending_signature, :petition => FactoryGirl.create(:open_petition), :email => email)
+    FactoryGirl.create(:"#{state}_signature", :petition => FactoryGirl.create(:open_petition), :email => email)
   end
 end
 
@@ -90,12 +90,19 @@ Then(/^I should see the email address is pending$/) do
   expect(page).to have_button "Validate"
 end
 
-When(/^I click the validate button$/) do
-  click_button "Validate"
+When(/^I click the (validate|invalidate) button$/) do |button|
+  click_button button.titleize
 end
 
 Then(/^I should see the email address is validated$/) do
   expect(page).not_to have_button "Validate"
+  expect(page).to have_button "Invalidate"
+  expect(page).to have_button "Delete"
+end
+
+Then(/^I should see the email address is invalidated$/) do
+  expect(page).not_to have_button "Validate"
+  expect(page).not_to have_button "Invalidate"
   expect(page).to have_button "Delete"
 end
 

--- a/features/step_definitions/invalidation_steps.rb
+++ b/features/step_definitions/invalidation_steps.rb
@@ -1,0 +1,11 @@
+Then(/^I should see a matching signature count of (\d+)$/) do |count|
+  expect(page).to have_selector(:css, ".invalidation-list tbody tr:first td:nth-child(3)", text: count)
+end
+
+Then(/^I should see an invalidation status of "(.*?)"$/) do |status|
+  expect(page).to have_selector(:css, ".invalidation-list tbody tr:first td:nth-child(2)", text: status)
+end
+
+Then(/^I should see a invalidated signature count of (\d+)$/) do |count|
+  expect(page).to have_selector(:css, ".invalidation-list tbody tr:first td:nth-child(4)", text: count)
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -86,6 +86,9 @@ module NavigationHelpers
     when /^in moderation petitions page$/
       admin_petitions_url(state: 'in_moderation')
 
+    when /^invalidations page$/
+      admin_invalidations_url
+
     when /^users index page$/
       admin_admin_users_url
 

--- a/spec/controllers/admin/admin_users_controller_spec.rb
+++ b/spec/controllers/admin/admin_users_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Admin::AdminUsersController, type: :controller, admin: true do
     describe "GET 'index'" do
       it "should be unsuccessful" do
         get :index
-        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
       end
     end
   end

--- a/spec/controllers/admin/invalidations_controller_spec.rb
+++ b/spec/controllers/admin/invalidations_controller_spec.rb
@@ -1,0 +1,405 @@
+require 'rails_helper'
+
+RSpec.describe Admin::InvalidationsController, type: :controller, admin: true do
+  context "when not logged in" do
+    [
+      ["GET", "/admin/invalidations", :index, {}],
+      ["GET", "/admin/invalidations", :new, {}],
+      ["POST", "/admin/invalidations", :create, {}],
+      ["GET", "/admin/invalidations/:id/edit", :edit, { id: 1 }],
+      ["PATCH", "/admin/invalidations/:id", :update, { id: 1 }],
+      ["DELETE", "/admin/invalidations/:id", :destroy, { id: 1 }],
+      ["POST", "/admin/invalidations/:id/cancel", :cancel, { id: 1 }],
+      ["POST", "/admin/invalidations/:id/count", :count, { id: 1 }],
+      ["POST", "/admin/invalidations/:id/start", :start, { id: 1 }]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method, params }
+
+        it "redirects to the login page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a moderator" do
+    let(:moderator) { FactoryGirl.create(:moderator_user) }
+    before { login_as(moderator) }
+
+    [
+      ["GET", "/admin/invalidations", :index, {}],
+      ["GET", "/admin/invalidations", :new, {}],
+      ["POST", "/admin/invalidations", :create, {}],
+      ["GET", "/admin/invalidations/:id/edit", :edit, { id: 1 }],
+      ["PATCH", "/admin/invalidations/:id", :update, { id: 1 }],
+      ["DELETE", "/admin/invalidations/:id", :destroy, { id: 1 }],
+      ["POST", "/admin/invalidations/:id/cancel", :cancel, { id: 1 }],
+      ["POST", "/admin/invalidations/:id/count", :count, { id: 1 }],
+      ["POST", "/admin/invalidations/:id/start", :start, { id: 1 }]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method, params }
+
+        it "redirects to the login page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a sysadmin" do
+    let(:sysadmin) { FactoryGirl.create(:sysadmin_user) }
+    before { login_as(sysadmin) }
+
+    describe "GET /admin/invalidations" do
+      before { get :index }
+
+      it "returns 200 OK" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the :index template" do
+        expect(response).to render_template("admin/invalidations/index")
+      end
+    end
+
+    describe "GET /admin/invalidations/new" do
+      before { get :new }
+
+      it "returns 200 OK" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the :new template" do
+        expect(response).to render_template("admin/invalidations/new")
+      end
+    end
+
+    describe "POST /admin/invalidations" do
+      before { post :create, invalidation: params }
+
+      context "with invalid params" do
+        let :params do
+          { summary: "Invalidate some signatures" }
+        end
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :new template" do
+          expect(response).to render_template("admin/invalidations/new")
+        end
+      end
+
+      context "with valid params" do
+        let :params do
+          { summary: "Invalidate some signatures", email: "user@example.com" }
+        end
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Invalidation created successfully")
+        end
+      end
+    end
+
+    describe "GET /admin/invalidations/:id/edit" do
+      before { get :edit, id: invalidation.id }
+
+      context "when the invalidation is still pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :edit template" do
+          expect(response).to render_template("admin/invalidations/edit")
+        end
+      end
+
+      context "when the invalidation is not pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :completed, email: "user@example.com") }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Can't edit invalidations that aren't pending")
+        end
+      end
+    end
+
+    describe "PATCH /admin/invalidations/:id" do
+      before { patch :update, id: invalidation.id, invalidation: params }
+
+      context "when the invalidation is still pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+
+        context "and the params are invalid" do
+          let :params do
+            { summary: "Invalidate some signatures", email: "" }
+          end
+
+          it "returns 200 OK" do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "renders the :edit template" do
+            expect(response).to render_template("admin/invalidations/edit")
+          end
+        end
+
+        context "and the params are valid" do
+          let :params do
+            { summary: "Invalidate some signatures", email: "user@example.com" }
+          end
+
+          it "redirects to the index page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+          end
+
+          it "sets the flash notice message" do
+            expect(flash[:notice]).to eq("Invalidation updated successfully")
+          end
+        end
+      end
+
+      context "when the invalidation is not pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :completed, email: "user@example.com") }
+
+        let :params do
+          { summary: "Invalidate some signatures", email: "user@example.com" }
+        end
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Can't edit invalidations that aren't pending")
+        end
+      end
+    end
+
+    describe "DELETE /admin/invalidations/:id" do
+      context "when the invalidation is still pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+
+        before { delete :destroy, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Invalidation removed successfully")
+        end
+      end
+
+      context "when the invalidation is cancelled, but not started" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :cancelled, email: "user@example.com") }
+
+        before { delete :destroy, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Invalidation removed successfully")
+        end
+      end
+
+      context "when the invalidation is not pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :started, email: "user@example.com") }
+
+        before { delete :destroy, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Can't remove invalidations that have started")
+        end
+      end
+
+      context "when the destroy fails for an unknown reason" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+        let(:id) { invalidation.id.to_s }
+
+        before do
+          expect(Invalidation).to receive(:find).with(id).and_return(invalidation)
+          expect(invalidation).to receive(:destroy).and_return(false)
+          delete :destroy, id: invalidation.id
+        end
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Invalidation could not be removed - please contact support")
+        end
+      end
+    end
+
+    describe "POST /admin/invalidations/:id/cancel" do
+      context "when the invalidation has not completed" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :started, email: "user@example.com") }
+
+        before { post :cancel, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Invalidation cancelled successfully")
+        end
+      end
+
+      context "when the invalidation has completed" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :completed, email: "user@example.com") }
+
+        before { post :cancel, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Can't cancel invalidations that have completed")
+        end
+      end
+
+      context "when the cancel fails for an unknown reason" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+        let(:id) { invalidation.id.to_s }
+
+        before do
+          expect(Invalidation).to receive(:find).with(id).and_return(invalidation)
+          expect(invalidation).to receive(:cancel!).and_return(false)
+          post :cancel, id: invalidation.id
+        end
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Invalidation could not be cancelled - please contact support")
+        end
+      end
+    end
+
+    describe "POST /admin/invalidations/:id/count" do
+      context "when the invalidation is still pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+
+        before { post :count, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to match(/\ACounted the matching signatures for invalidation/)
+        end
+      end
+
+      context "when the invalidation is no longer pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :started, email: "user@example.com") }
+
+        before { post :count, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Can't count invalidations that aren't pending")
+        end
+      end
+
+      context "when the count fails for an unknown reason" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+        let(:id) { invalidation.id.to_s }
+
+        before do
+          expect(Invalidation).to receive(:find).with(id).and_return(invalidation)
+          expect(invalidation).to receive(:count!).and_return(false)
+          post :count, id: invalidation.id
+        end
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Invalidation could not be counted - please contact support")
+        end
+      end
+    end
+
+    describe "POST /admin/invalidations/:id/start" do
+      context "when the invalidation is still pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+
+        before { post :start, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to match(/\AEnqueued the invalidation/)
+        end
+      end
+
+      context "when the invalidation is no longer pending" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, :started, email: "user@example.com") }
+
+        before { post :start, id: invalidation.id }
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Can't start invalidations that aren't pending")
+        end
+      end
+
+      context "when the start fails for an unknown reason" do
+        let(:invalidation) { FactoryGirl.create(:invalidation, email: "user@example.com") }
+        let(:id) { invalidation.id.to_s }
+
+        before do
+          expect(Invalidation).to receive(:find).with(id).and_return(invalidation)
+          expect(invalidation).to receive(:start!).and_return(false)
+          post :start, id: invalidation.id
+        end
+
+        it "redirects to the index page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/invalidations")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Invalidation could not be enqueued - please contact support")
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/signatures_controller_spec.rb
+++ b/spec/controllers/admin/signatures_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::SignaturesController, type: :controller, admin: true do
       context "when the signature is validated" do
         before do
           expect(signature).to receive(:validate!).and_return(true)
-          post :validate, id: signature.id
+          post :validate, id: signature.id, q: "user@example.com"
         end
 
         it "redirects to the search page" do
@@ -52,7 +52,7 @@ RSpec.describe Admin::SignaturesController, type: :controller, admin: true do
         before do
           expect(signature).to receive(:validate!).and_raise(exception)
           expect(Appsignal).to receive(:send_exception).with(exception)
-          post :validate, id: signature.id
+          post :validate, id: signature.id, q: "user@example.com"
         end
 
         it "redirects to the search page" do
@@ -65,11 +65,46 @@ RSpec.describe Admin::SignaturesController, type: :controller, admin: true do
       end
     end
 
+    describe "POST /admin/signatures/:id/invalidate" do
+      context "when the signature is validated" do
+        before do
+          expect(signature).to receive(:invalidate!).and_return(true)
+          post :invalidate, id: signature.id, q: "user@example.com"
+        end
+
+        it "redirects to the search page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/search?q=user%40example.com")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Signature invalidated successfully")
+        end
+      end
+
+      context "when the signature is not validated" do
+        let(:exception) { ActiveRecord::StatementInvalid.new("Invalid SQL") }
+
+        before do
+          expect(signature).to receive(:invalidate!).and_raise(exception)
+          expect(Appsignal).to receive(:send_exception).with(exception)
+          post :invalidate, id: signature.id, q: "user@example.com"
+        end
+
+        it "redirects to the search page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/search?q=user%40example.com")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Signature could not be invalidated - please contact support")
+        end
+      end
+    end
+
     describe "DELETE /admin/signatures/:id" do
       context "when the signature is destroyed" do
         before do
           expect(signature).to receive(:destroy).and_return(true)
-          delete :destroy, id: signature.id
+          delete :destroy, id: signature.id, q: "user@example.com"
         end
 
         it "redirects to the search page" do
@@ -84,7 +119,7 @@ RSpec.describe Admin::SignaturesController, type: :controller, admin: true do
       context "when the signature is not destroyed" do
         before do
           expect(signature).to receive(:destroy).and_return(false)
-          delete :destroy, id: signature.id
+          delete :destroy, id: signature.id, q: "user@example.com"
         end
 
         it "redirects to the search page" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -217,6 +217,10 @@ FactoryGirl.define do
     state      Signature::PENDING_STATE
   end
 
+  factory :fraudulent_signature, :parent => :signature do
+    state      Signature::FRAUDULENT_STATE
+  end
+
   factory :validated_signature, :parent => :signature do
     state                         Signature::VALIDATED_STATE
     validated_at                  { Time.current }
@@ -225,6 +229,11 @@ FactoryGirl.define do
     trait :just_signed do
       seen_signed_confirmation_page false
     end
+  end
+
+  factory :invalidated_signature, :parent => :validated_signature do
+    state                         Signature::INVALIDATED_STATE
+    invalidated_at                { Time.current }
   end
 
   sequence(:sponsor_email) { |n| "sponsor#{n}@example.com" }
@@ -349,5 +358,22 @@ FactoryGirl.define do
     petition_link_or_title "Do stuff"
     email "foo@example.com"
     user_agent "Mozilla/5.0"
+  end
+
+  factory :invalidation do
+    summary "Invalidation summary"
+    details "Reasons for invalidation"
+
+    trait :cancelled do
+      cancelled_at { Time.current }
+    end
+
+    trait :completed do
+      completed_at { Time.current }
+    end
+
+    trait :started do
+      started_at { Time.current }
+    end
   end
 end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -71,4 +71,46 @@ RSpec.describe AdminHelper, type: :helper do
       expect(subject).to have_css("option[value='open'][selected]")
     end
   end
+
+  describe "#admin_invalidation_facets_for_select" do
+    let(:selected) { "running" }
+
+    let(:facets) do
+      { all: 1, completed: 2, cancelled: 3, enqueued: 4, pending: 5, running: 6 }
+    end
+
+    subject { helper.admin_invalidation_facets_for_select(facets, selected) }
+
+    it "generates the correct number of options" do
+      expect(subject).to have_css("option", count: 6)
+    end
+
+    it "generates the correct option for 'all'" do
+      expect(subject).to have_css("option:nth-of-type(1)[value='all']", text: "All invalidations (1)")
+    end
+
+    it "generates the correct option for 'completed'" do
+      expect(subject).to have_css("option:nth-of-type(2)[value='completed']", text: "Completed invalidations (2)")
+    end
+
+    it "generates the correct option for 'cancelled'" do
+      expect(subject).to have_css("option:nth-of-type(3)[value='cancelled']", text: "Cancelled invalidations (3)")
+    end
+
+    it "generates the correct option for 'pending'" do
+      expect(subject).to have_css("option:nth-of-type(5)[value='pending']", text: "Pending invalidations (5)")
+    end
+
+    it "generates the correct option for 'enqueued'" do
+      expect(subject).to have_css("option:nth-of-type(4)[value='enqueued']", text: "Enqueued invalidations (4)")
+    end
+
+    it "generates the correct option for 'running'" do
+      expect(subject).to have_css("option:nth-of-type(6)[value='running']", text: "Running invalidations (6)")
+    end
+
+    it "marks the correct option as selected" do
+      expect(subject).to have_css("option[value='running'][selected]")
+    end
+  end
 end

--- a/spec/jobs/invalidate_signatures_job_spec.rb
+++ b/spec/jobs/invalidate_signatures_job_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe InvalidateSignaturesJob, type: :job do
+  let(:invalidation) { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1") }
+  let(:exception_class) { ActiveJob::DeserializationError }
+
+  context "when the invalidation is present" do
+    let!(:petition) { FactoryGirl.create(:open_petition) }
+    let!(:signature_1) { FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1", petition: petition) }
+    let!(:signature_2) { FactoryGirl.create(:validated_signature, ip_address: "192.168.1.1", petition: petition) }
+
+    it "performs the invalidation process" do
+      expect(Invalidation).to receive(:find).with(invalidation.id.to_s).and_return(invalidation)
+      expect(invalidation).to receive(:invalidate!).and_call_original
+      expect(petition.signature_count).to eq(3)
+
+      perform_enqueued_jobs {
+        described_class.perform_later(invalidation)
+      }
+
+      expect(invalidation.matching_count).to eq(1)
+      expect(invalidation.invalidated_count).to eq(1)
+      expect(petition.reload.signature_count).to eq(2)
+    end
+  end
+
+  context "when the invalidation has been deleted" do
+    before do
+      Invalidation.delete(invalidation)
+    end
+
+    it "notifies Appsignal of the error" do
+      expect(Appsignal).to receive(:send_exception).with(an_instance_of(exception_class))
+
+      perform_enqueued_jobs {
+        described_class.perform_later(invalidation)
+      }
+    end
+
+    it "doesn't raise an error" do
+      expect {
+        perform_enqueued_jobs {
+          described_class.perform_later(invalidation)
+        }
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/invalidation_spec.rb
+++ b/spec/models/invalidation_spec.rb
@@ -1,0 +1,808 @@
+require 'rails_helper'
+
+RSpec.describe Invalidation, type: :model do
+  subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs") }
+
+  it "has a valid factory" do
+    expect(FactoryGirl.build(:invalidation, name: "Joe Bloggs")).to be_valid
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:petition) }
+    it { is_expected.to have_many(:signatures) }
+  end
+
+  describe "indexes" do
+    it { is_expected.to have_db_index(:petition_id) }
+  end
+
+  describe "callbacks" do
+    context "when an invalidation hasn't started" do
+      let!(:invalidation) { FactoryGirl.create(:invalidation, name: "Joe Bloggs") }
+
+      it "can be deleted" do
+        expect(invalidation.destroy).to be_truthy
+      end
+    end
+
+    context "when an invalidation has started" do
+      let!(:invalidation) { FactoryGirl.create(:invalidation, :started, name: "Joe Bloggs") }
+
+      it "can't be deleted" do
+        expect(invalidation.destroy).to be_falsey
+      end
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:summary) }
+    it { is_expected.to validate_length_of(:summary).is_at_most(255) }
+    it { is_expected.to validate_length_of(:details).is_at_most(10000) }
+    it { is_expected.to validate_numericality_of(:petition_id).only_integer.is_greater_than_or_equal_to(100000) }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:postcode).is_at_most(255) }
+    it { is_expected.to validate_length_of(:ip_address).is_at_most(20) }
+    it { is_expected.to validate_length_of(:email).is_at_most(255) }
+    it { is_expected.to validate_length_of(:constituency_id).is_at_most(30) }
+    it { is_expected.to validate_length_of(:location_code).is_at_most(30) }
+
+    it { is_expected.not_to allow_value("foo").for(:ip_address) }
+    it { is_expected.to allow_value("123.123.123.123").for(:ip_address) }
+
+    context "when there are no conditions" do
+      subject { FactoryGirl.build(:invalidation) }
+
+      before do
+        subject.valid?
+      end
+
+      it "adds an error to :petition_id" do
+        expect(subject.errors[:petition_id]).to include("Please select some conditions, otherwise all signatures will be invalidated")
+      end
+    end
+
+    context "when a petition doesn't exist" do
+      subject { FactoryGirl.build(:invalidation, petition_id: 123456) }
+
+      before do
+        subject.valid?
+      end
+
+      it "adds an error to :petition_id" do
+        expect(subject.errors[:petition_id]).to include("Petition doesn't exist")
+      end
+    end
+
+    context "when a constituency doesn't exist" do
+      subject { FactoryGirl.build(:invalidation, constituency_id: "1234") }
+
+      before do
+        subject.valid?
+      end
+
+      it "adds an error to :constituency_id" do
+        expect(subject.errors[:constituency_id]).to include("Constituency doesn't exist")
+      end
+    end
+
+    context "when a constituency doesn't exist" do
+      subject { FactoryGirl.build(:invalidation, constituency_id: "1234") }
+
+      before do
+        subject.valid?
+      end
+
+      it "adds an error to :constituency_id" do
+        expect(subject.errors[:constituency_id]).to include("Constituency doesn't exist")
+      end
+    end
+
+    context "when a location doesn't exist" do
+      subject { FactoryGirl.build(:invalidation, location_code: "XX") }
+
+      before do
+        subject.valid?
+      end
+
+      it "adds an error to :location_code" do
+        expect(subject.errors[:location_code]).to include("Location doesn't exist")
+      end
+    end
+
+    context "when the date range is reversed" do
+      subject { FactoryGirl.build(:invalidation, created_after: 2.weeks.ago, created_before: 3.weeks.ago) }
+
+      before do
+        subject.valid?
+      end
+
+      it "adds an error to :created_after" do
+        expect(subject.errors[:created_after]).to include("Starting date is after the finishing date")
+      end
+    end
+  end
+
+  describe "class methods" do
+    describe ".by_most_recent" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", created_at: 3.weeks.ago) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", created_at: 2.weeks.ago) }
+
+      it "orders the invalidations by the created_at timestamp in descending order" do
+        expect(described_class.by_most_recent.to_a).to eq([invalidation_2, invalidation_1])
+      end
+    end
+
+    describe ".by_longest_running" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: 1.hour.ago) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: 2.hours.ago) }
+
+      it "orders the invalidations by the started_at timestamp in ascending order" do
+        expect(described_class.by_most_recent.to_a).to eq([invalidation_2, invalidation_1])
+      end
+    end
+
+    describe ".cancelled" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: nil) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: 2.hours.ago) }
+
+      it "scopes the query to invalidations with a cancelled_at timestamp" do
+        expect(described_class.cancelled.to_a).to eq([invalidation_2])
+      end
+    end
+
+    describe ".completed" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: nil) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: 2.hours.ago) }
+
+      it "scopes the query to invalidations with a completed_at timestamp" do
+        expect(described_class.completed.to_a).to eq([invalidation_2])
+      end
+    end
+
+    describe ".enqueued" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: nil) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: 2.hours.ago) }
+      let!(:invalidation_3) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: 2.hours.ago, started_at: 1.hour.ago) }
+
+      it "scopes the query to invalidations with a enqueued_at timestamp that have not started" do
+        expect(described_class.enqueued.to_a).to eq([invalidation_2])
+      end
+    end
+
+    describe ".not_completed" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: nil) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: 2.hours.ago) }
+
+      it "scopes the query to invalidations without a completed_at timestamp" do
+        expect(described_class.not_completed.to_a).to eq([invalidation_1])
+      end
+    end
+
+    describe ".pending" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs") }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: 2.hours.ago) }
+      let!(:invalidation_3) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: 2.hours.ago) }
+      let!(:invalidation_4) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: 2.hours.ago) }
+      let!(:invalidation_5) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: 2.hours.ago) }
+
+      it "scopes the query to invalidations that have not been processed in anyway" do
+        expect(described_class.pending.to_a).to eq([invalidation_1])
+      end
+    end
+
+    describe ".running" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: 3.hours.ago, completed_at: nil) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: 3.hours.ago, completed_at: 2.hours.ago) }
+
+      it "scopes the query to invalidations that have started, but not completed" do
+        expect(described_class.running.to_a).to eq([invalidation_1])
+      end
+    end
+
+    describe ".started" do
+      let!(:invalidation_1) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: nil) }
+      let!(:invalidation_2) { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: 2.hours.ago) }
+
+      it "scopes the query to invalidations with a started_at timestamp" do
+        expect(described_class.started.to_a).to eq([invalidation_2])
+      end
+    end
+  end
+
+  describe "instance methods" do
+    describe "#cancelled?" do
+      context "when cancelled_at is nil" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: nil) }
+
+        it "returns false" do
+          expect(subject.cancelled?).to eq(false)
+        end
+      end
+
+      context "when cancelled_at is set" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: Time.current) }
+
+        it "returns true" do
+          expect(subject.cancelled?).to eq(true)
+        end
+      end
+    end
+
+    describe "#cancel!" do
+      it "changes cancelled? from false to true" do
+        expect {
+          subject.cancel!
+        }.to change {
+          subject.cancelled?
+        }.from(false).to(true)
+      end
+
+      it "it sets cancelled_at" do
+        expect {
+          subject.cancel!
+        }.to change {
+          subject.cancelled_at
+        }.from(nil).to(be_within(1.second).of(Time.current))
+      end
+
+      context "when the invalidation has already been cancelled" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.cancel!).to be_falsey
+        end
+      end
+
+      context "when the invalidation has already completed processing" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.cancel!).to be_falsey
+        end
+      end
+    end
+
+    describe "#completed?" do
+      context "when completed_at is nil" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: nil) }
+
+        it "returns false" do
+          expect(subject.completed?).to eq(false)
+        end
+      end
+
+      context "when completed_at is set" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: Time.current) }
+
+        it "returns true" do
+          expect(subject.completed?).to eq(true)
+        end
+      end
+    end
+
+    describe "#count!" do
+      before do
+        3.times do
+          FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1")
+        end
+      end
+
+      subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1") }
+
+      it "updates the matching_count" do
+        expect {
+          subject.count!
+        }.to change {
+          subject.matching_count
+        }.from(0).to(3)
+      end
+
+      it "updates the counted_at timestamp" do
+        expect {
+          subject.count!
+        }.to change {
+          subject.counted_at
+        }.from(nil).to(be_within(1.second).of(Time.current))
+      end
+
+      context "when the invalidation in no longer pending" do
+        subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1", started_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.count!).to be_falsey
+        end
+      end
+    end
+
+    describe "#enqueued?" do
+      context "when enqueued_at is nil" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: nil) }
+
+        it "returns false" do
+          expect(subject.enqueued?).to eq(false)
+        end
+      end
+
+      context "when enqueued_at is set" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: Time.current) }
+
+        it "returns true" do
+          expect(subject.enqueued?).to eq(true)
+        end
+      end
+    end
+
+    describe "#start!" do
+      subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1") }
+
+      let(:job) do
+        {
+          job: InvalidateSignaturesJob,
+          args: [
+            { "_aj_globalid" => "gid://epets/Invalidation/#{subject.id}" }
+          ],
+          queue: "high_priority"
+        }
+      end
+
+      it "enqueues the invalidate signatures job" do
+        expect {
+          subject.start!
+        }.to change {
+          enqueued_jobs
+        }.from([]).to([job])
+      end
+
+      it "updates the enqueued_at timestamps" do
+        expect {
+          subject.start!
+        }.to change {
+          subject.enqueued_at
+        }.from(nil).to(be_within(1.second).of(Time.current))
+      end
+
+      context "when the invalidation in no longer pending" do
+        subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1", started_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.start!).to be_falsey
+        end
+      end
+    end
+
+    describe "#started?" do
+      context "when started_at is nil" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: nil) }
+
+        it "returns false" do
+          expect(subject.started?).to eq(false)
+        end
+      end
+
+      context "when started_at is set" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: Time.current) }
+
+        it "returns true" do
+          expect(subject.started?).to eq(true)
+        end
+      end
+    end
+
+    describe "#pending?" do
+      context "by default" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs") }
+
+        it "returns true" do
+          expect(subject.pending?).to eq(true)
+        end
+      end
+
+      context "when a invalidation is enqueued" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", enqueued_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.pending?).to eq(false)
+        end
+      end
+
+      context "when a invalidation is running" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.pending?).to eq(false)
+        end
+      end
+
+      context "when a invalidation has been cancelled" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", cancelled_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.pending?).to eq(false)
+        end
+      end
+
+      context "when a invalidation has been completed" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", completed_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.pending?).to eq(false)
+        end
+      end
+    end
+
+    describe "#running?" do
+      context "by default" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs") }
+
+        it "returns false" do
+          expect(subject.running?).to eq(false)
+        end
+      end
+
+      context "when a invalidation is running" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: Time.current) }
+
+        it "returns true" do
+          expect(subject.running?).to eq(true)
+        end
+      end
+
+      context "when a invalidation has been cancelled" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: Time.current, cancelled_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.running?).to eq(false)
+        end
+      end
+
+      context "when a invalidation has been completed" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", started_at: Time.current, completed_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.running?).to eq(false)
+        end
+      end
+    end
+
+    describe "#percent_completed" do
+      context "when matching_count is zero" do
+        context "and the invalidation has not started" do
+          subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", matching_count: 0, invalidated_count: 0) }
+
+          it "returns 0" do
+            expect(subject.percent_completed).to eq(0)
+          end
+        end
+
+        context "and the invalidation has started" do
+          subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", matching_count: 0, invalidated_count: 0, started_at: Time.current) }
+
+          it "returns 100" do
+            expect(subject.percent_completed).to eq(100)
+          end
+        end
+
+        context "and the invalidation has completed" do
+          subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", matching_count: 0, invalidated_count: 0, started_at: Time.current, completed_at: Time.current) }
+
+          it "returns 100" do
+            expect(subject.percent_completed).to eq(100)
+          end
+        end
+      end
+
+      context "when matching_count is not zero" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", matching_count: 100, invalidated_count: 50, started_at: Time.current) }
+
+        it "returns the percentage of completed invalidations" do
+          expect(subject.percent_completed).to eq(50)
+        end
+      end
+
+      context "when invalidated_count is a negative number" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", matching_count: 100, invalidated_count: -50, started_at: Time.current) }
+
+        it "returns 0" do
+          expect(subject.percent_completed).to eq(0)
+        end
+      end
+
+      context "when invalidated_count is greater than matching_count" do
+        subject { FactoryGirl.create(:invalidation, name: "Joe Bloggs", matching_count: 50, invalidated_count: 100, started_at: Time.current) }
+
+        it "returns 100" do
+          expect(subject.percent_completed).to eq(100)
+        end
+      end
+    end
+
+    describe "#matching_signatures" do
+      context "when filtering by petition" do
+        let!(:petition_1) { FactoryGirl.create(:open_petition) }
+        let!(:petition_2) { FactoryGirl.create(:open_petition) }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, petition: petition_1) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, petition: petition_2) }
+
+        subject { FactoryGirl.create(:invalidation, petition: petition_1) }
+
+        it "includes signatures for petition 1" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures for petition 2" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+      end
+
+      context "when filtering by name" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, name: "Joe Public", petition: petition) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, name: "John Doe", petition: petition) }
+
+        subject { FactoryGirl.create(:invalidation, name: "Joe Public") }
+
+        it "includes signatures that match" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures that don't match" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+
+        context "and the filter includes a LIKE wildcard" do
+          subject { FactoryGirl.create(:invalidation, name: "Joe %") }
+
+          it "includes signatures that match" do
+            expect(subject.matching_signatures).to include(signature_1)
+          end
+
+          it "excludes signatures that don't match" do
+            expect(subject.matching_signatures).not_to include(signature_2)
+          end
+        end
+      end
+
+      context "when filtering by postcode" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, postcode: "SW1A 0AA", petition: petition) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, postcode: "E1 6PL", petition: petition) }
+
+        subject { FactoryGirl.create(:invalidation, postcode: "SW1A0AA") }
+
+        it "includes signatures that match" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures that don't match" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+      end
+
+      context "when filtering by ip_address" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1", petition: petition) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, ip_address: "192.168.1.1", petition: petition) }
+
+        subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1") }
+
+        it "includes signatures that match" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures that don't match" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+      end
+
+      context "when filtering by email" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, email: "joe@public.com", petition: petition) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, email: "john@doe.com", petition: petition) }
+
+        subject { FactoryGirl.create(:invalidation, email: "joe@public.com") }
+
+        it "includes signatures that match" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures that don't match" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+
+        context "and the filter includes a LIKE wildcard" do
+          subject { FactoryGirl.create(:invalidation, email: "%@public.com") }
+
+          it "includes signatures that match" do
+            expect(subject.matching_signatures).to include(signature_1)
+          end
+
+          it "excludes signatures that don't match" do
+            expect(subject.matching_signatures).not_to include(signature_2)
+          end
+        end
+      end
+
+      context "when filtering by date range" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+
+        context "and just the start date is specified" do
+          let!(:signature_1) { FactoryGirl.create(:validated_signature, created_at: 2.weeks.ago, petition: petition) }
+          let!(:signature_2) { FactoryGirl.create(:validated_signature, created_at: 4.weeks.ago, petition: petition) }
+
+          subject { FactoryGirl.create(:invalidation, created_after: 3.weeks.ago) }
+
+          it "includes signatures that match" do
+            expect(subject.matching_signatures).to include(signature_1)
+          end
+
+          it "excludes signatures that don't match" do
+            expect(subject.matching_signatures).not_to include(signature_2)
+          end
+        end
+
+        context "and just the end date is specified" do
+          let!(:signature_1) { FactoryGirl.create(:validated_signature, created_at: 4.weeks.ago, petition: petition) }
+          let!(:signature_2) { FactoryGirl.create(:validated_signature, created_at: 2.weeks.ago, petition: petition) }
+
+          subject { FactoryGirl.create(:invalidation, created_before: 3.weeks.ago) }
+
+          it "includes signatures that match" do
+            expect(subject.matching_signatures).to include(signature_1)
+          end
+
+          it "excludes signatures that don't match" do
+            expect(subject.matching_signatures).not_to include(signature_2)
+          end
+        end
+
+        context "and both the start date and end date are specified" do
+          let!(:signature_1) { FactoryGirl.create(:validated_signature, created_at: 4.weeks.ago, petition: petition) }
+          let!(:signature_2) { FactoryGirl.create(:validated_signature, created_at: 2.weeks.ago, petition: petition) }
+
+          subject { FactoryGirl.create(:invalidation, created_before: 3.weeks.ago, created_after: 5.weeks.ago) }
+
+          it "includes signatures that match" do
+            expect(subject.matching_signatures).to include(signature_1)
+          end
+
+          it "excludes signatures that don't match" do
+            expect(subject.matching_signatures).not_to include(signature_2)
+          end
+        end
+      end
+
+      context "when filtering by constituency_id" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+        let!(:constituency_1) { FactoryGirl.create(:constituency, external_id: "3314") }
+        let!(:constituency_2) { FactoryGirl.create(:constituency, external_id: "3352") }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, constituency_id: "3314", petition: petition) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, constituency_id: "3352", petition: petition) }
+
+        subject { FactoryGirl.create(:invalidation, constituency_id: "3314") }
+
+        it "includes signatures that match" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures that don't match" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+      end
+
+      context "when filtering by location_code" do
+        let!(:petition) { FactoryGirl.create(:open_petition) }
+        let!(:united_kingdom) { FactoryGirl.create(:location, code: "GB", name: "United Kingdom") }
+        let!(:australia) { FactoryGirl.create(:location, code: "AU", name: "Australia") }
+        let!(:signature_1) { FactoryGirl.create(:validated_signature, location_code: "GB", petition: petition) }
+        let!(:signature_2) { FactoryGirl.create(:validated_signature, location_code: "AU", petition: petition) }
+
+        subject { FactoryGirl.create(:invalidation, location_code: "GB") }
+
+        it "includes signatures that match" do
+          expect(subject.matching_signatures).to include(signature_1)
+        end
+
+        it "excludes signatures that don't match" do
+          expect(subject.matching_signatures).not_to include(signature_2)
+        end
+      end
+    end
+
+    describe "#invalidate!" do
+      let!(:petition) { FactoryGirl.create(:open_petition) }
+      let!(:signature_1) { FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1", petition: petition) }
+      let!(:signature_2) { FactoryGirl.create(:validated_signature, ip_address: "192.168.1.1", petition: petition) }
+      let!(:signature_3) { FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1", petition: petition) }
+      let!(:signature_4) { FactoryGirl.create(:validated_signature, ip_address: "192.168.1.2", petition: petition) }
+      let!(:signature_5) { FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1", petition: petition) }
+
+      subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1") }
+
+      it "sets the matching_count" do
+        expect {
+          subject.invalidate!
+        }.to change {
+          subject.reload.matching_count
+        }.from(0).to(3)
+      end
+
+      it "increments the invalidated_count after each invalidation" do
+        expect(subject).to receive(:increment!).with(:invalidated_count).exactly(3).times.and_call_original
+        subject.invalidate!
+      end
+
+      it "sets the invalidated_count" do
+        expect {
+          subject.invalidate!
+        }.to change {
+          subject.reload.invalidated_count
+        }.from(0).to(3)
+      end
+
+      it "sets the started_at timestamp" do
+        expect {
+          subject.invalidate!
+        }.to change {
+          subject.reload.started_at
+        }.from(nil).to(be_within(1.second).of(Time.current))
+      end
+
+      it "sets the completed_at timestamp" do
+        expect {
+          subject.invalidate!
+        }.to change {
+          subject.reload.completed_at
+        }.from(nil).to(be_within(1.second).of(Time.current))
+      end
+
+      it "adds the invalidated signatures to the signatures association" do
+        expect {
+          subject.invalidate!
+        }.to change {
+          subject.signatures.count
+        }.from(0).to(3)
+      end
+
+      context "when the invalidation has already completed processing" do
+        subject { FactoryGirl.create(:invalidation, ip_address: "10.0.1.1", completed_at: Time.current) }
+
+        it "returns false" do
+          expect(subject.invalidate!).to be_falsey
+        end
+      end
+
+      context "when cancelled before starting" do
+        before do
+          subject.cancel!
+        end
+
+        it "doesn't start" do
+          expect {
+            subject.invalidate!
+          }.not_to change {
+            subject.reload.started_at
+          }
+        end
+      end
+
+      context "when cancelled during processing" do
+        before do
+          200.times do
+            FactoryGirl.create(:validated_signature, ip_address: "10.0.1.1", petition: petition)
+          end
+        end
+
+        it "doesn't finish" do
+          allow(subject).to receive(:cancelled?).and_return(false, true)
+
+          subject.invalidate!
+          subject.reload
+
+          expect(subject.matching_count).to eq(203)
+          expect(subject.invalidated_count).to eq(100)
+          expect(subject.signatures.count).to eq(100)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Petition, type: :model do
     it { is_expected.to have_one(:government_response).dependent(:destroy) }
 
     it { is_expected.to have_many(:emails).dependent(:destroy) }
+    it { is_expected.to have_many(:invalidations) }
   end
 
   describe "callbacks" do
@@ -1290,6 +1291,38 @@ RSpec.describe Petition, type: :model do
       it "sets the debate_state to 'awaiting'" do
         petition.increment_signature_count!
         expect(petition.debate_state).to eq("awaiting")
+      end
+    end
+  end
+
+  describe "#decrement_signature_count!" do
+    let(:signature_count) { 8 }
+    let(:petition) do
+      FactoryGirl.create(:open_petition, {
+        signature_count: signature_count,
+        last_signed_at: 2.days.ago,
+        updated_at: 2.days.ago
+      })
+    end
+
+    it "decreases the signature count by 1" do
+      expect{
+        petition.decrement_signature_count!
+      }.to change{ petition.signature_count }.by(-1)
+    end
+
+    it "updates the updated_at timestamp" do
+      petition.decrement_signature_count!
+      expect(petition.updated_at).to be_within(1.second).of(Time.current)
+    end
+
+    context "when the signature count is 1" do
+      let(:signature_count) { 1 }
+
+      it "does nothing" do
+        expect{
+          petition.decrement_signature_count!
+        }.not_to change{ petition.signature_count }
       end
     end
   end


### PR DESCRIPTION
Currently invalidating signatures is an ad-hoc task but with increasing amounts of fraudulent signatures we need to make it an admin task.

This commit adds an invalidation model that tracks what are the reasons for the invalidation and what are its criteria. It processes them in a background job so that a sysadmin can track the progress of a large invalidation and cancel it if necessary. You can also preview the number of signatures that will be invalidated.