### PR TITLE
Expose fraudulent domains on petition admin page

### DIFF
--- a/app/assets/stylesheets/petitions/admin/_tables.scss
+++ b/app/assets/stylesheets/petitions/admin/_tables.scss
@@ -10,3 +10,17 @@
 .action {
   text-align: right;
 }
+
+.fraudulent-domains {
+  width: 100%;
+
+  td {
+    border-bottom: none;
+    padding: 3px 0px 3px 0px;
+    text-align: right;
+  }
+
+  td:first-child {
+    text-align: left;
+  }
+}

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -598,4 +598,12 @@ class Petition < ActiveRecord::Base
       'awaiting'
     end
   end
+
+  def fraudulent_domains
+    @fraudulent_domains ||= signatures.fraudulent_domains
+  end
+
+  def fraudulent_domains?
+    !fraudulent_domains.empty?
+  end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -78,6 +78,14 @@ class Signature < ActiveRecord::Base
     raise ArgumentError, "Unknown petition email timestamp: #{timestamp.inspect}"
   end
 
+  def self.fraudulent_domains
+    where(state: FRAUDULENT_STATE).
+    select("SUBSTRING(email FROM POSITION('@' IN email) + 1) AS domain").
+    group("SUBSTRING(email FROM POSITION('@' IN email) + 1)").
+    order("COUNT(*) DESC").
+    count(:all)
+  end
+
   scope :in_days, ->(number_of_days) { validated.where("updated_at > ?", number_of_days.day.ago) }
   scope :matching, ->(signature) { where(email: signature.email,
                                          name: signature.name,

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -27,5 +27,18 @@
   <dt>ID</dt>
   <dd><%= @petition.id %></dd>
 
+  <% if @petition.fraudulent_domains? %>
+    <dt>Fraudulent domains</dt>
+    <dd>
+      <table class="fraudulent-domains">
+        <% @petition.fraudulent_domains.each do |domain, count| %>
+          <tr>
+            <td><%= domain %></td>
+            <td><%= number_with_delimiter(count) %></td>
+          </tr>
+        <% end %>
+      </table>
+    </dd>
+  <% end %>
 <% end %>
 </dl>

--- a/db/migrate/20160819062044_add_domain_index_to_signatures.rb
+++ b/db/migrate/20160819062044_add_domain_index_to_signatures.rb
@@ -1,0 +1,24 @@
+class AddDomainIndexToSignatures < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:signatures, :domain)
+      execute <<-SQL
+        CREATE INDEX CONCURRENTLY index_signatures_on_domain
+        ON signatures USING btree (SUBSTRING(email FROM POSITION('@' IN email) + 1));
+      SQL
+    end
+  end
+
+  def down
+    if index_exists?(:signatures, :domain)
+      remove_index :signatures, :domain
+    end
+  end
+
+  private
+
+  def index_exists?(table, names)
+    select_value("SELECT to_regclass('index_#{table}_on_#{Array(names).join('_and_')}')")
+  end
+end

--- a/db/migrate/20160819062058_add_state_index_to_signatures.rb
+++ b/db/migrate/20160819062058_add_state_index_to_signatures.rb
@@ -1,0 +1,15 @@
+class AddStateIndexToSignatures < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:signatures, [:state, :petition_id])
+      add_index :signatures, [:state, :petition_id], algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:signatures, [:state, :petition_id])
+      remove_index :signatures, [:state, :petition_id]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1503,6 +1503,13 @@ CREATE INDEX index_signatures_on_created_at_and_ip_address_and_petition_id ON si
 
 
 --
+-- Name: index_signatures_on_domain; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_domain ON signatures USING btree ("substring"((email)::text, ("position"((email)::text, '@'::text) + 1)));
+
+
+--
 -- Name: index_signatures_on_email_and_petition_id_and_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1535,6 +1542,13 @@ CREATE INDEX index_signatures_on_petition_id ON signatures USING btree (petition
 --
 
 CREATE INDEX index_signatures_on_petition_id_and_location_code ON signatures USING btree (petition_id, location_code);
+
+
+--
+-- Name: index_signatures_on_state_and_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_state_and_petition_id ON signatures USING btree (state, petition_id);
 
 
 --
@@ -1822,4 +1836,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160713130452');
 INSERT INTO schema_migrations (version) VALUES ('20160715092819');
 
 INSERT INTO schema_migrations (version) VALUES ('20160716164929');
+
+INSERT INTO schema_migrations (version) VALUES ('20160819062044');
+
+INSERT INTO schema_migrations (version) VALUES ('20160819062058');
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -443,6 +443,23 @@ RSpec.describe Signature, type: :model do
     end
   end
 
+  describe ".fraudulent_domains" do
+    subject do
+      described_class.fraudulent_domains
+    end
+
+    before do
+      FactoryGirl.create(:fraudulent_signature, email: "alice@foo.com")
+      FactoryGirl.create(:fraudulent_signature, email: "bob@bar.com")
+      FactoryGirl.create(:fraudulent_signature, email: "charlie@foo.com")
+    end
+
+    it "returns a hash of domains and counts in descending order" do
+      expect(subject).to be_an_instance_of(Hash)
+      expect(subject.to_a).to eq([["foo.com", 2], ["bar.com", 1]])
+    end
+  end
+
   describe "#number" do
     let(:attributes) { FactoryGirl.attributes_for(:petition) }
     let(:creator) { FactoryGirl.create(:pending_signature) }


### PR DESCRIPTION
List the domains marked as fraudulent on the petition admin page so that the moderation team can see whether there's been significant attempts at fraud on the petition.

The functional index for the domain ensures that the GROUP BY and COUNT are performant even when there's a large number of signatures.

Previously we've eschewed an index on state since it didn't provide much specificity but that has changed with the addition of the new invalidated and fraudulent states.