### PR TITLE
Fix encoding exceptions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,10 @@ module ApplicationHelper
     !params.values_at(:controller, :action).in?(INDEXED_PAGES)
   end
 
+  def original_url
+    request.original_url.force_encoding('utf-8')
+  end
+
   private
 
   def referer_url

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -77,7 +77,7 @@ module CacheHelper
       end
 
       def url
-        request.original_url
+        request.original_url.force_encoding('utf-8')
       end
 
       def for(keys)

--- a/app/views/application/_local_search.html.erb
+++ b/app/views/application/_local_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag local_petitions_path, class: 'search-inline', method: 'get' do %>
+<%= form_tag local_petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
   <%= label_tag 'postcode', 'UK postcode', class: 'form-label' %>
   <%= search_field_tag 'postcode', @postcode, class: 'form-control' %>
   <%= submit_tag 'Search', class: 'inline-submit', name: nil %>

--- a/app/views/application/_social_meta.html.erb
+++ b/app/views/application/_social_meta.html.erb
@@ -15,7 +15,7 @@
 <%= open_graph_tag 'title', :title, petition: @petition.action %>
 <%= open_graph_tag 'description', @petition.background %>
 <% else %>
-<%= open_graph_tag 'url', request.original_url %>
+<%= open_graph_tag 'url', original_url %>
 <%= open_graph_tag 'type', 'website' %>
 <%= open_graph_tag 'title', page_title %>
 <% end %>

--- a/app/views/archived/petitions/index.html.erb
+++ b/app/views/archived/petitions/index.html.erb
@@ -3,7 +3,7 @@
 <h1 class="page-title">Archived petitions</h1>
 <p class="text-secondary">Petitions from the 2010–2015 Conservative – Liberal Democrat coalition government</p>
 
-<%= form_tag archived_petitions_path, class: 'search-inline', method: 'get' do %>
+<%= form_tag archived_petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
   <%= search_field_tag  'q', @petitions.query, class: 'form-control', id: 'search' %>
   <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
 <% end %>

--- a/app/views/petitions/index.html.erb
+++ b/app/views/petitions/index.html.erb
@@ -19,7 +19,7 @@
   <p class="text-secondary"><%= petition_list_header %></p>
 <% end %>
 
-<%= form_tag petitions_path, class: 'search-inline', method: 'get' do %>
+<%= form_tag petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
   <%= search_field_tag 'q', @petitions.query, class: 'form-control', id: 'search' %>
   <%= hidden_field_tag 'state', @petitions.scope %>
   <%= submit_tag 'Search', class: 'inline-submit' %>

--- a/app/views/petitions/index.html.erb
+++ b/app/views/petitions/index.html.erb
@@ -22,7 +22,7 @@
 <%= form_tag petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
   <%= search_field_tag 'q', @petitions.query, class: 'form-control', id: 'search' %>
   <%= hidden_field_tag 'state', @petitions.scope %>
-  <%= submit_tag 'Search', class: 'inline-submit' %>
+  <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
 <% end %>
 
 <p class="filtered-petition-count"><%= filtered_petition_count(@petitions) %></p>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -178,4 +178,23 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#original_url" do
+    let(:headers) { helper.request.env }
+
+    before do
+      headers["HTTP_HOST"] = "petition.parliament.uk"
+      headers["HTTP_X_FORWARDED_PROTO"] = "https"
+      headers["PATH_INFO"] = "/petitions"
+      headers["QUERY_STRING"] = "utf8=✓&q=foo".force_encoding('binary')
+    end
+
+    it "returns the original request url" do
+      expect(helper.original_url).to eq("https://petition.parliament.uk/petitions?utf8=✓&q=foo")
+    end
+
+    it "is encoded as UTF-8" do
+      expect(helper.original_url.encoding).to eq(Encoding::UTF_8)
+    end
+  end
 end

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -181,6 +181,16 @@ RSpec.describe CacheHelper, type: :helper do
         expect(helper).to receive(:request).and_return(request)
         expect(keys.url).to eq("/petitions/123")
       end
+
+      context "when the URL isn't encoded properly" do
+        let(:original_url) { "/petitions?utf=✓&q=foo".force_encoding('binary') }
+        let(:request) { double(:request, original_url: original_url) }
+
+        it "forces the encoding to UTF-8" do
+          expect(helper).to receive(:request).and_return(request)
+          expect(keys.url.encoding).to eq(Encoding::UTF_8)
+        end
+      end
     end
 
     describe "#method_missing" do


### PR DESCRIPTION
Sometimes clients aren't properly encoding UTF-8 chars as %HH chars in the request url and this was causing exceptions further down the stack. The primary source of the UTF-8 chars is the tick mark introduced in Rails 3 to force UTF-8 encoding in form submissions from IE. Since this isn't relevant anymore we can just disable the tick mark but we should also force UTF-8 encoding on the url anyway because there were other sources (mostly old links to search pages).