### PR TITLE
Clarify unsubscribe wording

### DIFF
--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -8,12 +8,17 @@ class PetitionMailer < ApplicationMailer
 
   def email_signer(petition, signature, email)
     @petition, @signature, @email = petition, signature, email
-    mail to: @signature.email, subject: subject_for(:email_signer)
+
+    mail to: @signature.email,
+      subject: subject_for(:email_signer),
+      list_unsubscribe: unsubscribe_url
   end
 
   def email_creator(petition, signature, email)
     @petition, @signature, @email = petition, signature, email
-    mail to: @signature.email, subject: subject_for(:email_creator)
+    mail to: @signature.email,
+      subject: subject_for(:email_creator),
+      list_unsubscribe: unsubscribe_url
   end
 
   def special_resend_of_email_confirmation_for_signer(signature)
@@ -23,7 +28,10 @@ class PetitionMailer < ApplicationMailer
 
   def notify_creator_that_petition_is_published(signature)
     @signature, @petition = signature, signature.petition
-    mail to: @signature.email, subject: subject_for(:notify_creator_that_petition_is_published)
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_creator_that_petition_is_published),
+      list_unsubscribe: unsubscribe_url
   end
 
   def notify_sponsor_that_petition_is_published(signature)
@@ -43,12 +51,18 @@ class PetitionMailer < ApplicationMailer
 
   def notify_signer_of_threshold_response(petition, signature)
     @petition, @signature, @government_response = petition, signature, petition.government_response
-    mail to: @signature.email, subject: subject_for(:notify_signer_of_threshold_response)
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_signer_of_threshold_response),
+      list_unsubscribe: unsubscribe_url
   end
 
   def notify_creator_of_threshold_response(petition, signature)
     @petition, @signature, @government_response = petition, signature, petition.government_response
-    mail to: @signature.email, subject: subject_for(:notify_creator_of_threshold_response)
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_creator_of_threshold_response),
+      list_unsubscribe: unsubscribe_url
   end
 
   def notify_creator_of_closing_date_change(signature)
@@ -65,30 +79,39 @@ class PetitionMailer < ApplicationMailer
     @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
 
     if @debate_outcome.debated?
-      mail to: @signature.email, subject: subject_for(:notify_signer_of_positive_debate_outcome)
+      subject = subject_for(:notify_signer_of_positive_debate_outcome)
     else
-      mail to: @signature.email, subject: subject_for(:notify_signer_of_negative_debate_outcome)
+      subject = subject_for(:notify_signer_of_negative_debate_outcome)
     end
+
+    mail to: @signature.email, subject: subject, list_unsubscribe: unsubscribe_url
   end
 
   def notify_creator_of_debate_outcome(petition, signature)
     @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
 
     if @debate_outcome.debated?
-      mail to: @signature.email, subject: subject_for(:notify_creator_of_positive_debate_outcome)
+      subject = subject_for(:notify_creator_of_positive_debate_outcome)
     else
-      mail to: @signature.email, subject: subject_for(:notify_creator_of_negative_debate_outcome)
+      subject = subject_for(:notify_creator_of_negative_debate_outcome)
     end
+
+    mail to: @signature.email, subject: subject, list_unsubscribe: unsubscribe_url
   end
 
   def notify_signer_of_debate_scheduled(petition, signature)
     @petition, @signature = petition, signature
-    mail to: @signature.email, subject: subject_for(:notify_signer_of_debate_scheduled)
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_signer_of_debate_scheduled),
+      list_unsubscribe: unsubscribe_url
   end
 
   def notify_creator_of_debate_scheduled(petition, signature)
     @petition, @signature = petition, signature
-    mail to: @signature.email, subject: subject_for(:notify_creator_of_debate_scheduled)
+    mail to: @signature.email,
+      subject: subject_for(:notify_creator_of_debate_scheduled),
+      list_unsubscribe: unsubscribe_url
   end
 
   private
@@ -115,5 +138,9 @@ class PetitionMailer < ApplicationMailer
         options[:subject] = @email.subject
       end
     end
+  end
+
+  def unsubscribe_url
+    "<#{unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token)}>"
   end
 end

--- a/app/views/petition_mailer/email_creator.html.erb
+++ b/app/views/petition_mailer/email_creator.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -15,4 +15,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/email_creator.text.erb
+++ b/app/views/petition_mailer/email_creator.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -15,4 +15,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/email_signer.html.erb
+++ b/app/views/petition_mailer/email_signer.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -15,4 +15,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/email_signer.text.erb
+++ b/app/views/petition_mailer/email_signer.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -15,4 +15,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -38,4 +38,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -39,4 +39,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -18,4 +18,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -18,4 +18,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -30,4 +30,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -30,4 +30,4 @@ Thanks,
 
 --
 You’re receiving this email because you created this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -38,4 +38,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -39,4 +39,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -18,4 +18,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -18,4 +18,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -1,5 +1,5 @@
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
 <hr>
 
 <p>Dear <%= @signature.name %>,</p>
@@ -30,4 +30,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting updates about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -1,5 +1,5 @@
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
 --
 
 Dear <%= @signature.name %>,
@@ -30,4 +30,4 @@ Thanks,
 
 --
 You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
-To unsubscribe from this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+To unsubscribe from getting updates about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -267,6 +267,10 @@ RSpec.describe PetitionMailer, type: :mailer do
         it "includes an unsubscribe link" do
           expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
         end
+
+        it "has a List-Unsubscribe header" do
+          expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+        end
       end
 
       shared_examples_for "a positive debate outcome email" do
@@ -382,6 +386,10 @@ RSpec.describe PetitionMailer, type: :mailer do
         it "includes an unsubscribe link" do
           expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
         end
+
+        it "has a List-Unsubscribe header" do
+          expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+        end
       end
 
       shared_examples_for "a positive debate outcome email" do
@@ -493,6 +501,10 @@ RSpec.describe PetitionMailer, type: :mailer do
       it "includes an unsubscribe link" do
         expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
       end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+      end
     end
 
     context "when the signature is the creator" do
@@ -551,6 +563,10 @@ RSpec.describe PetitionMailer, type: :mailer do
 
       it "includes an unsubscribe link" do
         expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+      end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
       end
 
       it "includes the message body" do


### PR DESCRIPTION
Some people are thinking that unsubscribe links will remove their name from a petition so clarify the wording to make it clear that it's just about not receiving future updates.