### PR TITLE
Don't count invalidated signatures in trending query

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -245,6 +245,7 @@ class Petition < ActiveRecord::Base
       where('petitions.state = ?', OPEN_STATE).
       where('petitions.last_signed_at > ?', since).
       where('signatures.validated_at > ?', since).
+      where('signatures.invalidated_at IS NULL').
       group('petitions.id').order('signature_count_in_period DESC').
       limit(limit)
     end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe Petition, type: :model do
 
         expect(Petition.trending.to_a).not_to include(petition)
       end
+
+      it "excludes signatures that have been invalidated" do
+        petition = Petition.trending.first
+        signature = FactoryGirl.create(:validated_signature, petition: petition)
+
+        expect(Petition.trending.first.signature_count_in_period).to eq(12)
+
+        signature.invalidate!
+        expect(Petition.trending.first.signature_count_in_period).to eq(11)
+      end
     end
 
     context "threshold" do


### PR DESCRIPTION
Signatures that have been invalidated don't clear the validated_at column for reasons of maintaining useful information in tracking down any problems that may occur. However this means that the trending query must exclude them so that it is accurate.

The reason that the check is `invalidated_at IS NULL` rather than the more obvious `state = 'validated'` is for reasons of performance - there are a lot of validated rows so the index isn't much help in selecting rows whereas the invalidated_at check is a filter on the already reduced rows of the validated_at index scan.