### PR TITLE
Add trending domains and IP addresses

### DIFF
--- a/app/assets/stylesheets/petitions/admin/_meta.scss
+++ b/app/assets/stylesheets/petitions/admin/_meta.scss
@@ -1,7 +1,5 @@
 .admin {
-  .petition-meta {
-    padding-top: $gutter *1.5;
-
+  .petition-meta, .signature-trends {
     dl {
       dt {
         @include bold-19();
@@ -16,8 +14,20 @@
       }
     }
   }
-  .petition-meta-state, .petition-metaa-signature-count {
-    @include core-48;
+
+  .petition-meta-state, .petition-meta-signature-count {
+    @include core-36;
   }
 
+  .petition-meta {
+    padding-top: $gutter *1.5;
+  }
+
+  .signature-trends {
+    padding-top: 70px;
+  }
+
+  .petition-meta-state, .petition-meta-signature-count {
+    @include core-36;
+  }
 }

--- a/app/assets/stylesheets/petitions/admin/_tables.scss
+++ b/app/assets/stylesheets/petitions/admin/_tables.scss
@@ -11,7 +11,9 @@
   text-align: right;
 }
 
-.fraudulent-domains {
+.fraudulent-domains,
+.trending-domains,
+.trending-ips {
   width: 100%;
 
   td {

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -3,6 +3,8 @@ class Admin::SearchesController < Admin::AdminController
   def show
     if query_is_number?
       find_petition_by_id
+    elsif query_is_ip?
+      find_signatures_by_ip
     elsif query_is_email?
       find_signatures_by_email
     elsif query_is_name?
@@ -15,12 +17,21 @@ class Admin::SearchesController < Admin::AdminController
   end
 
   private
+
   def query
     @query ||= params.fetch(:q, '')
   end
 
+  def ip_address
+    @ip_address ||= @query
+  end
+
   def name
     @name ||= @query.gsub(/\A"|"\Z/, '')
+  end
+
+  def email
+    @email ||= @query
   end
 
   def tag
@@ -35,8 +46,12 @@ class Admin::SearchesController < Admin::AdminController
     end
   end
 
+  def find_signatures_by_ip
+    @signatures = Signature.for_ip(ip_address).paginate(page: params[:page], per_page: 50)
+  end
+
   def find_signatures_by_email
-    @signatures = Signature.for_email(query).paginate(page: params[:page], per_page: 50)
+    @signatures = Signature.for_email(email).paginate(page: params[:page], per_page: 50)
   end
 
   def find_signatures_by_name
@@ -53,6 +68,10 @@ class Admin::SearchesController < Admin::AdminController
 
   def query_is_number?
     /^\d+$/ =~ query
+  end
+
+  def query_is_ip?
+    /\A(?:\d{1,3}){1}(?:\.\d{1,3}){3}\z/ =~ query
   end
 
   def query_is_email?

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -43,6 +43,22 @@ module AdminHelper
     form.submit(t(:email_button, i18n_options), html_options)
   end
 
+  def trending_domains(since: 1.hour.ago, limit: 10)
+    @trending_domains ||= build_trending_domains(since, limit)
+  end
+
+  def trending_domains?(since: 1.hour.ago, limit: 10)
+    !trending_domains(since: since, limit: limit).empty?
+  end
+
+  def trending_ips(since: 1.hour.ago, limit: 10)
+    @trending_ips ||= build_trending_ips(since, limit)
+  end
+
+  def trending_ips?(since: 1.hour.ago, limit: 10)
+    !trending_ips(since: since, limit: limit).empty?
+  end
+
   private
 
   def admin_petition_facets
@@ -51,5 +67,39 @@ module AdminHelper
 
   def admin_invalidation_facets
     I18n.t(:keys, scope: :"admin.invalidations.facets")
+  end
+
+  def rate_limit
+    @rate_limit ||= RateLimit.first_or_create!
+  end
+
+  def build_trending_domains(since, limit)
+    all_domains = Signature.trending_domains(since: since, limit: limit + 30)
+    whitelist = rate_limit.whitelisted_domains
+
+    all_domains.inject([]) do |domains, (domain, count)|
+      return domains if domains.size == limit
+
+      unless whitelist.any?{ |d| d === domain }
+        domains << [domain, count]
+      end
+
+      domains
+    end
+  end
+
+  def build_trending_ips(since, limit)
+    all_ips = Signature.trending_ips(since: since, limit: limit + 30)
+    whitelist = rate_limit.whitelisted_ips
+
+    all_ips.inject([]) do |ips, (ip, count)|
+      return ips if ips.size == limit
+
+      unless whitelist.any?{ |i| i.include?(ip) }
+        ips << [ip, count]
+      end
+
+      ips
+    end
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -92,6 +92,26 @@ class Signature < ActiveRecord::Base
     count(:all)
   end
 
+  def self.trending_domains(since: 1.hour.ago, limit: 20)
+    select("SUBSTRING(email FROM POSITION('@' IN email) + 1) AS domain").
+    where(arel_table[:validated_at].gt(since)).
+    where(arel_table[:invalidated_at].eq(nil)).
+    group("SUBSTRING(email FROM POSITION('@' IN email) + 1)").
+    order("COUNT(*) DESC").
+    limit(limit).
+    count(:all)
+  end
+
+  def self.trending_ips(since: 1.hour.ago, limit: 20)
+    select(:ip_address).
+    where(arel_table[:validated_at].gt(since)).
+    where(arel_table[:invalidated_at].eq(nil)).
+    group(:ip_address).
+    order("COUNT(*) DESC").
+    limit(limit).
+    count(:all)
+  end
+
   scope :in_days, ->(number_of_days) { validated.where("updated_at > ?", number_of_days.day.ago) }
   scope :matching, ->(signature) { where(email: signature.email,
                                          name: signature.name,

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -55,6 +55,7 @@ class Signature < ActiveRecord::Base
   scope :fraudulent, -> { where(state: FRAUDULENT_STATE) }
   scope :invalidated, -> { where(state: INVALIDATED_STATE) }
   scope :notify_by_email, -> { where(notify_by_email: true) }
+  scope :for_ip, ->(ip) { where(ip_address: ip) }
   scope :for_email, ->(email) { where(email: email.downcase) }
   scope :for_name, ->(name) { where("lower(name) = ?", name.downcase) }
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -52,6 +52,8 @@ class Signature < ActiveRecord::Base
   # = Finders =
   scope :validated, -> { where(state: VALIDATED_STATE) }
   scope :pending, -> { where(state: PENDING_STATE) }
+  scope :fraudulent, -> { where(state: FRAUDULENT_STATE) }
+  scope :invalidated, -> { where(state: INVALIDATED_STATE) }
   scope :notify_by_email, -> { where(notify_by_email: true) }
   scope :for_email, ->(email) { where(email: email.downcase) }
   scope :for_name, ->(name) { where("lower(name) = ?", name.downcase) }

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -21,4 +21,36 @@
       </ul>
     <% end %>
   </div>
+
+  <div class="signature-trends column-third">
+    <dl>
+      <% if trending_domains? %>
+        <dt>Trending Domains</dt>
+        <dd>
+          <table class="trending-domains">
+            <% trending_domains.each do |domain, count| %>
+              <tr>
+                <td><%= domain %></td>
+                <td><%= number_with_delimiter(count) %></td>
+              </tr>
+            <% end %>
+          </table>
+        </dd>
+      <% end %>
+
+      <% if trending_ips? %>
+        <dt>Trending IP Addresses</dt>
+        <dd>
+          <table class="trending-ips">
+            <% trending_ips.each do |ip, count| %>
+              <tr>
+                <td><%= ip %></td>
+                <td><%= number_with_delimiter(count) %></td>
+              </tr>
+            <% end %>
+          </table>
+        </dd>
+      <% end %>
+    </dl>
+  </div>
 </div>

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -31,10 +31,14 @@
 
 <% else %>
   <p>
-    <% if @name %>
-      No signatures found for name <%= @query %>
+    <% if defined?(@name) %>
+      No signatures found for name <%= @name.inspect %>
+    <% elsif defined?(@ip_address) %>
+      No signatures found for IP address <%= @ip_address.inspect %>
+    <% elsif defined?(@email) %>
+      No signatures found for email address <%= mail_to @email %>
     <% else %>
-      No signatures found for email address <%= mail_to @query %>
+      No signatures found %>
     <% end %>
   </p>
 <% end %>

--- a/db/migrate/20160822064645_add_ip_address_index_to_signatures.rb
+++ b/db/migrate/20160822064645_add_ip_address_index_to_signatures.rb
@@ -1,0 +1,15 @@
+class AddIpAddressIndexToSignatures < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:signatures, [:ip_address, :petition_id])
+      add_index :signatures, [:ip_address, :petition_id], algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:signatures, [:ip_address, :petition_id])
+      remove_index :signatures, [:ip_address, :petition_id]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1526,6 +1526,13 @@ CREATE INDEX index_signatures_on_invalidation_id ON signatures USING btree (inva
 
 
 --
+-- Name: index_signatures_on_ip_address_and_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_ip_address_and_petition_id ON signatures USING btree (ip_address, petition_id);
+
+
+--
 -- Name: index_signatures_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1844,4 +1851,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160819062044');
 INSERT INTO schema_migrations (version) VALUES ('20160819062058');
 
 INSERT INTO schema_migrations (version) VALUES ('20160820132056');
+
+INSERT INTO schema_migrations (version) VALUES ('20160822064645');
 

--- a/features/admin/search_for_signatures_by_ip_address.feature
+++ b/features/admin/search_for_signatures_by_ip_address.feature
@@ -1,0 +1,17 @@
+@admin
+Feature: Searching for signatures as Terry
+  In order to easily find signatures from an IP address
+  As Terry
+  I would like to be able to enter an IP address, and see all signatures associated with it
+
+  Scenario: A user can search for signatures by IP address
+    Given 2 petitions signed from "192.168.1.1"
+    And I am logged in as a moderator
+    When I search for petitions signed from "192.168.1.1"
+    Then I should see 2 petitions associated with the IP address
+
+  Scenario: A user can search for signatures by name from the admin hub
+    Given 2 petitions signed from "192.168.1.1"
+    And I am logged in as a moderator
+    When I search for petitions signed from "192.168.1.1" from the admin hub
+    Then I should see 2 petitions associated with the IP address

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -11,6 +11,13 @@ Given(/^(\d+) petitions? signed by "([^"]*)"$/) do |petition_count, name_or_emai
   end
 end
 
+Given(/^(\d+) petitions? signed from "([^"]*)"$/) do |petition_count, ip_address|
+  petition_count.times do
+    petition = FactoryGirl.create(:open_petition)
+    FactoryGirl.create(:signature, ip_address: ip_address, petition: petition)
+  end
+end
+
 Given(/^(\d+) petitions? with a (pending|validated) signature by "([^"]*)"$/) do |petition_count, state, email|
   petition_count.times do
     FactoryGirl.create(:"#{state}_signature", :petition => FactoryGirl.create(:open_petition), :email => email)
@@ -31,6 +38,17 @@ When(/^I search for petitions signed by "([^"]*)"( from the admin hub)?$/) do |n
   end
 
   fill_in "Search", :with => query
+  click_button 'Search'
+end
+
+When(/^I search for petitions signed from "([^"]*)"( from the admin hub)?$/) do |ip_address, from_the_hub|
+  if from_the_hub.blank?
+    visit admin_petitions_url
+  else
+    visit admin_root_url
+  end
+
+  fill_in "Search", with: ip_address
   click_button 'Search'
 end
 
