### PR TITLE
Add the option to geo-block IP addresses

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,3 +7,4 @@ MODERATE_HOST=localhost
 SITE_TITLE="Petition parliament (Development)"
 MEMCACHE_SERVERS=localhost:11211
 APPSIGNAL_APP_NAME=epetitions-dev
+GEOIP_DB_PATH=/usr/local/var/GeoIP/GeoLite2-Country.mmdb

--- a/.env.test
+++ b/.env.test
@@ -7,3 +7,4 @@ MODERATE_HOST=moderate.petition.parliament.uk
 SITE_TITLE="Petition parliament (Test)"
 MEMCACHE_SERVERS=localhost:11211
 APPSIGNAL_APP_NAME=epetitions-test
+GEOIP_DB_PATH=/path/to/GeoLite2-Country.mmdb

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'lograge'
 gem 'logstash-logger'
 gem 'jbuilder'
 gem 'paperclip'
+gem 'maxminddb'
 
 # Two AWS libraries:
 #   - aws-sdk v2 for CodeDeploy, which neither Fog nor aws-sdk v1 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    maxminddb (0.1.11)
     method_source (0.8.2)
     mime-types (2.99.2)
     mimemagic (0.3.0)
@@ -333,6 +334,7 @@ DEPENDENCIES
   launchy
   lograge
   logstash-logger
+  maxminddb
   net-http-persistent
   nokogiri
   paperclip

--- a/app/controllers/admin/rate_limits_controller.rb
+++ b/app/controllers/admin/rate_limits_controller.rb
@@ -25,7 +25,11 @@ class Admin::RateLimitsController < Admin::AdminController
   end
 
   def rate_limit_attributes
-    %i[burst_rate burst_period sustained_rate sustained_period domain_whitelist ip_whitelist domain_blacklist ip_blacklist]
+    %i[
+      burst_rate burst_period sustained_rate sustained_period
+      domain_whitelist ip_whitelist domain_blacklist ip_blacklist
+      geoblocking_enabled countries
+    ]
   end
 
   def find_rate_limit

--- a/app/views/admin/rate_limits/edit.html.erb
+++ b/app/views/admin/rate_limits/edit.html.erb
@@ -8,31 +8,43 @@
         Domain Whitelist |
         <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
         <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
       <% elsif params[:tab] == "domain_blacklist" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
         <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
         Domain Blacklist |
         <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
       <% elsif params[:tab] == "ip_whitelist" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
         <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
         <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
         IP Whitelist |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
       <% elsif params[:tab] == "ip_blacklist" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
         <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
         <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
         <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        IP Blacklist
+        IP Blacklist |
+        <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
+      <% elsif params[:tab] == "countries" %>
+        <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
+        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
+        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
+        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        Countries
       <% else %>
         Rate Limits |
         <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
         <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
         <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %>
+        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
       <% end %>
     </p>
 
@@ -72,6 +84,26 @@
           <%= error_messages_for_field @rate_limit, :ip_blacklist %>
           <%= form.text_area :ip_blacklist, tabindex: increment, rows: 15, class: 'form-control' %>
           <p><small>use CIDR addressing to match ranges, e.g. 192.168.0.0/24</small><p>
+        <% end %>
+
+      <% elsif params[:tab] == "countries" %>
+        <%= hidden_field_tag :tab, "countries" %>
+
+        <%= form_row for: [form.object, :countries] do %>
+          <%= error_messages_for_field @rate_limit, :countries %>
+          <%= form.text_area :countries, tabindex: increment, rows: 8, class: 'form-control' %>
+          <p><small>Add countries that are allowed to sign petitions, e.g. United Kingdom</small><p>
+        <% end %>
+
+        <%= form_row for: [form.object, :geoblocking_enabled], class: 'inline' do %>
+          <%= form.label :geoblocking_enabled, "Enable geoblocking of signatures?", class: 'form-label' %>
+          <%= error_messages_for_field @rate_limit, :geoblocking_enabled %>
+          <%= form.label :geoblocking_enabled_true, nil, class: 'block-label' do %>
+            <%= form.radio_button :geoblocking_enabled, true %> Yes
+          <% end %>
+          <%= form.label :geoblocking_enabled_false, nil, class: 'block-label' do %>
+            <%= form.radio_button :geoblocking_enabled, false %> No
+          <% end %>
         <% end %>
 
       <% else %>

