### PR TITLE
Hide 'At X signatures' blocks if petition is closed

### DIFF
--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -69,7 +69,9 @@
 
   <%# Needs more signatures #%>
   <% else -%>
-    <h2 id="debate-threshold-heading">At <%= Site.formatted_threshold_for_debate %> signatures...</h2>
-    <p>At <%= Site.formatted_threshold_for_debate %> signatures, this petition will be considered for debate in Parliament</p>
+    <% if !@petition.closed? %>
+      <h2 id="debate-threshold-heading">At <%= Site.formatted_threshold_for_debate %> signatures...</h2>
+      <p>At <%= Site.formatted_threshold_for_debate %> signatures, this petition will be considered for debate in Parliament</p>
+    <% end %>
   <% end -%>
 </section>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -27,7 +27,9 @@
 
   <%# Needs more signatures #%>
   <% else -%>
-    <h2 id="response-threshold-heading">At <%= Site.formatted_threshold_for_response %> signatures...</h2>
-    <p>At <%= Site.formatted_threshold_for_response %> signatures, government will respond to this petition</p>
+    <% if !@petition.closed? %>
+      <h2 id="response-threshold-heading">At <%= Site.formatted_threshold_for_response %> signatures...</h2>
+      <p>At <%= Site.formatted_threshold_for_response %> signatures, government will respond to this petition</p>
+    <% end %>
   <% end -%>
 </section>

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -371,6 +371,10 @@ Given(/^a petition "(.*?)" exists with a debate outcome$/) do |action|
   @petition = FactoryGirl.create(:debated_petition, action: action, debated_on: 1.day.ago)
 end
 
+Given(/^a petition "(.*?)" exists with a debate outcome and with response threshold met$/) do |action|
+  @petition = FactoryGirl.create(:debated_petition, action: action, debated_on: 1.day.ago, overview: 'Everyone was in agreement, this petition must be made law!', response_threshold_reached_at: 30.days.ago)
+end
+
 Given(/^a petition "(.*?)" exists awaiting debate date$/) do |action|
   @petition = FactoryGirl.create(:awaiting_debate_petition, action: action)
 end

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -94,3 +94,34 @@ Feature: Suzie views a petition
     When I view the petition
     Then I should see "Parliament debated this petition on 26 October 2015"
     And I should see "Waiting for 1 day for Parliament to publish the debate outcome"
+
+  Scenario: Suzie does not see information about future signature targets when viewing a closed petition
+    Given a petition "Spend more money on Defence" has been closed
+    When I view the petition
+    Then I should not see "At 10,000 signatures..."
+    Then I should not see "At 100,000 signatures..."
+
+  Scenario: Suzie sees information about future signature targets when viewing an open petition which has not passed the threshold for response or debate
+    Given an open petition "Spend more money on Defence"
+    When I view the petition
+    Then I should see "At 10,000 signatures..."
+    Then I should see "At 100,000 signatures..."
+
+  @javascript
+  Scenario: Suzie sees information about a future signature target when viewing an open petition which has passed the threshold for response
+    Given an open petition "Spend more money on Defence" with response "Defence is the best Offence" and response summary "Oh yes please"
+    When I view the petition
+    Then I should not see "At 10,000 signatures..."
+    Then I should see "At 100,000 signatures..."
+    Then I should see "Oh yes please"
+    And I should not see "Defence is the best Offence"
+    When I expand "Read the response in full"
+    Then I should see "Defence is the best Offence"
+
+  @javascript
+  Scenario: Suzie does not see information about a future signature targets when viewing an open petition which has passed the threshold for response and debate
+    Given a petition "Spend more money on Defence" exists with a debate outcome and with response threshold met
+    When I view the petition
+    Then I should not see "At 10,000 signatures..."
+    Then I should not see "At 100,000 signatures..."
+    And I should see a summary of the debate outcome


### PR DESCRIPTION
Hide both 'At 10,000 signatures...' and 'At 100,000 signatures' if a petition is closed

PT: https://www.pivotaltracker.com/n/projects/307301/stories/106483956