### PR TITLE
Add blacklisting of domains and ip addresses

### DIFF
--- a/app/controllers/admin/rate_limits_controller.rb
+++ b/app/controllers/admin/rate_limits_controller.rb
@@ -25,7 +25,7 @@ class Admin::RateLimitsController < Admin::AdminController
   end
 
   def rate_limit_attributes
-    %i[burst_rate burst_period sustained_rate sustained_period domain_whitelist ip_whitelist]
+    %i[burst_rate burst_period sustained_rate sustained_period domain_whitelist ip_whitelist domain_blacklist ip_blacklist]
   end
 
   def find_rate_limit

--- a/app/views/admin/rate_limits/edit.html.erb
+++ b/app/views/admin/rate_limits/edit.html.erb
@@ -3,25 +3,43 @@
 <div class="grid-row">
   <div class="column-two-thirds extra-gutter">
     <p>
-      <% if params[:tab] == "domains" %>
+      <% if params[:tab] == "domain_whitelist" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
         Domain Whitelist |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ips') %>
-      <% elsif params[:tab] == "ips" %>
+        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
+        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+      <% elsif params[:tab] == "domain_blacklist" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domains') %> |
-        IP Whitelist
+        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
+        Domain Blacklist |
+        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+      <% elsif params[:tab] == "ip_whitelist" %>
+        <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
+        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
+        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
+        IP Whitelist |
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+      <% elsif params[:tab] == "ip_blacklist" %>
+        <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
+        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
+        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
+        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
+        IP Blacklist
       <% else %>
         Rate Limits |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domains') %> |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ips') %>
+        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
+        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
+        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
       <% end %>
     </p>
 
     <%= form_for @rate_limit, url: admin_rate_limits_path do |form| %>
 
-      <% if params[:tab] == "domains" %>
-        <%= hidden_field_tag :tab, "domains" %>
+      <% if params[:tab] == "domain_whitelist" %>
+        <%= hidden_field_tag :tab, "domain_whitelist" %>
 
         <%= form_row for: [form.object, :domain_whitelist] do %>
           <%= error_messages_for_field @rate_limit, :domain_whitelist %>
@@ -29,12 +47,30 @@
           <p><small>use *.example.com or **.example.com for wildcard matching</small><p>
         <% end %>
 
-      <% elsif params[:tab] == "ips" %>
-        <%= hidden_field_tag :tab, "ips" %>
+      <% elsif params[:tab] == "domain_blacklist" %>
+        <%= hidden_field_tag :tab, "domain_blacklist" %>
+
+        <%= form_row for: [form.object, :domain_blacklist] do %>
+          <%= error_messages_for_field @rate_limit, :domain_blacklist %>
+          <%= form.text_area :domain_blacklist, tabindex: increment, rows: 15, class: 'form-control' %>
+          <p><small>use *.example.com or **.example.com for wildcard matching</small><p>
+        <% end %>
+
+      <% elsif params[:tab] == "ip_whitelist" %>
+        <%= hidden_field_tag :tab, "ip_whitelist" %>
 
         <%= form_row for: [form.object, :ip_whitelist] do %>
           <%= error_messages_for_field @rate_limit, :ip_whitelist %>
           <%= form.text_area :ip_whitelist, tabindex: increment, rows: 15, class: 'form-control' %>
+          <p><small>use CIDR addressing to match ranges, e.g. 192.168.0.0/24</small><p>
+        <% end %>
+
+      <% elsif params[:tab] == "ip_blacklist" %>
+        <%= hidden_field_tag :tab, "ip_blacklist" %>
+
+        <%= form_row for: [form.object, :ip_blacklist] do %>
+          <%= error_messages_for_field @rate_limit, :ip_blacklist %>
+          <%= form.text_area :ip_blacklist, tabindex: increment, rows: 15, class: 'form-control' %>
           <p><small>use CIDR addressing to match ranges, e.g. 192.168.0.0/24</small><p>
         <% end %>
 

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -49,6 +49,8 @@ en-GB:
           attributes:
             ip_whitelist:
               invalid: "IP whitelist is invalid"
+            ip_blacklist:
+              invalid: "IP blacklist is invalid"
 
   errors:
     attributes:

--- a/db/migrate/20160820132056_add_blacklist_to_rate_limits.rb
+++ b/db/migrate/20160820132056_add_blacklist_to_rate_limits.rb
@@ -1,0 +1,6 @@
+class AddBlacklistToRateLimits < ActiveRecord::Migration
+  def change
+    add_column :rate_limits, :domain_blacklist, :string, null: false, limit: 50000, default: ""
+    add_column :rate_limits, :ip_blacklist, :string, null: false, limit: 50000, default: ""
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -639,7 +639,9 @@ CREATE TABLE rate_limits (
     domain_whitelist character varying(10000) DEFAULT ''::character varying NOT NULL,
     ip_whitelist character varying(10000) DEFAULT ''::character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    domain_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL,
+    ip_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -1840,4 +1842,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160716164929');
 INSERT INTO schema_migrations (version) VALUES ('20160819062044');
 
 INSERT INTO schema_migrations (version) VALUES ('20160819062058');
+
+INSERT INTO schema_migrations (version) VALUES ('20160820132056');
 


### PR DESCRIPTION
Rather than letting a few fraudulent emails through every time the rate limit resets, add the ability to permanently blacklist IPs and domains that we observe as being bad.