### PR TITLE
Only allow global requests on specific actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,6 @@ class ApplicationController < ActionController::Base
   before_action :set_seen_cookie_message, if: :show_cookie_message?
   helper_method :show_cookie_message?, :public_petition_facets
 
-  before_action :set_cors_headers, if: :json_request?
-
   protected
 
   def authenticate

--- a/app/controllers/archived/petitions_controller.rb
+++ b/app/controllers/archived/petitions_controller.rb
@@ -4,6 +4,8 @@ class Archived::PetitionsController < ApplicationController
   before_action :fetch_petitions, only: [:index]
   before_action :fetch_petition, only: [:show]
 
+  before_action :set_cors_headers, only: [:index, :show], if: :json_request?
+
   def index
     respond_with(@petitions)
   end

--- a/app/controllers/archived/petitions_controller.rb
+++ b/app/controllers/archived/petitions_controller.rb
@@ -15,11 +15,7 @@ class Archived::PetitionsController < ApplicationController
   private
 
   def fetch_petitions
-    if params[:q].blank?
-      @petitions = ArchivedPetition.search(params.merge({state: 'by_most_signatures'}))
-    else
-      @petitions = ArchivedPetition.search(params)
-    end
+    @petitions = ArchivedPetition.search(params)
   end
 
   def fetch_petition

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -8,6 +8,8 @@ class PetitionsController < ApplicationController
   before_action :redirect_to_moderation_info_url, if: :not_moderated?, only: :show
   before_action :redirect_to_petition_url, if: :moderated?, only: :moderation_info
 
+  before_action :set_cors_headers, only: [:index, :show, :count], if: :json_request?
+
   respond_to :html
   respond_to :json, only: [:index, :show]
 

--- a/app/models/archived_petition.rb
+++ b/app/models/archived_petition.rb
@@ -16,11 +16,12 @@ class ArchivedPetition < ActiveRecord::Base
   extend Searchable(:title, :description)
   include Browseable
 
-  facet :all, -> { by_created_at }
-  facet :open, -> { for_state(OPEN_STATE).by_created_at }
-  facet :closed, -> { for_state(CLOSED_STATE).by_created_at }
-  facet :rejected, -> { for_state(REJECTED_STATE).by_created_at }
+  facet :all, -> { by_most_signatures }
+  facet :open, -> { for_state(OPEN_STATE).by_most_signatures }
+  facet :closed, -> { for_state(CLOSED_STATE).by_most_signatures }
+  facet :rejected, -> { for_state(REJECTED_STATE).by_most_signatures }
   facet :by_most_signatures, -> { by_most_signatures }
+  facet :by_created_at, -> { by_created_at }
 
   class << self
     def for_state(state)

--- a/app/presenters/api_pagination_links_presenter.rb
+++ b/app/presenters/api_pagination_links_presenter.rb
@@ -3,8 +3,8 @@ class ApiPaginationLinksPresenter
 
   # results should be a Browseable::Search instance that
   # exposes the attributes delegated to it below
-  def initialize(results)
-    @results = results
+  def initialize(results, params)
+    @results, @params = results, params
   end
 
   def serialize
@@ -18,9 +18,9 @@ class ApiPaginationLinksPresenter
 
   private
 
-  attr_reader :results
+  attr_reader :results, :params
 
-  delegate :params, :total_pages, :first_page?, :second_page?, :last_page?, to: :results
+  delegate :total_pages, :first_page?, :second_page?, :last_page?, to: :results
 
   # Sense check that the current page cannot be greater than the total number of pages
   def current_page

--- a/app/views/archived/petitions/index.json.jbuilder
+++ b/app/views/archived/petitions/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.links do
   json.self request.url
-  json.merge! ApiPaginationLinksPresenter.new(@petitions).serialize
+  json.merge! ApiPaginationLinksPresenter.new(@petitions, params).serialize
 end
 
 json.data @petitions do |petition|

--- a/app/views/petitions/index.json.jbuilder
+++ b/app/views/petitions/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.links do
   json.self request.url
-  json.merge! ApiPaginationLinksPresenter.new(@petitions).serialize
+  json.merge! ApiPaginationLinksPresenter.new(@petitions, params).serialize
 end
 
 json.data @petitions do |petition|

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ApplicationController, type: :controller do
   controller do
     before_action :do_not_cache
