### PR TITLE
Make threshold limits dynamic

### DIFF
--- a/app/assets/javascripts/auto-updater.js.erb
+++ b/app/assets/javascripts/auto-updater.js.erb
@@ -6,8 +6,8 @@
   'use strict';
 
   var JSON_URL = window.location.pathname + '/count.json',
-      THRESHOLD_RESPONSE = 10000,
-      THRESHOLD_DEBATE = 100000,
+      THRESHOLD_RESPONSE = <%= Site.threshold_for_response %>,
+      THRESHOLD_DEBATE = <%= Site.threshold_for_debate %>,
       TIMEOUT = 10000;
 
   function add_commas(n) {


### PR DESCRIPTION
The preview site has lower threshold limits so to be able to test it properly make them dynamic (on asset compilation - not every request).