### PR TITLE
Add GMail action buttons

### DIFF
--- a/app/views/petition_mailer/_creator_footer.html.erb
+++ b/app/views/petition_mailer/_creator_footer.html.erb
@@ -1,0 +1,13 @@
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+
+<div itemscope itemtype="http://schema.org/EmailMessage">
+  <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ConfirmAction">
+    <meta itemprop="name" content="Unsubscribe" />
+    <div itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler">
+      <link itemprop="url" href="<%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>" />
+    </div>
+  </div>
+  <meta itemprop="description" content="Click to unsubscribe from getting emails about this petition" />
+</div>

--- a/app/views/petition_mailer/_creator_header.html.erb
+++ b/app/views/petition_mailer/_creator_header.html.erb
@@ -1,0 +1,3 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>

--- a/app/views/petition_mailer/_signer_footer.html.erb
+++ b/app/views/petition_mailer/_signer_footer.html.erb
@@ -1,0 +1,13 @@
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+
+<div itemscope itemtype="http://schema.org/EmailMessage">
+  <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ConfirmAction">
+    <meta itemprop="name" content="Unsubscribe" />
+    <div itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler">
+      <link itemprop="url" href="<%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>" />
+    </div>
+  </div>
+  <meta itemprop="description" content="Click to unsubscribe from getting emails about this petition" />
+</div>

--- a/app/views/petition_mailer/_signer_header.html.erb
+++ b/app/views/petition_mailer/_signer_header.html.erb
@@ -1,0 +1,3 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>

--- a/app/views/petition_mailer/email_confirmation_for_signer.html.erb
+++ b/app/views/petition_mailer/email_confirmation_for_signer.html.erb
@@ -5,3 +5,13 @@
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
+
+<div itemscope itemtype="http://schema.org/EmailMessage">
+  <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ConfirmAction">
+    <meta itemprop="name" content="Sign Petition" />
+    <div itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler">
+      <link itemprop="url" href="<%=verify_signature_url(@signature, token: @signature.perishable_token) %>" />
+    </div>
+  </div>
+  <meta itemprop="description" content="Click to sign the petition '<%= @petition.action %>'" />
+</div>

--- a/app/views/petition_mailer/email_creator.html.erb
+++ b/app/views/petition_mailer/email_creator.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'creator_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -13,6 +11,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'creator_footer' %>

--- a/app/views/petition_mailer/email_signer.html.erb
+++ b/app/views/petition_mailer/email_signer.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'signer_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -13,6 +11,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'signer_footer' %>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'creator_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -36,6 +34,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'creator_footer' %>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'creator_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -16,6 +14,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'creator_footer' %>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'creator_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -28,6 +26,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'creator_footer' %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'signer_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -36,6 +34,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<%= render 'signer_footer' %>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'signer_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -16,6 +14,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'signer_footer' %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -1,6 +1,4 @@
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
-<hr>
+<%= render 'signer_header' %>
 
 <p>Dear <%= @signature.name %>,</p>
 
@@ -28,6 +26,4 @@
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>
 
-<hr>
-<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<%= render 'signer_footer' %>


### PR DESCRIPTION
Allow one-click actions to sign or unsubscribe.

To complete this we need to go through the whitelisting process as described here:

https://developers.google.com/gmail/markup/registering-with-google

As far as I can see we're in good shape with the guidelines but it's hard to tell on the more subjective ones like "A very very low rate of spam complaints from users".

We need to send the emails to the whitelist address from the production servers and the easiest way to do this is deploy and signup the address to a petition. That will work for the 'Sign Petition' action but we'll need to manually validate and send another email with the 'Unsubscribe' action.