### PR TITLE
Improve local petition result pages

### DIFF
--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -2,6 +2,7 @@ require 'postcode_sanitizer'
 
 class LocalPetitionsController < ApplicationController
   respond_to :html
+  respond_to :json, only: [:show, :all]
 
   before_action :sanitize_postcode, only: :index
   before_action :find_by_postcode, if: :postcode?, only: :index

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -1,8 +1,9 @@
 require 'postcode_sanitizer'
+require 'csv'
 
 class LocalPetitionsController < ApplicationController
   respond_to :html
-  respond_to :json, only: [:show, :all]
+  respond_to :csv, :json, only: [:show, :all]
 
   before_action :sanitize_postcode, only: :index
   before_action :find_by_postcode, if: :postcode?, only: :index
@@ -10,6 +11,8 @@ class LocalPetitionsController < ApplicationController
   before_action :find_petitions, if: :constituency?, only: :show
   before_action :find_all_petitions, if: :constituency?, only: :all
   before_action :redirect_to_constituency, if: :constituency?, only: :index
+
+  after_action :set_content_disposition, if: :csv_request?, only: [:show, :all]
 
   def index
     respond_to do |format|
@@ -57,5 +60,21 @@ class LocalPetitionsController < ApplicationController
 
   def redirect_to_constituency
     redirect_to local_petition_url(@constituency.slug)
+  end
+
+  def csv_request?
+    request.format.symbol == :csv
+  end
+
+  def csv_filename
+    if action_name == 'all'
+      "all-popular-petitions-in-#{@constituency.slug}.csv"
+    else
+      "open-popular-petitions-in-#{@constituency.slug}.csv"
+    end
+  end
+
+  def set_content_disposition
+    response.headers['Content-Disposition'] = "attachment; filename=#{csv_filename}"
   end
 end

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -44,6 +44,10 @@ module CacheHelper
         archived_petition_page?
       end
 
+      def constituency
+        assigns['constituency']
+      end
+
       def create_petition_page
         create_petition_page?
       end

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -212,4 +212,13 @@ module CacheHelper
   def last_debate_outcome_updated_at
     @_last_debate_outcome_updated_at ||= DebateOutcome.maximum(:updated_at)
   end
+
+  def csv_cache(name, options = nil, &block)
+    if controller.respond_to?(:perform_caching) && controller.perform_caching
+      key = ActiveSupport::Cache.expand_cache_key(name, :csv)
+      Rails.cache.fetch(key, options, &block)
+    else
+      yield
+    end
+  end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -263,15 +263,11 @@ class Petition < ActiveRecord::Base
     end
 
     def popular_in_constituency(constituency_id, count = 50)
-      # NOTE: this query is complex, so we'll flatten it at the end
-      # to prevent chaining things off the end that might break it.
-      popular_in(constituency_id, count).for_state(OPEN_STATE).to_a
+      popular_in(constituency_id, count).for_state(OPEN_STATE)
     end
 
     def all_popular_in_constituency(constituency_id, count = 50)
-      # NOTE: this query is complex, so we'll flatten it at the end
-      # to prevent chaining things off the end that might break it.
-      popular_in(constituency_id, count).for_state(PUBLISHED_STATES).to_a
+      popular_in(constituency_id, count).for_state(PUBLISHED_STATES)
     end
 
     def tagged_with(tag)

--- a/app/views/local_petitions/_petitions.json.jbuilder
+++ b/app/views/local_petitions/_petitions.json.jbuilder
@@ -1,0 +1,14 @@
+json.constituency constituency.name
+
+json.mp do
+  json.name constituency.mp_name
+  json.url constituency.mp_url
+end
+
+json.petitions petitions do |petition|
+  json.action petition.action
+  json.url petition_url(petition)
+  json.state petition.state
+  json.constituency_signature_count petition.constituency_signature_count
+  json.total_signature_count petition.signature_count
+end

--- a/app/views/local_petitions/all.csv.ruby
+++ b/app/views/local_petitions/all.csv.ruby
@@ -1,0 +1,15 @@
+csv_cache [:all_local_petitions, @constituency], expires_in: 5.minutes do
+  CSV.generate do |csv|
+    csv << ['Petition', 'URL', 'State', 'Local Signatures', 'Total Signatures']
+
+    @petitions.each do |petition|
+      csv << [
+        petition.action,
+        petition_url(petition),
+        petition.state,
+        petition.constituency_signature_count,
+        petition.signature_count
+      ]
+    end
+  end
+end