+    before_action :set_cors_headers, if: :json_request?
 
     def index
       render text: 'OK'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,10 +30,6 @@ FactoryGirl.define do
       response "Petition response"
     end
 
-    trait :response_summary do
-      response_summary "Petition summary"
-    end
-
     trait :open do
       state "open"
       signature_count 100

--- a/spec/models/archived_petition_spec.rb
+++ b/spec/models/archived_petition_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe ArchivedPetition, type: :model do
 
   describe ".search" do
     let!(:petition_1) do
-      FactoryGirl.create(:archived_petition, :closed, title: "Wombles are great", created_at: 1.year.ago)
+      FactoryGirl.create(:archived_petition, :closed, title: "Wombles are great", created_at: 1.year.ago, signature_count: 100)
     end
 
     let!(:petition_2) do
-      FactoryGirl.create(:archived_petition, :closed, description: "The Wombles of Wimbledon", created_at: 2.years.ago)
+      FactoryGirl.create(:archived_petition, :closed, description: "The Wombles of Wimbledon", created_at: 2.years.ago, signature_count: 200)
     end
 
     it "searches based upon title" do
@@ -20,8 +20,19 @@ RSpec.describe ArchivedPetition, type: :model do
       expect(ArchivedPetition.search(q: "Wombles")).to include(petition_2)
     end
 
-    it "sorts the results by the created_at timestamp" do
+    it "sorts the results by the highest number of signatures" do
       expect(ArchivedPetition.search(q: "Petition").to_a).to eq([petition_2, petition_1])
+    end
+  end
+
+  describe ".by_created_at" do
+    let!(:petition_1) { FactoryGirl.create(:archived_petition, created_at: 3.years.ago) }
+    let!(:petition_2) { FactoryGirl.create(:archived_petition, created_at: 1.year.ago) }
+    let!(:petition_3) { FactoryGirl.create(:archived_petition, created_at: 2.years.ago) }
+    let(:petitions) { [petition_1, petition_3, petition_2] }
+
+    it 'returns archived petitions ordered by the created_at timestamp' do
+      expect(ArchivedPetition.by_created_at).to eq(petitions)
     end
   end
 

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -12,9 +12,20 @@ RSpec.describe 'API request to show an archived petition', type: :request, show_
   let(:petition) { FactoryGirl.create :archived_petition }
   let(:attributes) { json["data"]["attributes"] }
 
+  let(:access_control_allow_origin) { response.headers['Access-Control-Allow-Origin'] }
+  let(:access_control_allow_methods) { response.headers['Access-Control-Allow-Methods'] }
+  let(:access_control_allow_headers) { response.headers['Access-Control-Allow-Headers'] }
+
   describe "format" do
     it "responds to JSON" do
       make_successful_request petition
+    end
+
+    it "sets CORS headers" do
+      get archived_petition_url(petition, format: 'json')
+      expect(access_control_allow_origin).to eq('*')
+      expect(access_control_allow_methods).to eq('GET')
+      expect(access_control_allow_headers).to eq('Origin, X-Requested-With, Content-Type, Accept')
     end
 
     it "does not respond to XML" do

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+require_relative 'api_request_helpers'
+
+RSpec.describe 'API request to show an archived petition', type: :request, show_exceptions: true do
+  include ApiRequestHelpers
+
+  def make_successful_request(petition, params = {})
+    get archived_petition_url(petition, {format: 'json'}.merge(params))
+    expect(response).to be_success
+  end
+
+  let(:petition) { FactoryGirl.create :archived_petition }
+  let(:attributes) { json["data"]["attributes"] }
+
+  describe "format" do
+    it "responds to JSON" do
+      make_successful_request petition
+    end
+
+    it "does not respond to XML" do
+      get archived_petition_url(petition, format: 'xml')
+      expect(response.status).to eq(406)
+    end
+  end
+
+  describe "links" do
+    it "returns a link to itself" do
+      make_successful_request petition
+
+      expect(json["links"]).to include({"self" => archived_petition_url(petition, format: 'json')})
+    end
+  end
+
+  describe "data" do
+    it "returns the petition with the expected fields" do
+      make_successful_request petition
+
+      expect(json["data"]).to be_a(Hash)
+      expect(attributes["title"]).to eq(petition.title)
+      expect(attributes["description"]).to eq(petition.description)
+      expect(attributes["state"]).to eq(petition.state)
+      expect(attributes["signature_count"]).to eq(petition.signature_count)
+      expect(attributes["opened_at"]).to eq(timestampify petition.opened_at)
+      expect(attributes["closed_at"]).to eq(timestampify petition.closed_at)
+      expect(attributes["created_at"]).to eq(timestampify petition.created_at)
+      expect(attributes["updated_at"]).to eq(timestampify petition.updated_at)
+    end
+
+    it "includes the rejection section for rejected petitions" do
+      petition = FactoryGirl.create :archived_petition, :rejected
+
+      make_successful_request petition
+
+      expect(attributes["rejection"]).to be_a(Hash)
+      expect(attributes["rejection"]["details"]).to eq(petition.reason_for_rejection)
+    end
+
+    it "includes the government_response section for petitions with a government_response" do
+      petition = FactoryGirl.create :archived_petition, :response
+
+      make_successful_request petition
+
+      expect(attributes["government_response"]).to be_a(Hash)
+      expect(attributes["government_response"]["details"]).to eq(petition.response)
+    end
+  end
+end