--- a/db/migrate/20160820162023_add_geoblocking_to_rate_limits.rb
+++ b/db/migrate/20160820162023_add_geoblocking_to_rate_limits.rb
@@ -1,0 +1,5 @@
+class AddGeoblockingToRateLimits < ActiveRecord::Migration
+  def change
+    add_column :rate_limits, :geoblocking_enabled, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20160820165029_add_countries_to_rate_limits.rb
+++ b/db/migrate/20160820165029_add_countries_to_rate_limits.rb
@@ -1,0 +1,5 @@
+class AddCountriesToRateLimits < ActiveRecord::Migration
+  def change
+    add_column :rate_limits, :countries, :string, limit: 2000, null: false, default: ""
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -641,7 +641,9 @@ CREATE TABLE rate_limits (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     domain_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL,
-    ip_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL
+    ip_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL,
+    geoblocking_enabled boolean DEFAULT false NOT NULL,
+    countries character varying(2000) DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -1851,6 +1853,10 @@ INSERT INTO schema_migrations (version) VALUES ('20160819062044');
 INSERT INTO schema_migrations (version) VALUES ('20160819062058');
 
 INSERT INTO schema_migrations (version) VALUES ('20160820132056');
+
+INSERT INTO schema_migrations (version) VALUES ('20160820162023');
+
+INSERT INTO schema_migrations (version) VALUES ('20160820165029');
 
 INSERT INTO schema_migrations (version) VALUES ('20160822064645');
 

--- a/features/admin/updating_rate_limits.feature
+++ b/features/admin/updating_rate_limits.feature
@@ -70,5 +70,14 @@ Feature: Sysadmin updates the rate limits
     And I press "Save"
     Then I should see "IP blacklist is invalid"
     When I fill in "rate_limit_ip_blacklist" with "127.0.0.1/32"
+
+  Scenario: Sysadmin updates the countries
+    When I am logged in as a sysadmin
+    And I am on the admin home page
+    And I follow "Rate Limits"
+    Then I should see "Edit Rate Limits"
+    When I follow "Countries"
+    Then I should see "Add countries that are allowed to sign petitions, e.g. United Kingdom"
+    When I fill in "rate_limit_countries" with "United Kingdom"
     And I press "Save"
     Then I should see "Rate limits updated successfully"

--- a/spec/controllers/admin/rate_limits_controller_spec.rb
+++ b/spec/controllers/admin/rate_limits_controller_spec.rb
@@ -99,9 +99,51 @@ RSpec.describe Admin::RateLimitsController, type: :controller, admin: true do
         end
       end
 
+      context "when submitting just the domain blacklist" do
+        let :params do
+          { domain_blacklist: "example.com" }
+        end
+
+        it "redirects to the edit page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/rate-limits/edit")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Rate limits updated successfully")
+        end
+      end
+
       context "when submitting just the ip whitelist" do
         let :params do
-          { domain_whitelist: "127.0.0.1" }
+          { ip_whitelist: "127.0.0.1" }
+        end
+
+        it "redirects to the edit page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/rate-limits/edit")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Rate limits updated successfully")
+        end
+      end
+
+      context "when submitting just the ip blacklist" do
+        let :params do
+          { ip_blacklist: "127.0.0.1" }
+        end
+
+        it "redirects to the edit page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/rate-limits/edit")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Rate limits updated successfully")
+        end
+      end
+
+      context "when submitting just the countries list" do
+        let :params do
+          { countries: "127.0.0.1", geoblocking_enabled: "true" }
         end
 
         it "redirects to the edit page" do


### PR DESCRIPTION
If there is a persistent attack using botnets from abroad we want to have the option to block ip addresses from outside the UK.