### PR TITLE
Set the path in the crontab

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,8 @@
 
 # Learn more: http://github.com/javan/whenever
 
+env :PATH, env['PATH']
+
 every :weekday, at: '7am' do
   rake "epets:admin_email_reminder", output: nil
 end


### PR DESCRIPTION
The whenever gem uses a relative path for the rails runner command but just a `bundle exec rake` for rake tasks. When the crontab is executed the bundle command isn't in the path by default so ensure that it is.