--- a/spec/requests/archived_petitions_list_spec.rb
+++ b/spec/requests/archived_petitions_list_spec.rb
@@ -9,9 +9,20 @@ RSpec.describe 'API request to list archived petitions', type: :request, show_ex
     expect(response).to be_success
   end
 
+  let(:access_control_allow_origin) { response.headers['Access-Control-Allow-Origin'] }
+  let(:access_control_allow_methods) { response.headers['Access-Control-Allow-Methods'] }
+  let(:access_control_allow_headers) { response.headers['Access-Control-Allow-Headers'] }
+
   describe "format" do
     it "responds to JSON" do
       make_successful_request
+    end
+
+    it "sets CORS headers" do
+      get archived_petitions_url(format: 'json')
+      expect(access_control_allow_origin).to eq('*')
+      expect(access_control_allow_methods).to eq('GET')
+      expect(access_control_allow_headers).to eq('Origin, X-Requested-With, Content-Type, Accept')
     end
 
     it "does not respond to XML" do

--- a/spec/requests/archived_petitions_list_spec.rb
+++ b/spec/requests/archived_petitions_list_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+require_relative 'api_request_helpers'
+
+RSpec.describe 'API request to list archived petitions', type: :request, show_exceptions: true do
+  include ApiRequestHelpers
+
+  def make_successful_request(params = {})
+    get archived_petitions_url({format: 'json'}.merge(params))
+    expect(response).to be_success
+  end
+
+  describe "format" do
+    it "responds to JSON" do
+      make_successful_request
+    end
+
+    it "does not respond to XML" do
+      get archived_petitions_url(format: 'xml')
+      expect(response.status).to eq(406)
+    end
+  end
+
+  describe "links" do
+    before do
+      FactoryGirl.create_list :archived_petition, 3
+    end
+
+    it "returns a link to itself" do
+      make_successful_request
+
+      expect(json["links"]).to include({"self" => archived_petitions_url(format: 'json')})
+    end
+
+    it "returns a link to the first page of results" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"first" => archived_petitions_url(count: 2, format: 'json')})
+    end
+
+    it "returns a link to the last page of results" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"last" => archived_petitions_url(count: 2, page: 2, format: 'json')})
+    end
+
+    it "returns a link to the next page of results if there is one" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"next" => archived_petitions_url(count: 2 ,page: 2, format: 'json')})
+    end
+
+    it "returns a link to the previous page of results if there is one" do
+      make_successful_request count: 2, page: 2
+
+      expect(json["links"]).to include({"prev" => archived_petitions_url(count: 2, format: 'json')})
+    end
+
+    it "returns no link to the previous page of results when on the first page of results" do
+      make_successful_request count: 2
+
+      expect(json["links"]).to include({"prev" => nil})
+    end
+
+    it "returns no link to the next page of results when on the last page of results" do
+      make_successful_request count: 2, page: 2
+
+      expect(json["links"]).to include({"next" => nil})
+    end
+
+    it "returns the last link == first link for empty results" do
+      make_successful_request count: 2, page: 2, state: 'rejected'
+
+      expect(json["links"]).to include({"last" => json["links"]["first"]})
+    end
+
+    it "returns previous page link == last link when paging off the end of the results" do
+      make_successful_request count: 2, page: 3, state: 'rejected'
+
+      expect(json["links"]).to include({"prev" => json["links"]["last"]})
+    end
+  end
+
+  describe "data" do
+    it "returns an empty response if no petitions are public" do
+      make_successful_request
+
+      expect(json["data"]).to be_empty
+    end
+
+    it "returns a list of serialized petitions in the expected order" do
+      petition_1 = FactoryGirl.create :archived_petition, signature_count: 100
+      petition_2 = FactoryGirl.create :archived_petition, signature_count: 300
+      petition_3 = FactoryGirl.create :archived_petition, signature_count: 200
+
+      make_successful_request
+
+      expect(json["data"].length).to eq(3)
+
+      expect(json["data"][0]["attributes"]["title"]).to eq(petition_2.title)
+      expect(json["data"][1]["attributes"]["title"]).to eq(petition_3.title)
+      expect(json["data"][2]["attributes"]["title"]).to eq(petition_1.title)
+    end
+
+    it "includes a link to each petitions details" do
+      petition = FactoryGirl.create :archived_petition
+
+      make_successful_request
+
+      expect(json["data"][0]["links"]).to be_a Hash
+      expect(json["data"][0]["links"]).to include("self" => archived_petition_url(petition, format: 'json'))
+    end
+
+    it "includes the rejection section for rejected petitions" do
+      petition = FactoryGirl.create :archived_petition, :rejected
+
+      make_successful_request
+
+      expect(json["data"][0]["attributes"]["rejection"]["details"]).to eq(petition.reason_for_rejection)
+    end
+
+    it "includes the government_response section for petitions with a government_response" do
+      petition = FactoryGirl.create :archived_petition, :response
+
+      make_successful_request
+
+      expect(json["data"][0]["attributes"]["government_response"]["details"]).to eq(petition.response)
+    end
+  end
+end

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -10,10 +10,20 @@ RSpec.describe 'API request to show a petition', type: :request, show_exceptions
   end
 
   let(:petition) { FactoryGirl.create :open_petition }
