### PR TITLE
Add a 403 error page

### DIFF
--- a/app/views/errors/403.html.erb
+++ b/app/views/errors/403.html.erb
@@ -1,0 +1,13 @@
+<% content_for(:title) do %>
+<title>Sorry, you are not allow to access this page (error 403)</title>
+<% end %>
+
+<h1>
+  <span class="heading-secondary">Error 403</span>
+  Sorry, you are not allow to access this page
+</h1>
+<p>If you typed a web address or clicked a link, check it was correct</p>
+<p>
+  You can <a href="/" title="Petitions home">go back to the homepage</a> or
+  <a href="/petitions" title="All petitions">search for a petition</a>
+</p>

--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -25,7 +25,7 @@ namespace :errors do
       end
     end
 
-    %w[400 404 406 422 500 503].each do |status|
+    %w[400 403 404 406 422 500 503].each do |status|
       context = context_class.new('app/views', { status: status }, controller_class.new)
       File.open(Rails.public_path.join("#{status}.html"), 'wb') do |f|
         f.write context.render(template: "errors/#{status}", layout: 'errors/layout')


### PR DESCRIPTION
If someone types a link directly to an directory like `/assets/` they will receive an ugly 403 page from nginx so we should provide a nicer experience for them.