### PR TITLE
Only show fraud-related information to sysadmins

### DIFF
--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -23,34 +23,36 @@
   </div>
 
   <div class="signature-trends column-third">
-    <dl>
-      <% if trending_domains? %>
-        <dt>Trending Domains</dt>
-        <dd>
-          <table class="trending-domains">
-            <% trending_domains.each do |domain, count| %>
-              <tr>
-                <td><%= domain %></td>
-                <td><%= number_with_delimiter(count) %></td>
-              </tr>
-            <% end %>
-          </table>
-        </dd>
-      <% end %>
+    <% if current_user.is_a_sysadmin? %>
+      <dl>
+        <% if trending_domains? %>
+          <dt>Trending domains</dt>
+          <dd>
+            <table class="trending-domains">
+              <% trending_domains.each do |domain, count| %>
+                <tr>
+                  <td><%= domain %></td>
+                  <td><%= number_with_delimiter(count) %></td>
+                </tr>
+              <% end %>
+            </table>
+          </dd>
+        <% end %>
 
-      <% if trending_ips? %>
-        <dt>Trending IP Addresses</dt>
-        <dd>
-          <table class="trending-ips">
-            <% trending_ips.each do |ip, count| %>
-              <tr>
-                <td><%= ip %></td>
-                <td><%= number_with_delimiter(count) %></td>
-              </tr>
-            <% end %>
-          </table>
-        </dd>
-      <% end %>
-    </dl>
+        <% if trending_ips? %>
+          <dt>Trending IP addresses</dt>
+          <dd>
+            <table class="trending-ips">
+              <% trending_ips.each do |ip, count| %>
+                <tr>
+                  <td><%= ip %></td>
+                  <td><%= number_with_delimiter(count) %></td>
+                </tr>
+              <% end %>
+            </table>
+          </dd>
+        <% end %>
+      </dl>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -27,18 +27,20 @@
   <dt>ID</dt>
   <dd><%= @petition.id %></dd>
 
-  <% if @petition.fraudulent_domains? %>
-    <dt>Fraudulent domains</dt>
-    <dd>
-      <table class="fraudulent-domains">
-        <% @petition.fraudulent_domains.each do |domain, count| %>
-          <tr>
-            <td><%= domain %></td>
-            <td><%= number_with_delimiter(count) %></td>
-          </tr>
-        <% end %>
-      </table>
-    </dd>
+  <% if current_user.is_a_sysadmin? %>
+    <% if @petition.fraudulent_domains? %>
+      <dt>Fraudulent domains</dt>
+      <dd>
+        <table class="fraudulent-domains">
+          <% @petition.fraudulent_domains.each do |domain, count| %>
+            <tr>
+              <td><%= domain %></td>
+              <td><%= number_with_delimiter(count) %></td>
+            </tr>
+          <% end %>
+        </table>
+      </dd>
+    <% end %>
   <% end %>
 <% end %>
 </dl>

--- a/features/admin/fraudulent_domains.feature
+++ b/features/admin/fraudulent_domains.feature
@@ -1,0 +1,19 @@
+@admin
+Feature: Sysadmin can see fraudulent domains for a petition
+  In order to maintain the reputation of the service
+  As a sysadmin
+  I want to be able to see what domains have had fraudulent signatures
+
+  Scenario: Moderators should not see fraudulent domains
+    Given an open petition "Ban controversial thing" with some fraudulent signatures
+    And I am logged in as a moderator
+    When I view all petitions
+    And I follow "Ban controversial thing"
+    Then I should not see "Fraudulent domains"
+
+  Scenario: Sysadmins should see fraudulent domains
+    Given an open petition "Ban controversial thing" with some fraudulent signatures
+    And I am logged in as a sysadmin
+    When I view all petitions
+    And I follow "Ban controversial thing"
+    Then I should see "Fraudulent domains"

--- a/features/admin/trending_domains.feature
+++ b/features/admin/trending_domains.feature
@@ -1,0 +1,17 @@
+@admin
+Feature: Sysadmin can see trending domains
+  In order to maintain the reputation of the service
+  As a sysadmin
+  I want to be able to see what domains are trending
+
+  Scenario: Moderators should not see trending domains
+    Given an open petition "Ban controversial thing" with some signatures
+    And I am logged in as a moderator
+    When I go to the admin home page
+    Then I should not see "Trending domains"
+
+  Scenario: Sysadmins should see trending domains
+    Given an open petition "Ban controversial thing" with some signatures
+    And I am logged in as a sysadmin
+    When I go to the admin home page
+    Then I should see "Trending domains"

--- a/features/admin/trending_ips.feature
+++ b/features/admin/trending_ips.feature
@@ -1,0 +1,17 @@
+@admin
+Feature: Sysadmin can see trending IP addresses
+  In order to maintain the reputation of the service
+  As a sysadmin
+  I want to be able to see what IP addresses are trending
+
+  Scenario: Moderators should not see trending IP addresses
+    Given an open petition "Ban controversial thing" with some signatures
+    And I am logged in as a moderator
+    When I go to the admin home page
+    Then I should not see "Trending IP addresses"
+
+  Scenario: Sysadmins should see trending IP addresses
+    Given an open petition "Ban controversial thing" with some signatures
+    And I am logged in as a sysadmin
+    When I go to the admin home page
+    Then I should see "Trending IP addresses"

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -343,7 +343,7 @@ Then(/^I expand "([^"]*)"/) do |text|
   page.find("//details/summary[contains(., '#{text}')]").click
 end
 
-Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |state, petition_action|
+Given(/^an? (open|closed|rejected) petition "(.*?)" with some (fraudulent)? ?signatures$/) do |state, petition_action, signature_state|
   petition_closed_at = state == 'closed' ? 1.day.ago : nil
   petition_state = state == 'closed' ? 'open' : state
   petition_args = {
@@ -353,7 +353,8 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some signatures$/) do |
     state: petition_state
   }
   @petition = FactoryGirl.create(:open_petition, petition_args)
-  5.times { FactoryGirl.create(:validated_signature, petition: @petition) }
+  signature_state ||= "validated"
+  5.times { FactoryGirl.create(:"#{signature_state}_signature", petition: @petition) }
 end
 
 Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|


### PR DESCRIPTION
Regular moderators may be unsure what to do with the information presented by the fraudulent domains information on the petition admin page and the trending domains/IP addresses on the home page so only make them available to sysadmins.