+  let(:access_control_allow_origin) { response.headers['Access-Control-Allow-Origin'] }
+  let(:access_control_allow_methods) { response.headers['Access-Control-Allow-Methods'] }
+  let(:access_control_allow_headers) { response.headers['Access-Control-Allow-Headers'] }
 
   describe "format" do
     it "responds to JSON" do
       make_successful_request petition
+    end
+
+    it "sets CORS headers" do
+      get petition_url(petition, format: 'json')
+      expect(access_control_allow_origin).to eq('*')
+      expect(access_control_allow_methods).to eq('GET')
+      expect(access_control_allow_headers).to eq('Origin, X-Requested-With, Content-Type, Accept')
     end
 
     it "does not respond to XML" do
@@ -81,4 +91,3 @@ RSpec.describe 'API request to show a petition', type: :request, show_exceptions
     end
   end
 end
-

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -9,9 +9,20 @@ RSpec.describe 'API request to list petitions', type: :request, show_exceptions:
     expect(response).to be_success
   end
 
+  let(:access_control_allow_origin) { response.headers['Access-Control-Allow-Origin'] }
+  let(:access_control_allow_methods) { response.headers['Access-Control-Allow-Methods'] }
+  let(:access_control_allow_headers) { response.headers['Access-Control-Allow-Headers'] }
+
   describe "format" do
     it "responds to JSON" do
       make_successful_request
+    end
+
+    it "sets CORS headers" do
+      get petitions_url(format: 'json')
+      expect(access_control_allow_origin).to eq('*')
+      expect(access_control_allow_methods).to eq('GET')
+      expect(access_control_allow_headers).to eq('Origin, X-Requested-With, Content-Type, Accept')
     end
 
     it "does not respond to XML" do
@@ -153,4 +164,3 @@ RSpec.describe 'API request to list petitions', type: :request, show_exceptions:
     end
   end
 end
-


### PR DESCRIPTION
Rather than globally allowing JSON requests from anywhere restrict them to the actions that we explicitly need. This ensures that we don't inadvertently allow requests for content that we don't mean to. The only affect url in this commit is for `/manifest.json`.