### PR TITLE
Add task locking

### DIFF
--- a/app/jobs/email_threshold_reminder_job.rb
+++ b/app/jobs/email_threshold_reminder_job.rb
@@ -1,0 +1,7 @@
+class EmailThresholdReminderJob < ActiveJob::Base
+  queue_as :high_priority
+
+  def perform
+    EmailReminder.threshold_email_reminder
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,50 @@
+class Task < ActiveRecord::Base
+  validates :name, presence: true, length: { maximum: 60 }
+
+  class << self
+    def run(name, period = 12.hours, &block)
+      task_for(name).send(:run, period, &block)
+    end
+
+    private
+
+    def task_for(name)
+      begin
+        find_or_create_by!(name: name)
+      rescue ActiveRecord::RecordNotUnique => e
+        retry
+      end
+    end
+  end
+
+  private
+
+  def run(period = 12.hours, &block)
+    retry_lock do
+      if pending?(period)
+        block.call
+        touch
+      end
+    end
+  end
+
+  def pending?(period)
+    created_at == updated_at || updated_at < period.ago
+  end
+
+  def retry_lock
+    retried = false
+
+    begin
+      with_lock { yield }
+    rescue PG::InFailedSqlTransaction => e
+      if retried
+        raise e
+      else
+        retried = true
+        self.class.connection.clear_cache!
+        retry
+      end
+    end
+  end
+end

--- a/app/views/admin_mailer/admin_email_reminder.html.erb
+++ b/app/views/admin_mailer/admin_email_reminder.html.erb
@@ -1,9 +1,0 @@
-<p>Dear <%= @admin_user.first_name %>,</p>
-
-<p><%= @new_petitions_count %> <%= @new_petitions_count == 1 ? 'petition is new' : 'petitions are new' %></p>
-
-<p><%= @petitions.length %> <%= @petitions.length == 1 ? 'petition requires action' : 'petitions require action' %></p>
-
-<p>Please go here <%= link_to nil, admin_root_url %></p>
-
-<p>Thank you.</p>

--- a/app/views/admin_mailer/admin_email_reminder.text.erb
+++ b/app/views/admin_mailer/admin_email_reminder.text.erb
@@ -1,8 +1,0 @@
-Dear <%= @admin_user.first_name %>,
-
-<%= @new_petitions_count %> <%= @new_petitions_count == 1 ? 'petition is new' : 'petitions are new' %>
-<%= @petitions.length %> <%= @petitions.length == 1 ? 'petition requires action' : 'petitions require action' %>
-
-Please go here <%= admin_root_url %>
-
-Thank you.

--- a/app/views/admin_mailer/threshold_email_reminder.html.erb
+++ b/app/views/admin_mailer/threshold_email_reminder.html.erb
@@ -1,5 +1,5 @@
 
-<p><%= @petitions.length %> <%= @petitions.length == 1 ? 'petition requires action' : 'petitions require action' %></p>
+<p><%= t(:threshold_reminder, scope: :admin, count: @petitions.length) %></p>
 
 <p>Please go here <%= link_to nil, admin_petitions_url(state: :awaiting_debate_date) %></p>
 

--- a/app/views/admin_mailer/threshold_email_reminder.text.erb
+++ b/app/views/admin_mailer/threshold_email_reminder.text.erb
@@ -1,5 +1,5 @@
 
-<%= @petitions.length %> <%= @petitions.length == 1 ? 'petition requires action' : 'petitions require action' %>
+<%= t(:threshold_reminder, scope: :admin, count: @petitions.length) %>
 
 Please go here <%= admin_petitions_url(state: :awaiting_debate_date) %>
 

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -7,6 +7,10 @@ en-GB:
       one: "Are you sure you want to do this and email the petitioner?"
       other: "Are you sure you want to do this and email all %{formatted_count} petitioners?"
 
+    threshold_reminder:
+      one: "%{count} petition requires action"
+      other: "%{count} petitions require action"
+
     invalidations:
       facets:
         keys:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,10 +21,6 @@
 
 env :PATH, env['PATH']
 
