### PR TITLE
Clear threshold timestamps when decrementing

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -358,6 +358,15 @@ class Petition < ActiveRecord::Base
   def decrement_signature_count!(time = Time.current)
     updates = []
 
+    if below_threshold_for_debate?
+      updates << "debate_threshold_reached_at = NULL"
+      updates << "debate_state = 'pending'"
+    end
+
+    if below_threshold_for_response?
+      updates << "response_threshold_reached_at = NULL"
+    end
+
     updates << "signature_count = greatest(signature_count - 1, 1)"
     updates << "updated_at = :now"
 
@@ -381,6 +390,18 @@ class Petition < ActiveRecord::Base
   def at_threshold_for_debate?
     unless debate_threshold_reached_at?
       signature_count >= Site.threshold_for_debate - 1
+    end
+  end
+
+  def below_threshold_for_response?
+    if response_threshold_reached_at?
+      signature_count <= Site.threshold_for_response
+    end
+  end
+
+  def below_threshold_for_debate?
+    if debate_threshold_reached_at?
+      signature_count <= Site.threshold_for_debate
     end
   end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1301,7 +1301,10 @@ RSpec.describe Petition, type: :model do
       FactoryGirl.create(:open_petition, {
         signature_count: signature_count,
         last_signed_at: 2.days.ago,
-        updated_at: 2.days.ago
+        updated_at: 2.days.ago,
+        response_threshold_reached_at: 2.days.ago,
+        debate_threshold_reached_at: 2.days.ago,
+        debate_state: 'awaiting'
       })
     end
 
@@ -1323,6 +1326,37 @@ RSpec.describe Petition, type: :model do
         expect{
           petition.decrement_signature_count!
         }.not_to change{ petition.signature_count }
+      end
+    end
+
+    context "when the signature count crosses below the threshold for a response" do
+      let(:signature_count) { 10 }
+
+      before do
+        expect(Site).to receive(:threshold_for_response).and_return(10)
+      end
+
+      it "resets the timestamp" do
+        petition.decrement_signature_count!
+        expect(petition.response_threshold_reached_at).to be_nil
+      end
+    end
+
+    context "when the signature count crosses below the threshold for a debate" do
+      let(:signature_count) { 100 }
+
+      before do
+        expect(Site).to receive(:threshold_for_debate).and_return(100)
+      end
+
+      it "records the time it happened" do
+        petition.decrement_signature_count!
+        expect(petition.debate_threshold_reached_at).to be_nil
+      end
+
+      it "sets the debate_state to 'pending'" do
+        petition.decrement_signature_count!
+        expect(petition.debate_state).to eq("pending")
       end
     end
   end


### PR DESCRIPTION
If we're invalidating a bunch of signatures and it goes through a threshold like 100,000 for a debate or 10,000 for a response then we need to clear the relevant timestamp so that it doesn't appear in the wrong lists in both the public and admin websites.