### PR TITLE
Fix appsignal and delayed job integration

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -34,7 +34,7 @@ module Delayed
           ::ActiveRecord::Base.establish_connection
 
           # Let AppSignal know that a worker process has been forked
-          ::Appsignal.agent.forked! if defined?(::Appsignal) && ::Appsignal.config.active?
+          ::Appsignal.forked if defined?(::Appsignal) && ::Appsignal.config.active?
         end
       end
     end


### PR DESCRIPTION
A reorganization of the appsignal code suggests that `Appsignal.agent` is no
longer available so we can't call `.forked!` on it.  We can instead call
`Appsignal.forked` to achieve the same thing.

`Appsignal.agent` stopped being set in v1.0.0 and we were using v0.11.17 until
then (we upgraded in #460).