### PR TITLE
Anonymise signatures after 12 months

### DIFF
--- a/app/jobs/anonymise_signatures_job.rb
+++ b/app/jobs/anonymise_signatures_job.rb
@@ -1,0 +1,7 @@
+class AnonymiseSignaturesJob < ActiveJob::Base
+  queue_as :high_priority
+
+  def perform(time)
+    Signature.anonymise!(time.in_time_zone)
+  end
+end

--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -4,6 +4,10 @@ require_dependency 'constituency/api_query'
 class Constituency < ActiveRecord::Base
   MP_URL = "http://www.parliament.uk/biographies/commons"
 
+  MAPIT_HOST = "https://mapit.mysociety.org"
+  MAPIT_AREA_URL = "/area/%{ons_code}"
+  MAPIT_POSTCODE_URL = "https://mapit.mysociety.org/area/%{area_id}/example_postcode"
+
   has_many :signatures, primary_key: :external_id
   has_many :petitions, through: :signatures
 
@@ -45,5 +49,70 @@ class Constituency < ActiveRecord::Base
 
   def mp_url
     "#{MP_URL}/#{mp_name.parameterize}/#{mp_id}"
+  end
+
+  def example_postcode
+    super || fetch_and_save_example_postcode
+  end
+
+  def reset_example_postcode
+    update(example_postcode: nil)
+  end
+
+  private
+
+  def fetch_and_save_example_postcode
+    area = fetch_area(ons_code)
+
+    if area
+      postcode = fetch_example_postcode(area["id"])
+    else
+      postcode = nil
+    end
+
+    if postcode
+      update(example_postcode: postcode)
+    end
+
+    postcode
+
+  rescue Faraday::Error => e
+    Appsignal.send_exception(e) if defined?(Appsignal)
+    return nil
+  end
+
+  def faraday
+    @faraday ||= Faraday.new(MAPIT_HOST) do |f|
+      f.response :follow_redirects
+      f.response :raise_error
+      f.adapter  :net_http_persistent
+    end
+  end
+
+  def get(path)
+    faraday.get(path) do |request|
+      request.options[:timeout] = 5
+      request.options[:open_timeout] = 5
+    end
+  end
+
+  def fetch_area(ons_code)
+    response = get(MAPIT_AREA_URL % { ons_code: ons_code })
+
+    if response.success?
+      JSON.load(response.body)
+    else
+      nil
+    end
+  end
+
+  def fetch_example_postcode(area_id)
+    response = get(MAPIT_POSTCODE_URL % { area_id: area_id })
+
+    if response.success?
+      PostcodeSanitizer.call(JSON.load(response.body))
+    else
+      nil
+    end
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -40,3 +40,7 @@ end
 every :day, at: '7.15am' do
   rake "epets:petitions:debated", output: nil
 end
+
+every :day, at: '7.30am' do
+  rake "epets:signatures:anonymise", output: nil
+end

--- a/db/migrate/20160811123057_add_anonymised_at_to_signatures.rb
+++ b/db/migrate/20160811123057_add_anonymised_at_to_signatures.rb
@@ -1,0 +1,6 @@
+class AddAnonymisedAtToSignatures < ActiveRecord::Migration
+  def change
+    add_column :signatures, :anonymised_at, :datetime
+    add_index :signatures, [:anonymised_at, :petition_id]
+  end
+end

--- a/db/migrate/20160811143039_add_example_postcode_to_constituencies.rb
+++ b/db/migrate/20160811143039_add_example_postcode_to_constituencies.rb
@@ -1,0 +1,5 @@
+class AddExamplePostcodeToConstituencies < ActiveRecord::Migration
+  def change
+    add_column :constituencies, :example_postcode, :string, limit: 30
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,8 @@ CREATE TABLE constituencies (
     mp_name character varying(100),
     mp_date date,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    example_postcode character varying(30)
 );
 
 