--- a/app/views/local_petitions/all.html.erb
+++ b/app/views/local_petitions/all.html.erb
@@ -1,33 +1,35 @@
-<h1 class="page-title">
-  Popular petitions in the constituency of <%= @constituency.name %>
-</h1>
+<%= cache_for :all_local_petitions_page do %>
+  <h1 class="page-title">
+    Popular petitions in the constituency of <%= @constituency.name %>
+  </h1>
 
-<p class="heading-link">
-  <%= link_to "View open popular petitions in #{@constituency.name}", local_petition_path(@constituency), class: 'view-all' %>
-</p>
+  <p class="heading-link">
+    <%= link_to "View open popular petitions in #{@constituency.name}", local_petition_path(@constituency), class: 'view-all' %>
+  </p>
 
-<% if @constituency.sitting_mp? %>
-  <p class="lede">Your member of parliament is <%= link_to @constituency.mp_name, @constituency.mp_url, rel: 'external' %></p>
-<% end %>
-
-<div class="section-panel local-petitions">
-  <% if @petitions.empty? %>
-    <p>No petitions are popular in your constituency.</p>
-  <% else %>
-    <ol>
-      <% @petitions.each do |petition| %>
-        <li class="petition-item petition-<%= petition.state %>">
-          <h3><%= link_to petition.action, petition_path(petition) %></h3>
-          <p>
-            <%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
-            <% if petition.closed? %>
-              (<%= signature_count(:in_total, petition.signature_count) %>, now closed)
-            <% else %>
-              (<%= signature_count(:in_total, petition.signature_count) %>)
-            <% end %>
-          </p>
-        </li>
-      <% end -%>
-    </ol>
+  <% if @constituency.sitting_mp? %>
+    <p class="lede">Your member of parliament is <%= link_to @constituency.mp_name, @constituency.mp_url, rel: 'external' %></p>
   <% end %>
-</div>
+
+  <div class="section-panel local-petitions">
+    <% if @petitions.empty? %>
+      <p>No petitions are popular in your constituency.</p>
+    <% else %>
+      <ol>
+        <% @petitions.each do |petition| %>
+          <li class="petition-item petition-<%= petition.state %>">
+            <h3><%= link_to petition.action, petition_path(petition) %></h3>
+            <p>
+              <%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
+              <% if petition.closed? %>
+                (<%= signature_count(:in_total, petition.signature_count) %>, now closed)
+              <% else %>
+                (<%= signature_count(:in_total, petition.signature_count) %>)
+              <% end %>
+            </p>
+          </li>
+        <% end -%>
+      </ol>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/local_petitions/all.html.erb
+++ b/app/views/local_petitions/all.html.erb
@@ -35,7 +35,7 @@
 
   <ul class="petition-meta">
     <li class="meta-json">
-      <span class="note"><%= link_to 'Get this data in JSON format', all_local_petition_path(@constituency, :json) %></span>
+      <span class="note">Get this data in <%= link_to 'JSON', all_local_petition_path(@constituency, :json) %> or <%= link_to 'CSV', all_local_petition_path(@constituency, :csv) %> format</span>
     </li>
   </ul>
 <% end %>

--- a/app/views/local_petitions/all.html.erb
+++ b/app/views/local_petitions/all.html.erb
@@ -32,4 +32,10 @@
       </ol>
     <% end %>
   </div>
+
+  <ul class="petition-meta">
+    <li class="meta-json">
+      <span class="note"><%= link_to 'Get this data in JSON format', all_local_petition_path(@constituency, :json) %></span>
+    </li>
+  </ul>
 <% end %>

--- a/app/views/local_petitions/all.json.jbuilder
+++ b/app/views/local_petitions/all.json.jbuilder
@@ -1,0 +1,3 @@
+json.cache! [:all_local_petitions, @constituency], expires_in: 5.minutes do
+  json.partial! 'petitions', petitions: @petitions, constituency: @constituency
+end

--- a/app/views/local_petitions/show.csv.ruby
+++ b/app/views/local_petitions/show.csv.ruby
@@ -1,0 +1,15 @@
+csv_cache [:local_petitions, @constituency], expires_in: 5.minutes do
+  CSV.generate do |csv|
+    csv << ['Petition', 'URL', 'State', 'Local Signatures', 'Total Signatures']
+
+    @petitions.each do |petition|
+      csv << [
+        petition.action,
+        petition_url(petition),
+        petition.state,
+        petition.constituency_signature_count,
+        petition.signature_count
+      ]
+    end
+  end
+end

