### PR TITLE
Drop email_sent_receipts table

### DIFF
--- a/db/migrate/20160910054223_drop_email_sent_receipts.rb
+++ b/db/migrate/20160910054223_drop_email_sent_receipts.rb
@@ -1,0 +1,17 @@
+class DropEmailSentReceipts < ActiveRecord::Migration
+  def up
+    remove_foreign_key :email_sent_receipts, column: :signature_id
+    drop_table :email_sent_receipts
+  end
+
+  def down
+    create_table :email_sent_receipts do |t|
+      t.references :signature, index: true, foreign_key: true
+      t.datetime :government_response
+      t.datetime :debate_outcome
+      t.timestamps null: false
+      t.datetime :debate_scheduled
+      t.datetime :petition_email
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -330,41 +330,6 @@ ALTER SEQUENCE email_requested_receipts_id_seq OWNED BY email_requested_receipts
 
 
 --
--- Name: email_sent_receipts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE email_sent_receipts (
-    id integer NOT NULL,
-    signature_id integer,
-    government_response timestamp without time zone,
-    debate_outcome timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    debate_scheduled timestamp without time zone,
-    petition_email timestamp without time zone
-);
-
-
---
--- Name: email_sent_receipts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE email_sent_receipts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: email_sent_receipts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE email_sent_receipts_id_seq OWNED BY email_sent_receipts.id;
-
-
---
 -- Name: feedback; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -926,13 +891,6 @@ ALTER TABLE ONLY email_requested_receipts ALTER COLUMN id SET DEFAULT nextval('e
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY email_sent_receipts ALTER COLUMN id SET DEFAULT nextval('email_sent_receipts_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY feedback ALTER COLUMN id SET DEFAULT nextval('feedback_id_seq'::regclass);
 
 
@@ -1082,14 +1040,6 @@ ALTER TABLE ONLY delayed_jobs
 
 ALTER TABLE ONLY email_requested_receipts
     ADD CONSTRAINT email_requested_receipts_pkey PRIMARY KEY (id);
-
-
---
--- Name: email_sent_receipts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY email_sent_receipts
-    ADD CONSTRAINT email_sent_receipts_pkey PRIMARY KEY (id);
 
 
 --
@@ -1327,13 +1277,6 @@ CREATE INDEX index_delayed_jobs_on_priority_and_run_at ON delayed_jobs USING btr
 --
 
 CREATE INDEX index_email_requested_receipts_on_petition_id ON email_requested_receipts USING btree (petition_id);
-
-
---
--- Name: index_email_sent_receipts_on_signature_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_email_sent_receipts_on_signature_id ON email_sent_receipts USING btree (signature_id);
 
 
 --
@@ -1677,14 +1620,6 @@ ALTER TABLE ONLY debate_outcomes
 
 
 --
--- Name: fk_rails_e256832d5d; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY email_sent_receipts
-    ADD CONSTRAINT fk_rails_e256832d5d FOREIGN KEY (signature_id) REFERENCES signatures(id);
-
-
---
 -- PostgreSQL database dump complete
 --
 
@@ -1853,4 +1788,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160819062058');
 INSERT INTO schema_migrations (version) VALUES ('20160820132056');
 
 INSERT INTO schema_migrations (version) VALUES ('20160822064645');
+
+INSERT INTO schema_migrations (version) VALUES ('20160910054223');
 

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -254,27 +254,5 @@ namespace :epets do
         petition.touch
       end
     end
-
-    desc "Migrate email sent receipts to signature columns"
-    task :email_sent_receipts_to_signatures => :environment do
-      class EmailSentReceipt < ActiveRecord::Base; end
-
-      EmailSentReceipt.find_each do |receipt|
-        updates = []
-        updates << "government_response_email_at = GREATEST(government_response_email_at, ?)"
-        updates << "debate_scheduled_email_at = GREATEST(debate_scheduled_email_at, ?)"
-        updates << "debate_outcome_email_at = GREATEST(debate_outcome_email_at, ?)"
-        updates << "petition_email_at = GREATEST(petition_email_at, ?)"
-        updates = updates.join(", ")
-
-        params = []
-        params << receipt.government_response
-        params << receipt.debate_scheduled
-        params << receipt.debate_outcome
-        params << receipt.petition_email
-
-        Signature.where(id: receipt.signature_id).update_all([updates] + params)
-      end
-    end
   end
 end


### PR DESCRIPTION
All of the timestamps have been migrated to the new columns in the signatures table so we can safely drop the email_sent_receipts table now.