### PR TITLE
Auto update signature count

### DIFF
--- a/app/assets/javascripts/auto-updater.js
+++ b/app/assets/javascripts/auto-updater.js
@@ -1,0 +1,54 @@
+//= require jquery.countTo
+//
+// Check for signature count update every few seconds
+// Has hardcoded threshold levels.
+(function ($) {
+  'use strict';
+
+  var JSON_URL = $('.meta-json a').attr('href'),
+      THRESHOLD_RESPONSE = 10000,
+      THRESHOLD_DEBATE = 100000,
+      TIMEOUT = 10000;
+
+  function add_commas(n) {
+        return n.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  function update_progress_bar(value) {
+    var pc = value / (value >= THRESHOLD_RESPONSE ? THRESHOLD_DEBATE : THRESHOLD_RESPONSE) * 100;
+    if (pc > 100) {
+      pc = 100;
+    } else if (pc < 1) {
+      pc = 1;
+    }
+    $('.signature-count-current').width(pc + '%');
+    if (value >= THRESHOLD_RESPONSE) {
+      $('.signature-count-goal').text(add_commas(THRESHOLD_DEBATE));
+    } else {
+      $('.signature-count-goal').text(add_commas(THRESHOLD_RESPONSE));
+    }
+  }
+
+  function fetch_count() {
+    $.get(JSON_URL, function(data) {
+      if (data && data.data && data.data.attributes) {
+        var sigs = data.data.attributes.signature_count,
+            current = parseInt($('.signature-count-number .count').text());
+        if (sigs && sigs != current) {
+          $('.signature-count-number .count').countTo({
+            from: current,
+            to: sigs,
+            refreshInterval: 50,
+            formatter: add_commas,
+            onUpdate: update_progress_bar,
+            onComplete: update_progress_bar
+          });
+        }
+      }
+      setTimeout(fetch_count, TIMEOUT);
+    });
+  }
+  setTimeout(fetch_count, TIMEOUT);
+
+})(jQuery);
+

--- a/app/assets/javascripts/auto-updater.js
+++ b/app/assets/javascripts/auto-updater.js
@@ -5,7 +5,7 @@
 (function ($) {
   'use strict';
 
-  var JSON_URL = $('.meta-json a').attr('href'),
+  var JSON_URL = window.location.pathname + '/count.json',
       THRESHOLD_RESPONSE = 10000,
       THRESHOLD_DEBATE = 100000,
       TIMEOUT = 10000;
@@ -31,16 +31,15 @@
 
   function fetch_count() {
     $.get(JSON_URL, function(data) {
-      if (data && data.data && data.data.attributes) {
+      if (data && data.signature_count) {
         var $count = $('.signature-count-number .count');
-        var sigs = data.data.attributes.signature_count;
-        var current = parseInt($('.signature-count-number .count').data('count'));
+        var current = parseInt($count.data('count'));
 
-        if (sigs && sigs != current) {
-          $count.data('count', sigs);
+        if (data.signature_count != current) {
+          $count.data('count', data.signature_count);
           $count.countTo({
             from: current,
-            to: sigs,
+            to: data.signature_count,
             refreshInterval: 50,
             formatter: add_commas,
             onUpdate: update_progress_bar,

--- a/app/assets/javascripts/auto-updater.js
+++ b/app/assets/javascripts/auto-updater.js
@@ -32,10 +32,13 @@
   function fetch_count() {
     $.get(JSON_URL, function(data) {
       if (data && data.data && data.data.attributes) {
-        var sigs = data.data.attributes.signature_count,
-            current = parseInt($('.signature-count-number .count').text());
+        var $count = $('.signature-count-number .count');
+        var sigs = data.data.attributes.signature_count;
+        var current = parseInt($('.signature-count-number .count').data('count'));
+
         if (sigs && sigs != current) {
-          $('.signature-count-number .count').countTo({
+          $count.data('count', sigs);
+          $count.countTo({
             from: current,
             to: sigs,
             refreshInterval: 50,

--- a/app/assets/stylesheets/petitions/views/_petition-show.scss
+++ b/app/assets/stylesheets/petitions/views/_petition-show.scss
@@ -13,7 +13,7 @@
       margin-bottom: em(10, 48);
     }
 
-    span {
+    span.text {
       @include bold-27();
     }
   }

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -4,7 +4,7 @@ class PetitionsController < ApplicationController
   before_action :avoid_unknown_state_filters, only: :index
   before_action :do_not_cache, except: %i[index show]
 
-  before_action :retrieve_petition, only: [:show, :moderation_info]
+  before_action :retrieve_petition, only: [:show, :count, :moderation_info]
   before_action :redirect_to_moderation_info_url, if: :not_moderated?, only: :show
   before_action :redirect_to_petition_url, if: :moderated?, only: :moderation_info
 
@@ -18,6 +18,10 @@ class PetitionsController < ApplicationController
 
   def show
     respond_with @petition
+  end
+
+  def count
+    respond_to { |f| f.json }
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,10 @@ module ApplicationHelper
     params.values_at(:controller, :action) == %w[petitions show]
   end
 
+  def open_petition_page?
+    petition_page? && @petition.open?
+  end
+
   def archived_petition_page?
     params[:controller] == 'archived/petitions' && params[:action] == 'show'
   end

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -27,6 +27,7 @@ module CacheHelper
       delegate :assigns, :params, to: :template
       delegate :archived_petition_page?, to: :template
       delegate :create_petition_page?, to: :template
+      delegate :open_petition_page?, to: :template
       delegate :home_page?, to: :template
       delegate :last_signature_at, to: :template
       delegate :last_government_response_updated_at, to: :template
@@ -45,6 +46,10 @@ module CacheHelper
 
       def create_petition_page
         create_petition_page?
+      end
+
+      def open_petition_page
+        open_petition_page?
       end
 
       def home_page

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,9 @@
     <%= cache_for :footer do %>
       <%= render 'application/footer' %>
       <%= javascript_include_tag 'application' %>
+      <% if open_petition_page? %>
+        <%= javascript_include_tag 'auto-updater' %>
+      <% end %>
       <% if create_petition_page? %>
         <%= javascript_include_tag 'character-counter' %>
       <% end %>

--- a/app/views/petitions/count.json.jbuilder
+++ b/app/views/petitions/count.json.jbuilder
@@ -1,0 +1,1 @@
+json.signature_count @petition.signature_count

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -14,6 +14,7 @@ header:
 footer:
   keys:
     - :create_petition_page
+    - :open_petition_page
   options:
     expires_in: 300
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,6 +16,7 @@ Rails.application.config.assets.precompile += %w(
   ie.js
   admin.js
   character-counter.js
+  auto-updater.js
 )
 
 # Compress JavaScript assets.

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -146,8 +146,8 @@ en-GB:
     signature_counts:
       default:
         html:
-          one: "<span class=\"count\">%{formatted_count}</span> <span class=\"text\">signature</span>"
-          other: "<span class=\"count\">%{formatted_count}</span> <span class=\"text\">signatures</span>"
+          one: "<span class=\"count\" data-count=\"%{count}\">%{formatted_count}</span> <span class=\"text\">signature</span>"
+          other: "<span class=\"count\" data-count=\"%{count}\">%{formatted_count}</span> <span class=\"text\">signatures</span>"
       trending:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> signature in the last hour"

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -146,8 +146,8 @@ en-GB:
     signature_counts:
       default:
         html:
-          one: "%{formatted_count} <span>signature</span>"
-          other: "%{formatted_count} <span>signatures</span>"
+          one: "<span class=\"count\">%{formatted_count}</span> <span class=\"text\">signature</span>"
+          other: "<span class=\"count\">%{formatted_count}</span> <span class=\"text\">signatures</span>"
       trending:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> signature in the last hour"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,11 @@ Rails.application.routes.draw do
       end
 
       member do
-        get  'thank-you', :action => :thank_you, :as => :thank_you
-        get  'moderation-info', :action => :moderation_info, :as => :moderation_info
+        get 'count', :action => :count, :as => :count
+        get 'thank-you', :action => :thank_you, :as => :thank_you
+        get 'moderation-info', :action => :moderation_info, :as => :moderation_info
       end
+
       resources :sponsors, only: [:show, :update], param: :token do
         get 'thank-you', on: :member
         get 'sponsored', on: :member

--- a/spec/helpers/signature_helper_spec.rb
+++ b/spec/helpers/signature_helper_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe SignatureHelper, type: :helper do
 
       context "when the signature count is 1" do
         it "returns a correctly formatted signature count" do
-          expect(helper.signature_count(:default, 1)).to eq("1 <span>signature</span>")
+          expect(helper.signature_count(:default, 1)).to eq("<span class=\"count\">1</span> <span class=\"text\">signature</span>")
         end
       end
 
       context "when the signature count is 100" do
         it "returns a correctly formatted signature count" do
-          expect(helper.signature_count(:default, 100)).to eq("100 <span>signatures</span>")
+          expect(helper.signature_count(:default, 100)).to eq("<span class=\"count\">100</span> <span class=\"text\">signatures</span>")
         end
       end
 
       context "when the signature count is 1000" do
         it "returns a correctly formatted signature count" do
-          expect(helper.signature_count(:default, 1000)).to eq("1,000 <span>signatures</span>")
+          expect(helper.signature_count(:default, 1000)).to eq("<span class=\"count\">1,000</span> <span class=\"text\">signatures</span>")
         end
       end
     end

--- a/spec/helpers/signature_helper_spec.rb
+++ b/spec/helpers/signature_helper_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe SignatureHelper, type: :helper do
 
       context "when the signature count is 1" do
         it "returns a correctly formatted signature count" do
-          expect(helper.signature_count(:default, 1)).to eq("<span class=\"count\">1</span> <span class=\"text\">signature</span>")
+          expect(helper.signature_count(:default, 1)).to eq("<span class=\"count\" data-count=\"1\">1</span> <span class=\"text\">signature</span>")
         end
       end
 
       context "when the signature count is 100" do
         it "returns a correctly formatted signature count" do
-          expect(helper.signature_count(:default, 100)).to eq("<span class=\"count\">100</span> <span class=\"text\">signatures</span>")
+          expect(helper.signature_count(:default, 100)).to eq("<span class=\"count\" data-count=\"100\">100</span> <span class=\"text\">signatures</span>")
         end
       end
 
       context "when the signature count is 1000" do
         it "returns a correctly formatted signature count" do
-          expect(helper.signature_count(:default, 1000)).to eq("<span class=\"count\">1,000</span> <span class=\"text\">signatures</span>")
+          expect(helper.signature_count(:default, 1000)).to eq("<span class=\"count\" data-count=\"1000\">1,000</span> <span class=\"text\">signatures</span>")
         end
       end
     end

--- a/vendor/assets/javascripts/jquery.countTo.js
+++ b/vendor/assets/javascripts/jquery.countTo.js
@@ -1,0 +1,130 @@
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        factory(require('jquery'));
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function ($) {
+  var CountTo = function (element, options) {
+    this.$element = $(element);
+    this.options  = $.extend({}, CountTo.DEFAULTS, this.dataOptions(), options);
+    this.init();
+  };
+
+  CountTo.DEFAULTS = {
+    from: 0,               // the number the element should start at
+    to: 0,                 // the number the element should end at
+    speed: 1000,           // how long it should take to count between the target numbers
+    refreshInterval: 100,  // how often the element should be updated
+    decimals: 0,           // the number of decimal places to show
+    formatter: formatter,  // handler for formatting the value before rendering
+    onUpdate: null,        // callback method for every time the element is updated
+    onComplete: null       // callback method for when the element finishes updating
+  };
+
+  CountTo.prototype.init = function () {
+    this.value     = this.options.from;
+    this.loops     = Math.ceil(this.options.speed / this.options.refreshInterval);
+    this.loopCount = 0;
+    this.increment = (this.options.to - this.options.from) / this.loops;
+  };
+
+  CountTo.prototype.dataOptions = function () {
+    var options = {
+      from:            this.$element.data('from'),
+      to:              this.$element.data('to'),
+      speed:           this.$element.data('speed'),
+      refreshInterval: this.$element.data('refresh-interval'),
+      decimals:        this.$element.data('decimals')
+    };
+
+    var keys = Object.keys(options);
+
+    for (var i in keys) {
+      var key = keys[i];
+
+      if (typeof(options[key]) === 'undefined') {
+        delete options[key];
+      }
+    }
+
+    return options;
+  };
+
+  CountTo.prototype.update = function () {
+    this.value += this.increment;
+    this.loopCount++;
+
+    this.render();
+
+    if (typeof(this.options.onUpdate) == 'function') {
+      this.options.onUpdate.call(this.$element, this.value);
+    }
+
+    if (this.loopCount >= this.loops) {
+      clearInterval(this.interval);
+      this.value = this.options.to;
+
+      if (typeof(this.options.onComplete) == 'function') {
+        this.options.onComplete.call(this.$element, this.value);
+      }
+    }
+  };
+
+  CountTo.prototype.render = function () {
+    var formattedValue = this.options.formatter.call(this.$element, this.value, this.options);
+    this.$element.text(formattedValue);
+  };
+
+  CountTo.prototype.restart = function () {
+    this.stop();
+    this.init();
+    this.start();
+  };
+
+  CountTo.prototype.start = function () {
+    this.stop();
+    this.render();
+    this.interval = setInterval(this.update.bind(this), this.options.refreshInterval);
+  };
+
+  CountTo.prototype.stop = function () {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  };
+
+  CountTo.prototype.toggle = function () {
+    if (this.interval) {
+      this.stop();
+    } else {
+      this.start();
+    }
+  };
+
+  function formatter(value, options) {
+    return value.toFixed(options.decimals);
+  }
+
+  $.fn.countTo = function (option) {
+    return this.each(function () {
+      var $this   = $(this);
+      var data    = $this.data('countTo');
+      var init    = !data || typeof(option) === 'object';
+      var options = typeof(option) === 'object' ? option : {};
+      var method  = typeof(option) === 'string' ? option : 'start';
+
+      if (init) {
+        if (data) data.stop();
+        $this.data('countTo', data = new CountTo(this, options));
+      }
+
+      data[method].call(data);
+    });
+  };
+}));


### PR DESCRIPTION
This is a update to #482, with fixes for the following:

* Store current count in a data attribute because of `parseInt`
* Use lightweight signature count API endpoint