--- a/app/views/local_petitions/show.html.erb
+++ b/app/views/local_petitions/show.html.erb
@@ -29,7 +29,7 @@
 
   <ul class="petition-meta">
     <li class="meta-json">
-      <span class="note"><%= link_to 'Get this data in JSON format', local_petition_path(@constituency, :json) %></span>
+      <span class="note">Get this data in <%= link_to 'JSON', local_petition_path(@constituency, :json) %> or <%= link_to 'CSV', local_petition_path(@constituency, :csv) %> format</span>
     </li>
   </ul>
 <% end %>

--- a/app/views/local_petitions/show.html.erb
+++ b/app/views/local_petitions/show.html.erb
@@ -1,27 +1,29 @@
-<h1 class="page-title">
-  Popular open petitions in the constituency of <%= @constituency.name %>
-</h1>
+<%= cache_for :local_petitions_page do %>
+  <h1 class="page-title">
+    Popular open petitions in the constituency of <%= @constituency.name %>
+  </h1>
 
-<p class="heading-link">
-  <%= link_to "View all popular petitions in #{@constituency.name}", all_local_petition_path(@constituency), class: 'view-all' %>
-</p>
+  <p class="heading-link">
+    <%= link_to "View all popular petitions in #{@constituency.name}", all_local_petition_path(@constituency), class: 'view-all' %>
+  </p>
 
-<% if @constituency.sitting_mp? %>
-  <p class="lede">Your member of parliament is <%= link_to @constituency.mp_name, @constituency.mp_url, rel: 'external' %></p>
-<% end %>
-
-<div class="section-panel local-petitions">
-  <% if @petitions.empty? %>
-    <p>No petitions are popular in your constituency.</p>
-  <% else %>
-    <ol>
-      <% @petitions.each do |petition| %>
-        <li class="petition-item petition-<%= petition.state %>">
-          <h3><%= link_to petition.action, petition_path(petition) %></h3>
-          <p><%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
-          (<%= signature_count(:in_total, petition.signature_count) %>)</p>
-        </li>
-      <% end -%>
-    </ol>
+  <% if @constituency.sitting_mp? %>
+    <p class="lede">Your member of parliament is <%= link_to @constituency.mp_name, @constituency.mp_url, rel: 'external' %></p>
   <% end %>
-</div>
+
+  <div class="section-panel local-petitions">
+    <% if @petitions.empty? %>
+      <p>No petitions are popular in your constituency.</p>
+    <% else %>
+      <ol>
+        <% @petitions.each do |petition| %>
+          <li class="petition-item petition-<%= petition.state %>">
+            <h3><%= link_to petition.action, petition_path(petition) %></h3>
+            <p><%= signature_count(:in_your_constituency, petition.constituency_signature_count, constituency: @constituency.name) %><br/>
+            (<%= signature_count(:in_total, petition.signature_count) %>)</p>
+          </li>
+        <% end -%>
+      </ol>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/local_petitions/show.html.erb
+++ b/app/views/local_petitions/show.html.erb
@@ -26,4 +26,10 @@
       </ol>
     <% end %>
   </div>
+
+  <ul class="petition-meta">
+    <li class="meta-json">
+      <span class="note"><%= link_to 'Get this data in JSON format', local_petition_path(@constituency, :json) %></span>
+    </li>
+  </ul>
 <% end %>

--- a/app/views/local_petitions/show.json.jbuilder
+++ b/app/views/local_petitions/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.cache! [:local_petitions, @constituency], expires_in: 5.minutes do
+  json.partial! 'petitions', petitions: @petitions, constituency: @constituency
+end

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -25,6 +25,18 @@ home_page:
   options:
     expires_in: 300
 
+local_petitions_page:
+  keys:
+    - :constituency
+  options:
+    expires_in: 300
+
+all_local_petitions_page:
+  keys:
+    - :constituency
+  options:
+    expires_in: 300
+
 petition:
   keys:
     - :petition

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -39,6 +39,27 @@ Feature: Freya searches petitions by constituency
     And I should see that closed petitions are identified
     And the petitions I see should be ordered by my fellow constituents level of support
 
