### PR TITLE
Increase allowed size of government responses

### DIFF
--- a/app/models/government_response.rb
+++ b/app/models/government_response.rb
@@ -3,7 +3,7 @@ class GovernmentResponse < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :summary, presence: true, length: { maximum: 200 }
-  validates :details, length: { maximum: 5000 }, allow_blank: true
+  validates :details, length: { maximum: 6000 }, allow_blank: true
 
   after_create do
     petition.touch(:government_response_at)

--- a/spec/models/government_response_spec.rb
+++ b/spec/models/government_response_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovernmentResponse, type: :model do
     it { is_expected.to validate_presence_of(:petition) }
     it { is_expected.to validate_presence_of(:summary) }
     it { is_expected.to validate_length_of(:summary).is_at_most(200) }
-    it { is_expected.to validate_length_of(:details).is_at_most(5000) }
+    it { is_expected.to validate_length_of(:details).is_at_most(6000) }
   end
 
   describe "callbacks" do


### PR DESCRIPTION
The limit of 5000 doesn't take into account the fact that posting the form sends CR/LFs which counts as two characters but in Word it's seen as one character by the counter in the document chrome.

Fix this by increasing the validation limit to 6000 characters but still instruct staff to keep responses to 5000 characters.