@@ -77,7 +95,7 @@ When(/^I view the petition through the admin interface$/) do
   click_button 'Search'
 end
 
-Then(/^I should see (\d+) petitions? associated with the (?:name|email address)$/) do |petition_count|
+Then(/^I should see (\d+) petitions? associated with the (?:name|email address|IP address)$/) do |petition_count|
   expect(page).to have_css("tbody tr", :count => petition_count)
 end
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -336,6 +336,8 @@ RSpec.describe Signature, type: :model do
     let!(:signature1) { FactoryGirl.create(:signature, :email => "person1@example.com", :petition => petition, :state => Signature::VALIDATED_STATE, :notify_by_email => true) }
     let!(:signature2) { FactoryGirl.create(:signature, :email => "person2@example.com", :petition => petition, :state => Signature::PENDING_STATE, :notify_by_email => true) }
     let!(:signature3) { FactoryGirl.create(:signature, :email => "person3@example.com", :petition => petition, :state => Signature::VALIDATED_STATE, :notify_by_email => false) }
+    let!(:signature4) { FactoryGirl.create(:signature, :email => "person4@example.com", :petition => petition, :state => Signature::INVALIDATED_STATE, :notify_by_email => false) }
+    let!(:signature5) { FactoryGirl.create(:signature, :email => "person4@example.com", :petition => petition, :state => Signature::FRAUDULENT_STATE, :notify_by_email => false) }
 
     describe "validated" do
       it "returns only validated signatures" do
@@ -358,6 +360,22 @@ RSpec.describe Signature, type: :model do
         signatures = Signature.pending
         expect(signatures.size).to eq(1)
         expect(signatures).to include(signature2)
+      end
+    end
+
+    describe "invalidated" do
+      it "returns only invalidated signatures" do
+        signatures = Signature.invalidated
+        expect(signatures.size).to eq(1)
+        expect(signatures).to include(signature4)
+      end
+    end
+
+    describe "fraudulent" do
+      it "returns only fraudulent signatures" do
+        signatures = Signature.fraudulent
+        expect(signatures.size).to eq(1)
+        expect(signatures).to include(signature5)
       end
     end
 


### PR DESCRIPTION
To assist with fraud detection expose the trending domains and IP addresses on the admin home page so that the moderation team can see whether any possible fraud is being attempted. Note that whitelisted entries are removed from the lists because they would likely predominate anyway.

Also add the ability to search by IP address for signatures so that if a trending IP appears the moderation team can check whether all of the signatures are from the same person or different people.