### PR TITLE
Fix timestamp string formatting

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -22,7 +22,7 @@ class PackageBuilder
     @revision    = %x[git rev-parse #{treeish}].strip
     @tmpdir      = Dir.mktmpdir
     @timestamp   = Time.now.getutc
-    @release     = @timestamp.strftime('%Y%m%d%H%I%S')
+    @release     = @timestamp.strftime('%Y%m%d%H%M%S')
   end
 
   def build!


### PR DESCRIPTION
The correct placeholder for minutes is `%M` for strftime not `%I` - probably a PHP-ism from `date('H:i:s')`.