### PR TITLE
Fix race conditions in admin controllers

### DIFF
--- a/app/controllers/admin/debate_outcomes_controller.rb
+++ b/app/controllers/admin/debate_outcomes_controller.rb
@@ -3,6 +3,10 @@ class Admin::DebateOutcomesController < Admin::AdminController
   before_action :fetch_petition
   before_action :fetch_debate_outcome
 
+  rescue_from ActiveRecord::RecordNotUnique do
+    @debate_outcome = @petition.debate_outcome(true) and update
+  end
+
   def show
     render 'admin/petitions/show'
   end

--- a/app/controllers/admin/government_response_controller.rb
+++ b/app/controllers/admin/government_response_controller.rb
@@ -3,12 +3,16 @@ class Admin::GovernmentResponseController < Admin::AdminController
   before_action :fetch_petition
   before_action :fetch_government_response
 
+  rescue_from ActiveRecord::RecordNotUnique do
+    @government_response = @petition.government_response(true) and update
+  end
+
   def show
     render 'admin/petitions/show'
   end
 
   def update
-    if @government_response.update_attributes(government_response_params)
+    if @government_response.update(government_response_params)
       if send_email_to_petitioners?
         EmailThresholdResponseJob.run_later_tonight(petition: @petition)
         message = 'Email will be sent overnight'

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -3,6 +3,10 @@ class Admin::NotesController < Admin::AdminController
   before_action :fetch_petition
   before_action :fetch_note
 
+  rescue_from ActiveRecord::RecordNotUnique do
+    @note = @petition.note(true) and update
+  end
+
   def show
     render 'admin/petitions/show'
   end


### PR DESCRIPTION
There exists a number of race conditions in admin controller that are managing `has_one` associations on the petition. These exist because we don't create a blank record when first visiting the page because that would create records in response to a simple GET request.

To fix the problem we use the same pattern in each instance - force reloading the association and then retrying the action. We have to mock out some of the Active Record interactions in the controller action to reproduce the error because there's no other way to raise the exception without manually raising it ourselves.