### PR TITLE
Redirect to home page on invalid urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,8 @@ class ApplicationController < ActionController::Base
     URI.parse(request.original_url).tap do |uri|
       uri.path = File.join(File.dirname(request.path), File.basename(request.path, '.*'))
     end.to_s
+  rescue URI::InvalidURIError => e
+    home_url
   end
 
   def redirect_to_url_without_format

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -100,4 +100,18 @@ RSpec.describe ApplicationController, type: :controller do
       expect(controller.class.helpers).to respond_to :public_petition_facets
     end
   end
+
+  context "when the url has an invalid format" do
+    let(:exception) { URI::InvalidURIError.new }
+
+    before do
+      allow(request).to receive(:format).and_return(nil)
+      allow(request).to receive(:original_url).and_return("https://petition.parliament.uk/petitions.json]")
+    end
+
+    it "redirects to the home page" do
+      get :index
+      expect(response).to redirect_to("https://petition.parliament.uk/")
+    end
+  end
 end


### PR DESCRIPTION
Every now and again we get invalid urls which causes the check for unknown formats to blow up. In these circumstances we should catch the invalid URI error and redirect to the home page.