-every :weekday, at: '7am' do
-  rake "epets:admin_email_reminder", output: nil
-end
-
 every :weekday, at: '6.30am' do
   rake "epets:threshold_email_reminder", output: nil
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,11 +30,11 @@ every :weekday, at: '6.30am' do
 end
 
 every :day, at: '1.15am' do
-  runner "FetchCountryRegisterJob.perform_later"
+  rake "epets:countries:fetch", output: nil
 end
 
 every :day, at: '2.30am' do
-  runner "PetitionCountJob.perform_later"
+  rake "epets:petitions:count", output: nil
 end
 
 every :day, at: '7.00am' do

--- a/db/migrate/20160715092819_create_tasks.rb
+++ b/db/migrate/20160715092819_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration
+  def change
+    create_table :tasks do |t|
+      t.string :name, limit: 60, null: false
+      t.timestamps null: false
+    end
+
+    add_index :tasks, :name, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -830,6 +830,37 @@ ALTER SEQUENCE sponsors_id_seq OWNED BY sponsors.id;
 
 
 --
+-- Name: tasks; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE tasks (
+    id integer NOT NULL,
+    name character varying(60) NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: tasks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE tasks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: tasks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE tasks_id_seq OWNED BY tasks.id;
+
+
+--
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -974,6 +1005,13 @@ ALTER TABLE ONLY sites ALTER COLUMN id SET DEFAULT nextval('sites_id_seq'::regcl
 --
 
 ALTER TABLE ONLY sponsors ALTER COLUMN id SET DEFAULT nextval('sponsors_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY tasks ALTER COLUMN id SET DEFAULT nextval('tasks_id_seq'::regclass);
 
 
 --
@@ -1142,6 +1180,14 @@ ALTER TABLE ONLY sites
 
 ALTER TABLE ONLY sponsors
     ADD CONSTRAINT sponsors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY tasks
+    ADD CONSTRAINT tasks_pkey PRIMARY KEY (id);
 
 
 --
@@ -1502,6 +1548,13 @@ CREATE INDEX index_signatures_on_validated_at ON signatures USING btree (validat
 
 
 --
+-- Name: index_tasks_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_tasks_on_name ON tasks USING btree (name);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1761,4 +1814,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160706060256');
 INSERT INTO schema_migrations (version) VALUES ('20160713124623');
 
 INSERT INTO schema_migrations (version) VALUES ('20160713130452');
+
+INSERT INTO schema_migrations (version) VALUES ('20160715092819');
 

--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -501,7 +501,7 @@ class PackageBuilder
 
       # Run cron jobs only on workers, as webservers autoscale up and down.
       # ${SERVER_TYPE} is pre-populated for the deploy user by the build scripts
-      # su - deploy -c 'if [ ${SERVER_TYPE} = "worker" ] ; then cd /home/deploy/epetitions/current && bundle exec whenever -w ; else echo not running whenever ; fi'
+      su - deploy -c 'if [ ${SERVER_TYPE} = "worker" ] ; then cd /home/deploy/epetitions/current && bundle exec whenever -w ; else echo not running whenever ; fi'
     SCRIPT
   end
 

--- a/lib/tasks/countries.rake
+++ b/lib/tasks/countries.rake
@@ -2,7 +2,9 @@ namespace :epets do
   namespace :countries do
     desc "Add task to the queue to fetch country list from the register"
     task :fetch => :environment do
-      FetchCountryRegisterJob.perform_later
+      Task.run("epets:countries:fetch") do
+        FetchCountryRegisterJob.perform_later
+      end
     end
   end
 end

--- a/lib/tasks/countries.rake
+++ b/lib/tasks/countries.rake
@@ -1,0 +1,8 @@
+namespace :epets do
+  namespace :countries do
+    desc "Add task to the queue to fetch country list from the register"
+    task :fetch => :environment do
+      FetchCountryRegisterJob.perform_later
+    end
+  end
+end

--- a/lib/tasks/epets.rake
+++ b/lib/tasks/epets.rake
@@ -12,7 +12,7 @@ namespace :epets do
   desc "Email threshold users with a list of threshold petitions"
   task :threshold_email_reminder => :environment do
     Task.run("epets:threshold_email_reminder") do
-      EmailReminder.threshold_email_reminder
+      EmailThresholdReminderJob.perform_later
     end
   end
 

--- a/lib/tasks/epets.rake
+++ b/lib/tasks/epets.rake
@@ -11,7 +11,9 @@ namespace :epets do
 
   desc "Email threshold users with a list of threshold petitions"
   task :threshold_email_reminder => :environment do
-    EmailReminder.threshold_email_reminder
+    Task.run("epets:threshold_email_reminder") do
+      EmailReminder.threshold_email_reminder
+    end
   end
 
   desc "Special resend of signature email validation"

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -1,12 +1,17 @@
 namespace :epets do
   namespace :petitions do
-    desc "Add task to the queue to close petitions at midnight"
+    desc "Add a task to the queue to close petitions at midnight"
     task :close => :environment do
       time = Date.tomorrow.beginning_of_day
       ClosePetitionsJob.set(wait_until: time).perform_later(time.iso8601)
     end
 
-    desc "Add task to the queue to mark petitions as debated at midnight"
+    desc "Add a task to the queue to validate petition counts"
+    task :count => :environment do
+      PetitionCountJob.perform_later
+    end
+
+    desc "Add a task to the queue to mark petitions as debated at midnight"
     task :debated => :environment do
       date = Date.tomorrow
       DebatedPetitionsJob.set(wait_until: date.beginning_of_day).perform_later(date.iso8601)

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -2,19 +2,25 @@ namespace :epets do
   namespace :petitions do
     desc "Add a task to the queue to close petitions at midnight"
     task :close => :environment do
-      time = Date.tomorrow.beginning_of_day
-      ClosePetitionsJob.set(wait_until: time).perform_later(time.iso8601)
+      Task.run("epets:petitions:close") do
+        time = Date.tomorrow.beginning_of_day
+        ClosePetitionsJob.set(wait_until: time).perform_later(time.iso8601)
+      end
     end
 
     desc "Add a task to the queue to validate petition counts"
     task :count => :environment do
-      PetitionCountJob.perform_later
+      Task.run("epets:petitions:count") do
+        PetitionCountJob.perform_later
+      end
     end
 
     desc "Add a task to the queue to mark petitions as debated at midnight"
     task :debated => :environment do
-      date = Date.tomorrow
-      DebatedPetitionsJob.set(wait_until: date.beginning_of_day).perform_later(date.iso8601)
+      Task.run("epets:petitions:debated") do
+        date = Date.tomorrow
+        DebatedPetitionsJob.set(wait_until: date.beginning_of_day).perform_later(date.iso8601)
+      end
     end
   end
 end

--- a/spec/jobs/email_threshold_reminder_job_spec.rb
+++ b/spec/jobs/email_threshold_reminder_job_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe EmailThresholdReminderJob, type: :job do
+  let!(:moderator_1) { FactoryGirl.create(:moderator_user, email: "alice@parliament.uk") }
+  let!(:moderator_2) { FactoryGirl.create(:moderator_user, email: "bob@parliament.uk") }
+
+  let!(:petition_1) { FactoryGirl.create(:open_petition, signature_count: 11) }
+  let!(:petition_2) { FactoryGirl.create(:open_petition, signature_count: 10) }
+  let!(:petition_3) { FactoryGirl.create(:open_petition, signature_count: 9) }
+  let!(:petition_4) { FactoryGirl.create(:open_petition, notified_by_email: true) }
+
+  let(:deliveries) { ActionMailer::Base.deliveries }
+  let(:email) { deliveries.last }
+
+  before do
+    allow(Site).to receive(:threshold_for_debate).and_return(10)
+  end
+
+  it "send out an email alert" do
+    expect {
+      described_class.perform_now
+    }.to change {
+      deliveries.size
+    }.by(1)
+  end
+
+  it "delivers it to all the moderators" do
+    described_class.perform_now
+
+    expect(email).to deliver_to("alice@parliament.uk", "bob@parliament.uk")
+    expect(email).to have_subject("Petitions alert")
+    expect(email).to have_body_text("2 petitions require action")
+  end
+
+  it "updates notified by email on petition 1" do
+    expect {
+      described_class.perform_now
+    }.to change {
+      petition_1.reload.notified_by_email
+    }.from(false).to(true)
+  end
+
+  it "updates notified by email on petition 2" do
+    expect {
+      described_class.perform_now
+    }.to change {
+      petition_2.reload.notified_by_email
+    }.from(false).to(true)
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  describe "indexes" do
+    it { is_expected.to have_db_index(:name).unique }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(60) }
+  end
+
+  describe ".run" do
+    subject { described_class.find_by!(name: "task") }
+
+    context "with the default period" do
+      context "when the task has been newly created" do
+        let(:now) { Time.current }
+
+        before do
+          described_class.create!(name: 'task', created_at: now, updated_at: now)
+        end
+
+        it "calls the block" do
+          expect { |b| described_class.run("task", &b) }.to yield_control
+        end
+
+        it "updates the timestamp" do
+          expect {
+            described_class.run("task"){}
+          }.to change {
+            subject.reload.updated_at
+          }.to(be_within(1.second).of(Time.current))
+        end
+      end
+
+      context "when the period has not elapsed" do
+        before do
+          described_class.create!(name: 'task', created_at: 2.weeks.ago, updated_at: 6.hours.ago)
+        end
+
+        it "doesn't call the block" do
+          expect { |b| described_class.run("task", &b) }.not_to yield_control
+        end
+
+        it "doesn't update the timestamp" do
+          expect {
+            described_class.run("task"){}
+          }.not_to change {
+            subject.reload.updated_at
+          }
+        end
+      end
+
+      context "when the period has elapsed" do
+        before do
+          described_class.create!(name: 'task', created_at: 2.weeks.ago, updated_at: 24.hours.ago)
+        end
+
+        it "calls the block" do
+          expect { |b| described_class.run("task", &b) }.to yield_control
+        end
+
+        it "updates the timestamp" do
+          expect {
+            described_class.run("task"){}
+          }.to change {
+            subject.reload.updated_at
+          }.to(be_within(1.second).of(Time.current))
+        end
+      end
+    end
+
+    context "with a custom period" do
+      context "when the task has been newly created" do
+        let(:now) { Time.current }
+
+        before do
+          described_class.create!(name: 'task', created_at: now, updated_at: now)
+        end
+
+        it "calls the block" do
+          expect { |b| described_class.run("task", 30.minutes, &b) }.to yield_control
+        end
+
+        it "updates the timestamp" do
+          expect {
+            described_class.run("task", 30.minutes){}
+          }.to change {
+            subject.reload.updated_at
+          }.to(be_within(1.second).of(Time.current))
+        end
+      end
+
+      context "when the period has not elapsed" do
+        before do
+          described_class.create!(name: 'task', created_at: 2.weeks.ago, updated_at: 10.minutes.ago)
+        end
+
+        it "doesn't call the block" do
+          expect { |b| described_class.run("task", 30.minutes, &b) }.not_to yield_control
+        end
+
+        it "doesn't update the timestamp" do
+          expect {
+            described_class.run("task", 30.minutes){}
+          }.not_to change {
+            subject.reload.updated_at
+          }
+        end
+      end
+
+      context "when the period has elapsed" do
+        before do
+          described_class.create!(name: 'task', created_at: 2.weeks.ago, updated_at: 1.hour.ago)
+        end
+
+        it "calls the block" do
+          expect { |b| described_class.run("task", 30.minutes, &b) }.to yield_control
+        end
+
+        it "updates the timestamp" do
+          expect {
+            described_class.run("task", 30.minutes){}
+          }.to change {
+            subject.reload.updated_at
+          }.to(be_within(1.second).of(Time.current))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since we run multiple app servers we need to ensure that cron jobs are only executed the once across the autoscaling group. To do this we can add a tasks table that allows us to create a shared lock that works across the whole group.

Depends on #508 and #510 to be merged first.