### PR TITLE
Fix race condition in sponsors controller

### DIFF
--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -31,6 +31,8 @@ class SponsorsController < ApplicationController
         format.html { render :show }
       end
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    redirect_to thank_you_petition_sponsor_url(@petition, token: @petition.sponsor_token)
   end
 
   def thank_you

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -477,6 +477,7 @@ RSpec.describe SignaturesController, type: :controller do
 
       context "when a race condition occurs" do
         let(:exception) { ActiveRecord::RecordNotUnique.new("PG::UniqueViolation") }
+
         before do
           FactoryGirl.create(:validated_signature, signature_params.merge(petition_id: petition.id))
           allow_any_instance_of(Signature).to receive(:save).and_raise(exception)

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -284,6 +284,20 @@ RSpec.describe SponsorsController, type: :controller do
         expect(assigns[:stage_manager].stage).to eq 'signer'
       end
     end
+
+    context "when a race condition occurs" do
+      let(:exception) { ActiveRecord::RecordNotUnique.new("PG::UniqueViolation") }
+
+      before do
+        FactoryGirl.create(:sponsor, :validated, petition: petition)
+        allow_any_instance_of(Signature).to receive(:save).and_raise(exception)
+      end
+
+      it "redirects to the thank you page" do
+        do_patch
+        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/sponsors/#{petition.sponsor_token}/thank-you")
+      end
+    end
   end
 
   context 'GET thank-you' do


### PR DESCRIPTION
Similar to #506, there's a race condition in the sponsors controller that can be triggered by a double submit. We can fix it in a similar fashion as well by redirecting to the thank you url as the email will have already been sent by the first submit.