### PR TITLE
Fix race condition in petition rejection

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -454,7 +454,11 @@ class Petition < ActiveRecord::Base
   end
 
   def reject(attributes)
-    build_rejection(attributes) && rejection.save
+    begin
+      build_rejection(attributes) && rejection.save
+    rescue ActiveRecord::RecordNotUnique => e
+      rejection(true).update(attributes)
+    end
   end
 
   def flag

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1570,6 +1570,28 @@ RSpec.describe Petition, type: :model do
         end
       end
     end
+
+    context "when two moderators reject the petition at the same time" do
+      let(:rejection) { petition.reload.rejection }
+
+      it "doesn't raise an ActiveRecord::RecordNotUnique error" do
+        expect {
+          p1 = described_class.find(petition.id)
+          p2 = described_class.find(petition.id)
+
+          expect(p1.rejection).to be_nil
+          expect(p1.association(:rejection)).to be_loaded
+
+          expect(p2.rejection).to be_nil
+          expect(p2.association(:rejection)).to be_loaded
+
+          p1.reject(code: "duplicate")
+          p2.reject(code: "irrelevant")
+
+          expect(rejection.code).to eq("irrelevant")
+        }.not_to raise_error
+      end
+    end
   end
 
   describe '#close!' do


### PR DESCRIPTION
When a petition is rejected by two moderators at the same time there is a race condition which results in an ActiveRecord::RecordNotUnique error for the `has_one :rejection` association.

To fix this we rescue the error, force the association to reload which picks up the existing record and then update that instead of inserting our own. The result of this is that the last committer wins which is the standard pattern elsewhere in the app with write conflicts.

The test for the race condition fakes two moderators by pre-loading the rejection association which convinces Active Record that there is no existing record so will not attempt to delete it first.