### PR TITLE
Add SocketError to the list of temporary failures

### DIFF
--- a/app/jobs/concerns/email_delivery.rb
+++ b/app/jobs/concerns/email_delivery.rb
@@ -18,7 +18,8 @@ module EmailDelivery
     Errno::ECONNREFUSED,
     Errno::ETIMEDOUT,
     Timeout::Error,
-    EOFError
+    EOFError,
+    SocketError
   ]
 
   included do

--- a/app/jobs/email_job.rb
+++ b/app/jobs/email_job.rb
@@ -14,7 +14,8 @@ class EmailJob < ApplicationJob
     Errno::ECONNREFUSED,
     Errno::ETIMEDOUT,
     Timeout::Error,
-    EOFError
+    EOFError,
+    SocketError
   ]
 
   queue_as :high_priority

--- a/spec/jobs/email_job_spec.rb
+++ b/spec/jobs/email_job_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe EmailJob, type: :job do
       it_behaves_like "catching errors during individual email sending"
       it_behaves_like "retrying the email delivery"
     end
+
+    context "with socket error" do
+      let(:exception_class) { SocketError }
+
+      it_behaves_like "catching errors during individual email sending"
+      it_behaves_like "retrying the email delivery"
+    end
   end
 end
 

--- a/spec/jobs/shared_examples.rb
+++ b/spec/jobs/shared_examples.rb
@@ -228,6 +228,13 @@ RSpec.shared_examples_for "a job to send an signatory email" do
         it_behaves_like "catching errors during individual email sending"
         it_behaves_like "retrying the email delivery"
       end
+
+      context "with socket error" do
+        let(:exception_class) { SocketError }
+
+        it_behaves_like "catching errors during individual email sending"
+        it_behaves_like "retrying the email delivery"
+      end
     end
   end
 


### PR DESCRIPTION
If for some reason the DNS system is down (like the recent DDoS attack on Dyn) then we may get a `SocketError` from `getaddrinfo`. There's no need to raise these errors with Appsignal so capture them and retry the job later.
