### PR TITLE
Add an all local petitions view

### DIFF
--- a/app/assets/stylesheets/petitions/_typography.scss
+++ b/app/assets/stylesheets/petitions/_typography.scss
@@ -90,6 +90,16 @@ p {
   }
 }
 
+.heading-link {
+  margin-top: em(-16, 16);
+  margin-bottom: em(24, 16);
+
+  @include media(tablet) {
+    margin-top: em(-19, 19);
+    margin-bottom: em(32, 19);
+  }
+}
+
 // Link styles
 a {
   color: $link-colour;

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -5,8 +5,9 @@ class LocalPetitionsController < ApplicationController
 
   before_action :sanitize_postcode, only: :index
   before_action :find_by_postcode, if: :postcode?, only: :index
-  before_action :find_by_slug, only: :show
+  before_action :find_by_slug, only: [:show, :all]
   before_action :find_petitions, if: :constituency?, only: :show
+  before_action :find_all_petitions, if: :constituency?, only: :all
   before_action :redirect_to_constituency, if: :constituency?, only: :index
 
   def index
@@ -16,6 +17,10 @@ class LocalPetitionsController < ApplicationController
   end
 
   def show
+    respond_with(@petitions)
+  end
+
+  def all
     respond_with(@petitions)
   end
 
@@ -43,6 +48,10 @@ class LocalPetitionsController < ApplicationController
 
   def find_petitions
     @petitions = Petition.popular_in_constituency(@constituency.external_id, 50)
+  end
+
+  def find_all_petitions
+    @petitions = Petition.all_popular_in_constituency(@constituency.external_id, 50)
   end
 
   def redirect_to_constituency

--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -46,4 +46,8 @@ class Constituency < ActiveRecord::Base
   def mp_url
     "#{MP_URL}/#{mp_name.parameterize}/#{mp_id}"
   end
+
+  def to_param
+    slug
+  end
 end

--- a/app/views/local_petitions/all.html.erb
+++ b/app/views/local_petitions/all.html.erb
@@ -1,9 +1,9 @@
 <h1 class="page-title">
-  Popular open petitions in the constituency of <%= @constituency.name %>
+  Popular petitions in the constituency of <%= @constituency.name %>
 </h1>
 
 <p class="heading-link">
-  <%= link_to "View all popular petitions in #{@constituency.name}", all_local_petition_path(@constituency), class: 'view-all' %>
+  <%= link_to "View open popular petitions in #{@constituency.name}", local_petition_path(@constituency), class: 'view-all' %>
 </p>
 
 <% if @constituency.sitting_mp? %>
@@ -18,8 +18,14 @@
       <% @petitions.each do |petition| %>
         <li class="petition-item petition-<%= petition.state %>">
           <h3><%= link_to petition.action, petition_path(petition) %></h3>
-          <p><%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
-          (<%= signature_count(:in_total, petition.signature_count) %>)</p>
+          <p>
+            <%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
+            <% if petition.closed? %>
+              (<%= signature_count(:in_total, petition.signature_count) %>, now closed)
+            <% else %>
+              (<%= signature_count(:in_total, petition.signature_count) %>)
+            <% end %>
+          </p>
         </li>
       <% end -%>
     </ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     scope 'petitions' do
       get 'local' => 'local_petitions#index', as: 'local_petitions'
       get 'local/:id' => 'local_petitions#show', as: 'local_petition'
+      get 'local/:id/all' => 'local_petitions#all', as: 'all_local_petition'
     end
 
     resources :petitions, :only => [:new, :show, :index] do

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -22,11 +22,21 @@ Feature: Freya searches petitions by constituency
     Then I should be on the local petitions results page
     And the markup should be valid
     And I should see "Petitions in South Dorset" in the browser page title
+    And I should see "Popular open petitions in the constituency of South Dorset"
+    And I should see a link to view all local petitions
     And I should see a link to the MP for my constituency
     And I should see that my fellow constituents support "Save the monkeys"
     And I should see that my fellow constituents support "Build more quirky theme parks"
     But I should not see that my fellow constituents support "What about other primates?"
     And I should not see that my fellow constituents support "Restore vintage diggers"
+    And the petitions I see should be ordered by my fellow constituents level of support
+    When I click the view all local petitions
+    Then I should be on the all local petitions results page
+    And the markup should be valid
+    And I should see "Popular petitions in the constituency of South Dorset"
+    And I should see a link to view open local petitions
+    And I should see that my fellow constituents support "What about other primates?"
+    And I should see that closed petitions are identified
     And the petitions I see should be ordered by my fellow constituents level of support
 
   Scenario: Searching for local petitions when the api is down

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -101,8 +101,8 @@ Then(/^I should see that my fellow constituents support "(.*?)"$/) do |petition_
   local_signature_count = petition.signatures.validated.where(constituency_id: @my_constituency.external_id).count
   within :css, '.local-petitions' do
     within ".//*#{XPathHelpers.class_matching('petition-item')}[.//a[.='#{petition_action}']]" do
-      expect(page).to have_text("#{local_signature_count} signatures from #{@my_constituency.name}")
-      expect(page).to have_text("#{all_signature_count} signatures total")
+      expect(page).to have_text("#{local_signature_count} #{'signature'.pluralize(local_signature_count)} from #{@my_constituency.name}")
+      expect(page).to have_text("#{all_signature_count} #{'signature'.pluralize(all_signature_count)} total")
     end
   end
 end
@@ -143,4 +143,20 @@ end
 
 Then(/^I should not see a link to the MP for my constituency$/) do
   expect(page).not_to have_link(@my_constituency.mp_name, href: @my_constituency.mp_url)
+end
+
+Then(/^I should see a link to view all local petitions$/) do
+  expect(page).to have_link("View all popular petitions in #{@my_constituency.name}", href: all_local_petition_path(@my_constituency))
+end
+
+Then(/^I should see a link to view open local petitions$/) do
+  expect(page).to have_link("View open popular petitions in #{@my_constituency.name}", href: local_petition_path(@my_constituency))
+end
+
+When(/^I click the view all local petitions$/) do
+  click_on "View all popular petitions in #{@my_constituency.name}"
+end
+
+Then(/^I should see that closed petitions are identified$/) do
+  expect(page).to have_text("now closed")
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -359,10 +359,9 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some (fraudulent)? ?sig
   petition_args = {
     action: petition_action,
     open_at: 3.months.ago,
-    closed_at: petition_closed_at,
-    state: petition_state
+    closed_at: petition_closed_at
   }
-  @petition = FactoryGirl.create(:open_petition, petition_args)
+  @petition = FactoryGirl.create(:"#{state}_petition", petition_args)
   signature_state ||= "validated"
   5.times { FactoryGirl.create(:"#{signature_state}_signature", petition: @petition) }
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -53,6 +53,9 @@ module NavigationHelpers
     when /^the local petitions results page$/
       local_petition_url(@my_constituency.slug)
 
+    when /^the all local petitions results page$/
+      all_local_petition_url(@my_constituency.slug)
+
     else
       begin
         page_name =~ /^the (.*) page$/

--- a/spec/controllers/local_petitions_controller_spec.rb
+++ b/spec/controllers/local_petitions_controller_spec.rb
@@ -100,4 +100,27 @@ RSpec.describe LocalPetitionsController, type: :controller do
       expect(assigns(:petitions)).to eq(petitions)
     end
   end
+
+  describe "GET /petitions/local/:id/all" do
+    let(:petitions) { double(:petitions) }
+
+    before do
+      expect(Constituency).to receive(:find_by_slug!).with("holborn").and_return(constituency)
+      expect(Petition).to receive(:all_popular_in_constituency).with("99999", 50).and_return(petitions)
+
+      get :all, id: "holborn"
+    end
+
+    it "renders the all template" do
+      expect(response).to render_template("local_petitions/all")
+    end
+
+    it "assigns the constituency" do
+      expect(assigns(:constituency)).to eq(constituency)
+    end
+
+    it "assigns the petitions" do
+      expect(assigns(:petitions)).to eq(petitions)
+    end
+  end
 end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -519,6 +519,66 @@ RSpec.describe Petition, type: :model do
       end
     end
 
+    describe '.all_popular_in_constituency' do
+      let!(:petition_1) { FactoryGirl.create(:open_petition, signature_count: 10) }
+      let!(:petition_2) { FactoryGirl.create(:open_petition, signature_count: 20) }
+      let!(:petition_3) { FactoryGirl.create(:open_petition, signature_count: 30) }
+      let!(:petition_4) { FactoryGirl.create(:open_petition, signature_count: 40) }
+
+      let!(:constituency_1) { FactoryGirl.generate(:constituency_id) }
+      let!(:constituency_2) { FactoryGirl.generate(:constituency_id) }
+
+      let!(:petition_1_journal_1) { FactoryGirl.create(:constituency_petition_journal, petition: petition_1, constituency_id: constituency_1, signature_count: 6) }
+      let!(:petition_1_journal_2) { FactoryGirl.create(:constituency_petition_journal, petition: petition_1, constituency_id: constituency_2, signature_count: 4) }
+      let!(:petition_2_journal_2) { FactoryGirl.create(:constituency_petition_journal, petition: petition_2, constituency_id: constituency_2, signature_count: 20) }
+      let!(:petition_3_journal_1) { FactoryGirl.create(:constituency_petition_journal, petition: petition_3, constituency_id: constituency_1, signature_count: 30) }
+      let!(:petition_4_journal_1) { FactoryGirl.create(:constituency_petition_journal, petition: petition_4, constituency_id: constituency_1, signature_count: 0) }
+      let!(:petition_4_journal_2) { FactoryGirl.create(:constituency_petition_journal, petition: petition_4, constituency_id: constituency_2, signature_count: 40) }
+
+      it 'excludes petitions that have no journal for the supplied constituency_id' do
+        popular = Petition.all_popular_in_constituency(constituency_1, 4)
+        expect(popular).not_to include(petition_2)
+      end
+
+      it 'excludes petitions that have a journal with 0 votes for the supplied constituency_id' do
+        popular = Petition.all_popular_in_constituency(constituency_1, 4)
+        expect(popular).not_to include(petition_4)
+      end
+
+      it 'includes closed petitions with signatures from the supplied constituency_id' do
+        petition_1.update_columns(state: 'closed', closed_at: 3.days.ago)
+        popular = Petition.all_popular_in_constituency(constituency_1, 4)
+        expect(popular).to include(petition_1)
+      end
+
+      it 'excludes rejected petitions with signatures from the supplied constituency_id' do
+        petition_1.update_column(:state, Petition::REJECTED_STATE)
+        popular = Petition.all_popular_in_constituency(constituency_1, 4)
+        expect(popular).not_to include(petition_1)
+      end
+
+      it 'excludes hidden petitions with signatures from the supplied constituency_id' do
+        petition_1.update_column(:state, Petition::HIDDEN_STATE)
+        popular = Petition.all_popular_in_constituency(constituency_1, 4)
+        expect(popular).not_to include(petition_1)
+      end
+
+      it 'includes open petitions with signatures from the supplied constituency_id ordered by the count of signatures' do
+        popular = Petition.all_popular_in_constituency(constituency_1, 2)
+        expect(popular).to eq [petition_3, petition_1]
+      end
+
+      it 'adds the constituency_signature_count attribute to the retrieved petitions' do
+        most_popular = Petition.all_popular_in_constituency(constituency_1, 1).first
+        expect(most_popular).to respond_to :constituency_signature_count
+        expect(most_popular.constituency_signature_count).to eq 30
+      end
+
+      it 'returns an array, not a scope' do
+        expect(Petition.all_popular_in_constituency(constituency_1, 1)).to be_an Array
+      end
+    end
+
     describe 'tagged_with' do
       let!(:petition_1) { FactoryGirl.create(:petition, admin_notes: '[foo]') }
       let!(:petition_2) { FactoryGirl.create(:petition, admin_notes: 'foo') }


### PR DESCRIPTION
We get a lot of requests for top petitions in a constituency but the current page only shows open petitions. To reduce the need for running custom database queries we can add a page to show all petitions and then direct any FoI requests to the page for the constituency.