+  Scenario: Downloading the JSON data for open local petitions
+    Given I am on the home page
+    When I search for petitions local to me in "BH20 6HH"
+    Then I should be on the local petitions results page
+    And the markup should be valid
+    When I click the JSON link
+    Then I should be on the local petitions JSON page
+    And the JSON should be valid
+
+  Scenario: Downloading the JSON data for all local petitions
+    Given I am on the home page
+    When I search for petitions local to me in "BH20 6HH"
+    Then I should be on the local petitions results page
+    And the markup should be valid
+    When I click the view all local petitions
+    Then I should be on the all local petitions results page
+    And the markup should be valid
+    When I click the JSON link
+    Then I should be on the all local petitions JSON page
+    And the JSON should be valid
+
   Scenario: Searching for local petitions when the api is down
     Given the constituency api is down
     And I am on the home page

--- a/features/freya_searches_for_petitions_by_constituency.feature
+++ b/features/freya_searches_for_petitions_by_constituency.feature
@@ -60,6 +60,25 @@ Feature: Freya searches petitions by constituency
     Then I should be on the all local petitions JSON page
     And the JSON should be valid
 
+  Scenario: Downloading the CSV data for open local petitions
+    Given I am on the home page
+    When I search for petitions local to me in "BH20 6HH"
+    Then I should be on the local petitions results page
+    And the markup should be valid
+    When I click the CSV link
+    Then I should get a download with the filename "open-popular-petitions-in-south-dorset.csv"
+
+  Scenario: Downloading the CSV data for all local petitions
+    Given I am on the home page
+    When I search for petitions local to me in "BH20 6HH"
+    Then I should be on the local petitions results page
+    And the markup should be valid
+    When I click the view all local petitions
+    Then I should be on the all local petitions results page
+    And the markup should be valid
+    When I click the CSV link
+    Then I should get a download with the filename "all-popular-petitions-in-south-dorset.csv"
+
   Scenario: Searching for local petitions when the api is down
     Given the constituency api is down
     And I am on the home page

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -160,3 +160,11 @@ end
 Then(/^I should see that closed petitions are identified$/) do
   expect(page).to have_text("now closed")
 end
+
+When(/^I click the JSON link$/) do
+  click_on "Get this data in JSON format"
+end
+
+Then(/^the JSON should be valid$/) do
+  expect { JSON.parse(page.body) }.not_to raise_error
+end

--- a/features/step_definitions/constituency_search_steps.rb
+++ b/features/step_definitions/constituency_search_steps.rb
@@ -162,9 +162,13 @@ Then(/^I should see that closed petitions are identified$/) do
 end
 
 When(/^I click the JSON link$/) do
-  click_on "Get this data in JSON format"
+  click_on "JSON"
 end
 
 Then(/^the JSON should be valid$/) do
   expect { JSON.parse(page.body) }.not_to raise_error
+end
+
+When(/^I click the CSV link$/) do
+  click_on "CSV"
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -53,8 +53,14 @@ module NavigationHelpers
     when /^the local petitions results page$/
       local_petition_url(@my_constituency.slug)
 
+    when /^the local petitions JSON page$/
+      local_petition_url(@my_constituency.slug, :json)
+
     when /^the all local petitions results page$/
       all_local_petition_url(@my_constituency.slug)
+
+    when /^the all local petitions JSON page$/
+      all_local_petition_url(@my_constituency.slug, :json)
 
     else
       begin

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -360,4 +360,54 @@ RSpec.describe CacheHelper, type: :helper do
       end
     end
   end
+
+  describe "#csv_cache" do
+    after do
+      Rails.cache.delete("csv/foo")
+    end
+
+    context "when caching is not enabled" do
+      before do
+        allow(controller).to receive(:perform_caching).and_return(false)
+      end
+
+      context "and the cache key is not set" do
+        it "calls the block" do
+          expect { |b| helper.csv_cache("foo", nil, &b) }.to yield_control
+        end
+      end
+
+      context "and the cache key is set" do
+        before do
+          Rails.cache.write("csv/foo", "bar")
+        end
+
+        it "calls the block" do
+          expect { |b| helper.csv_cache("foo", nil, &b) }.to yield_control
+        end
+      end
+    end
+
+    context "when caching is enabled" do
+      before do
+        allow(controller).to receive(:perform_caching).and_return(true)
+      end
+
+      context "and the cache key is not set" do
+        it "calls the block" do
+          expect { |b| helper.csv_cache("foo", nil, &b) }.to yield_control
+        end
+      end
+
+      context "and the cache key is set" do
+        before do
+          Rails.cache.write("csv/foo", "bar")
+        end
+
+        it "doesn't call the block" do
+          expect { |b| helper.csv_cache("foo", nil, &b) }.not_to yield_control
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe CacheHelper, type: :helper do
       end
     end
 