@@ -733,7 +734,8 @@ CREATE TABLE signatures (
     government_response_email_at timestamp without time zone,
     debate_scheduled_email_at timestamp without time zone,
     debate_outcome_email_at timestamp without time zone,
-    petition_email_at timestamp without time zone
+    petition_email_at timestamp without time zone,
+    anonymised_at timestamp without time zone
 );
 
 
@@ -1491,6 +1493,13 @@ CREATE UNIQUE INDEX index_rejections_on_petition_id ON rejections USING btree (p
 
 
 --
+-- Name: index_signatures_on_anonymised_at_and_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_anonymised_at_and_petition_id ON signatures USING btree (anonymised_at, petition_id);
+
+
+--
 -- Name: index_signatures_on_constituency_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1845,6 +1854,10 @@ INSERT INTO schema_migrations (version) VALUES ('20160713130452');
 INSERT INTO schema_migrations (version) VALUES ('20160715092819');
 
 INSERT INTO schema_migrations (version) VALUES ('20160716164929');
+
+INSERT INTO schema_migrations (version) VALUES ('20160811123057');
+
+INSERT INTO schema_migrations (version) VALUES ('20160811143039');
 
 INSERT INTO schema_migrations (version) VALUES ('20160819062044');
 

--- a/lib/tasks/signatures.rake
+++ b/lib/tasks/signatures.rake
@@ -1,0 +1,11 @@
+namespace :epets do
+  namespace :signatures do
+    desc "Add a task to the queue to close petitions at midnight"
+    task :anonymise => :environment do
+      Task.run("epets:signatures:anonymise") do
+        time = Date.tomorrow.beginning_of_day
+        AnonymiseSignaturesJob.set(wait_until: time).perform_later(time.iso8601)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -279,16 +279,18 @@ FactoryGirl.define do
       mp_id "4378"
       mp_name "Colleen Fletcher MP"
       mp_date "2015-05-07"
+      example_postcode "CV21PH"
     end
 
     trait(:bethnal_green_and_bow) do
       name "Bethnal Green and Bow"
       slug "bethnal-green-and-bow"
       external_id "3320"
-      ons_code "E14000649"
+      ons_code "E14000555"
       mp_id "4138"
       mp_name "Rushanara Ali MP"
       mp_date "2015-05-07"
+      example_postcode "E27AX"
     end
 
     england

--- a/spec/jobs/anonymise_signatures_job_spec.rb
+++ b/spec/jobs/anonymise_signatures_job_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe AnonymiseSignaturesJob, type: :job do
+  shared_examples_for "anonymisation" do
+    let(:timestamp) { Date.tomorrow.beginning_of_day }
+    let(:now) { "2016-08-11T07:30:00Z".in_time_zone }
+
+    context "created over 12 months ago" do
+      let!(:signature) {
+        FactoryGirl.create(signature_type, created_at: 13.months.ago(now))
+      }
+
+      it "anonymises the signature" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later(timestamp.iso8601)
+          }
+        }.to change {
+          signature.reload.anonymised_at
+        }.from(nil).to(timestamp)
+      end
+    end
+
+    context "less than 12 months ago" do
+      let!(:signature) {
+        FactoryGirl.create(signature_type, created_at: 11.months.ago(now))
+      }
+
+      it "doesn't anonymise the signature" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later(timestamp.iso8601)
+          }
+        }.not_to change {
+          signature.reload.anonymised_at
+        }
+      end
+    end
+  end
+
+  context "with a pending signature" do
+    let(:signature_type) { :pending_signature }
+
+    it_behaves_like "anonymisation"
+  end
+
+  context "when a validated signature" do
+    let(:signature_type) { :validated_signature }
+
+    it_behaves_like "anonymisation"
+  end
+end


### PR DESCRIPTION
Rather than just deleting the signatures we set them to generic values based on the id of the record and an example postcode for the constituency so that we can still recalculate counts and journals should we wish to retro-fit features onto old petitions that have closed such as signatures by hour.
