### PR TITLE
Fix edge cases when closing petitions

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -320,7 +320,13 @@ class Site < ActiveRecord::Base
   end
 
   def opened_at_for_closing(time = Time.current)
-    time.beginning_of_day - petition_duration.months
+    opened_at = time.beginning_of_day - petition_duration.months
+
+    if opened_at.day < time.day
+      opened_at + 1.day
+    else
+      opened_at
+    end
   end
 
   def closed_at_for_opening(time = Time.current)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -760,6 +760,118 @@ RSpec.describe Site, type: :model do
     it "returns the opening date at petition_duration months ago" do
       expect(site.opened_at_for_closing).to eq(3.months.ago.beginning_of_day)
     end
+
+    describe "special cases" do
+      subject :site do
+        described_class.create!(petition_duration: 6)
+      end
+
+      around do |example|
+        travel_to(now) { example.run }
+      end
+
+      context "when the date is 31st January" do
+        let(:now) { Time.utc(2016, 1, 31, 12, 0, 0) }
+
+        it "returns the 31st July" do
+          expect(site.opened_at_for_closing).to eq("2015-07-31T00:00:00".in_time_zone)
+        end
+      end
+
+      context "when the date is 31st March" do
+        let(:now) { Time.utc(2016, 3, 31, 12, 0, 0) }
+
+        it "returns the 1st October" do
+          expect(site.opened_at_for_closing).to eq("2015-10-01T00:00:00".in_time_zone)
+        end
+      end
+
+      context "when the date is 31st May" do
+        let(:now) { Time.utc(2016, 5, 31, 12, 0, 0) }
+
+        it "returns the 1st December" do
+          expect(site.opened_at_for_closing).to eq("2015-12-01T00:00:00".in_time_zone)
+        end
+      end
+
+      context "when the date is 31st July" do
+        let(:now) { Time.utc(2016, 7, 31, 12, 0, 0) }
+
+        it "returns the 31st January" do
+          expect(site.opened_at_for_closing).to eq("2016-01-31T00:00:00".in_time_zone)
+        end
+      end
+
+      context "when the date is 29th August" do
+        context "and it's a leap year" do
+          let(:now) { Time.utc(2016, 8, 29, 12, 0, 0) }
+
+          it "returns the 29th February" do
+            expect(site.opened_at_for_closing).to eq("2016-02-29T00:00:00".in_time_zone)
+          end
+        end
+
+        context "and it's not a leap year" do
+          let(:now) { Time.utc(2017, 8, 29, 12, 0, 0) }
+
+          it "returns the 1st March" do
+            expect(site.opened_at_for_closing).to eq("2017-03-01T00:00:00".in_time_zone)
+          end
+        end
+      end
+
+      context "when the date is 30th August" do
+        context "and it's a leap year" do
+          let(:now) { Time.utc(2016, 8, 30, 12, 0, 0) }
+
+          it "returns the 1st March" do
+            expect(site.opened_at_for_closing).to eq("2016-03-01T00:00:00".in_time_zone)
+          end
+        end
+
+        context "and it's not a leap year" do
+          let(:now) { Time.utc(2017, 8, 30, 12, 0, 0) }
+
+          it "returns the 1st March" do
+            expect(site.opened_at_for_closing).to eq("2017-03-01T00:00:00".in_time_zone)
+          end
+        end
+      end
+
+      context "when the date is 31st August" do
+        context "and it's a leap year" do
+          let(:now) { Time.utc(2016, 8, 31, 12, 0, 0) }
+
+          it "returns the 1st March" do
+            expect(site.opened_at_for_closing).to eq("2016-03-01T00:00:00".in_time_zone)
+          end
+        end
+
+        context "and it's not a leap year" do
+          let(:now) { Time.utc(2017, 8, 31, 12, 0, 0) }
+
+          it "returns the 1st March" do
+            expect(site.opened_at_for_closing).to eq("2017-03-01T00:00:00".in_time_zone)
+          end
+        end
+      end
+
+      context "when the date is 31st October" do
+        let(:now) { Time.utc(2016, 10, 31, 12, 0, 0) }
+
+        it "returns the 1st May" do
+          expect(site.opened_at_for_closing).to eq("2016-05-01T00:00:00".in_time_zone)
+        end
+      end
+
+      context "when the date is 31st December" do
+        let(:now) { Time.utc(2016, 12, 31, 12, 0, 0) }
+
+        it "returns the 1st July" do
+          expect(site.opened_at_for_closing).to eq("2016-07-01T00:00:00".in_time_zone)
+        end
+      end
+    end
   end
 
   describe "#closed_at_for_opening" do


### PR DESCRIPTION
When trying to calculate the opening date for petitions that should be closed we need to take account of the fact that date calculations using months is inherently imprecise. This only really has an effect when the date is the 31st though for August it's a much bigger effect since it could affect 29th, 30th and 31st depending on whether it's a leap year.

The fix itself is straightforward - just add a day to take us onto the 1st of the next month. This does mean that we're running a background job pointlessly for 1-2 days in August depending on whether it's a leap year but the extra code to handle this condition isn't worth it.