+    describe "#constituency" do
+      context "when the @constituency instance variable is not set" do
+        it "returns nil" do
+          expect(keys.constituency).to be_nil
+        end
+      end
+
+      context "when the @constituency instance variable is set" do
+        let(:constituency) { double(:constituency) }
+
+        before do
+          assign('constituency', constituency)
+        end
+
+        it "returns the petition" do
+          expect(keys.constituency).to eq(constituency)
+        end
+      end
+    end
+
     describe "#create_petition_page" do
       it "delegates to the template context" do
         expect(helper).to receive(:create_petition_page?).and_return(true)

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -514,8 +514,8 @@ RSpec.describe Petition, type: :model do
         expect(most_popular.constituency_signature_count).to eq 30
       end
 
-      it 'returns an array, not a scope' do
-        expect(Petition.popular_in_constituency(constituency_1, 1)).to be_an Array
+      it 'returns a scope' do
+        expect(Petition.popular_in_constituency(constituency_1, 1)).to be_an ActiveRecord::Relation
       end
     end
 
@@ -574,8 +574,8 @@ RSpec.describe Petition, type: :model do
         expect(most_popular.constituency_signature_count).to eq 30
       end
 
-      it 'returns an array, not a scope' do
-        expect(Petition.all_popular_in_constituency(constituency_1, 1)).to be_an Array
+      it 'returns a scope' do
+        expect(Petition.all_popular_in_constituency(constituency_1, 1)).to be_an ActiveRecord::Relation
       end
     end
 

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -66,6 +66,50 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     end
   end
 
+  shared_examples 'a route that supports html, json and csv formats' do |headers_only: false|
+    unless headers_only
+      it 'supports json via extension' do
+        get url + '.json', params
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq :json
+      end
+
+      it 'supports csv via extension' do
+        get url + '.csv', params
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq :csv
+      end
+
+      it 'does not support xml via extension' do
+        get url + '.xml', params
+        expect(response.status).to eq 406
+      end
+    end
+
+    it 'supports html' do
+      get url, params
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :html
+    end
+
+    it 'supports json via accepts header' do
+      get url, params, {'Accept' => 'application/json'}
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :json
+    end
+
+    it 'supports csv via accepts header' do
+      get url, params, {'Accept' => 'text/csv'}
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq :csv
+    end
+
+    it 'does not support xml via accepts header' do
+      get url, params,  {'Accept' => 'application/xml'}
+      expect(response.status).to eq 406
+    end
+  end
+
   shared_examples 'a POST route where failure only supports html formats' do
     around do |example|
       begin
@@ -140,7 +184,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     let(:constituency) { FactoryGirl.create(:constituency) }
     let(:params) { {} }
 
-    it_behaves_like 'a route that supports html and json formats'
+    it_behaves_like 'a route that supports html, json and csv formats'
   end
 
   context 'the petitions/local/all results url' do
@@ -148,7 +192,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     let(:constituency) { FactoryGirl.create(:constituency) }
     let(:params) { {} }
 
-    it_behaves_like 'a route that supports html and json formats'
+    it_behaves_like 'a route that supports html, json and csv formats'
   end
 
   context 'the petitions show url' do

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -140,7 +140,15 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     let(:constituency) { FactoryGirl.create(:constituency) }
     let(:params) { {} }
 
-    it_behaves_like 'a route that only supports html formats'
+    it_behaves_like 'a route that supports html and json formats'
+  end
+
+  context 'the petitions/local/all results url' do
+    let(:url) { "/petitions/local/#{constituency.slug}/all" }
+    let(:constituency) { FactoryGirl.create(:constituency) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that supports html and json formats'
   end
 
   context 'the petitions show url' do


### PR DESCRIPTION
A view for all popular local petitions was adding in #554 to help address FoI requests. It's likely that those requests will want it in data form too so provide an option to get the data in JSON or CSV format.

Also wrap some fragment caching around all the format response to ensure that the database doesn't become overloaded when responding to requests for popular local petitions.
