### PR TITLE
Add trending petition journals

### DIFF
--- a/app/helpers/signature_helper.rb
+++ b/app/helpers/signature_helper.rb
@@ -11,6 +11,10 @@ module SignatureHelper
     t(:"#{key}.html", options)
   end
 
+  def signatures_by_hour(petition)
+    TrendingSignatureCollection.new(petition).hourly_intervals
+  end
+
   private
 
   def render_signature_hidden_details(stage_manager, form, options)

--- a/app/jobs/petition_signed_data_update_job.rb
+++ b/app/jobs/petition_signed_data_update_job.rb
@@ -8,6 +8,7 @@ class PetitionSignedDataUpdateJob < ApplicationJob
   def perform(signature)
     ConstituencyPetitionJournal.record_new_signature_for(signature)
     CountryPetitionJournal.record_new_signature_for(signature)
+    TrendingPetitionJournal.record_new_signature_for(signature)
     signature.petition.increment_signature_count!
 
     if signature.sponsor?

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -71,6 +71,7 @@ class Petition < ActiveRecord::Base
   has_many :sponsor_signatures, :through => :sponsors, :source => :signature
   has_many :country_petition_journals, :dependent => :destroy
   has_many :constituency_petition_journals, :dependent => :destroy
+  has_many :trending_petition_journals, :dependent => :destroy
   has_many :emails, :dependent => :destroy
   has_many :invalidations
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -114,6 +114,13 @@ class Signature < ActiveRecord::Base
     count(:all)
   end
 
+  def self.validated_dates
+    validated.
+    where.not(validated_at: nil).
+    order("date").
+    pluck("DISTINCT date(validated_at) as date")
+  end
+
   scope :in_days, ->(number_of_days) { validated.where("updated_at > ?", number_of_days.day.ago) }
   scope :matching, ->(signature) { where(email: signature.email,
                                          name: signature.name,

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -45,6 +45,7 @@ class Signature < ActiveRecord::Base
       now = Time.current
       ConstituencyPetitionJournal.invalidate_signature_for(self, now)
       CountryPetitionJournal.invalidate_signature_for(self, now)
+      TrendingPetitionJournal.invalidate_signature_for(self, now)
       petition.decrement_signature_count!(now)
     end
   end
@@ -208,6 +209,7 @@ class Signature < ActiveRecord::Base
     if update_signature_counts
       ConstituencyPetitionJournal.invalidate_signature_for(self, now)
       CountryPetitionJournal.invalidate_signature_for(self, now)
+      TrendingPetitionJournal.invalidate_signature_for(self, now)
       petition.decrement_signature_count!(now)
     end
   end

--- a/app/models/signature_interval.rb
+++ b/app/models/signature_interval.rb
@@ -1,0 +1,9 @@
+class SignatureInterval
+  attr_reader :starts_at, :ends_at, :count
+
+  def initialize(starts_at:, ends_at:, count:)
+    @starts_at = starts_at
+    @ends_at = ends_at
+    @count = count
+  end
+end

--- a/app/models/trending_petition_journal.rb
+++ b/app/models/trending_petition_journal.rb
@@ -1,0 +1,6 @@
+class TrendingPetitionJournal < ActiveRecord::Base
+  belongs_to :petition
+
+  validates :petition, presence: true
+  validates :date, presence: true
+end

--- a/app/models/trending_petition_journal.rb
+++ b/app/models/trending_petition_journal.rb
@@ -3,4 +3,45 @@ class TrendingPetitionJournal < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :date, presence: true
+
+  class << self
+    def for(petition, date = Date.current)
+      begin
+        find_or_create_by(
+          petition: petition,
+          date: date
+        )
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+    end
+
+    def record_new_signature_for(signature, now = Time.current)
+      unless unrecordable?(signature)
+        journal = self.for(signature.petition, signature.validated_at.to_date)
+        count_column = signature_count_column(signature)
+        updates = "#{count_column} = #{count_column} + 1, updated_at = :now"
+        unscoped.where(id: journal.id).update_all([updates, now: now])
+      end
+    end
+
+    def invalidate_signature_for(signature, now = Time.current)
+      unless unrecordable?(signature)
+        journal = self.for(signature.petition, signature.validated_at.to_date)
+        count_column = signature_count_column(signature)
+        updates = "#{count_column} = greatest(#{count_column} - 1, 0), updated_at = :now"
+        unscoped.where(id: journal.id).update_all([updates, now: now])
+      end
+    end
+
+    private
+
+    def unrecordable?(signature)
+      signature.nil? || signature.petition.nil? || !signature.validated_at?
+    end
+
+    def signature_count_column(signature)
+      "hour_#{signature.validated_at.strftime('%-k')}_signature_count"
+    end
+  end
 end

--- a/app/models/trending_signature_collection.rb
+++ b/app/models/trending_signature_collection.rb
@@ -1,0 +1,60 @@
+class TrendingSignatureCollection
+  HOURS = (0..23)
+
+  def initialize(petition)
+    @petition = petition
+  end
+
+  def hourly_intervals
+    Enumerator.new do |yielder|
+      signature_dates.each do |date|
+        HOURS.each do |hour|
+          starts_at = date.to_time.change(hour: hour)
+          ends_at = date.to_time.change(hour: hour + 1)
+
+          yielder << SignatureInterval.new(
+            starts_at: starts_at, ends_at: ends_at, count: signature_count(date, hour)
+          ) unless starts_at.future?
+        end
+      end
+    end
+  end
+
+  private
+
+  attr_reader :petition
+
+  def signature_dates
+    if trending_petition_journals.any?
+      (first_signature_date..last_signature_date)
+    else
+      []
+    end
+  end
+
+  def journal(date)
+    trending_petition_journals.find do |journal|
+      journal.date == date
+    end || TrendingPetitionJournal.new
+  end
+
+  def signature_count(date, hour)
+    journal(date).public_send("hour_#{hour}_signature_count")
+  end
+
+  def trending_signature_dates
+    trending_petition_journals.map(&:date)
+  end
+
+  def first_signature_date
+    trending_signature_dates.first
+  end
+
+  def last_signature_date
+    trending_signature_dates.last
+  end
+
+  def trending_petition_journals
+    @_trending_petition_journals ||= petition.trending_petition_journals.order(:date)
+  end
+end

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -74,5 +74,11 @@ json.attributes do
       json.mp constituency.mp_name
       json.signature_count constituency.signature_count
     end
+
+    json.signatures_by_hour signatures_by_hour(petition) do |signature_interval|
+      json.starts_at api_date_format(signature_interval.starts_at)
+      json.ends_at api_date_format(signature_interval.ends_at)
+      json.signature_count signature_interval.count
+    end
   end
 end

--- a/db/migrate/20170226133907_create_trending_petition_journals.rb
+++ b/db/migrate/20170226133907_create_trending_petition_journals.rb
@@ -1,0 +1,42 @@
+class CreateTrendingPetitionJournals < ActiveRecord::Migration
+  def up
+    create_table :trending_petition_journals do |t|
+      t.references :petition, null: false
+      t.date :date, null: false
+
+      t.integer :hour_0_signature_count, default: 0, null: false
+      t.integer :hour_1_signature_count, default: 0, null: false
+      t.integer :hour_2_signature_count, default: 0, null: false
+      t.integer :hour_3_signature_count, default: 0, null: false
+      t.integer :hour_4_signature_count, default: 0, null: false
+      t.integer :hour_5_signature_count, default: 0, null: false
+      t.integer :hour_6_signature_count, default: 0, null: false
+      t.integer :hour_7_signature_count, default: 0, null: false
+      t.integer :hour_8_signature_count, default: 0, null: false
+      t.integer :hour_9_signature_count, default: 0, null: false
+      t.integer :hour_10_signature_count, default: 0, null: false
+      t.integer :hour_11_signature_count, default: 0, null: false
+      t.integer :hour_12_signature_count, default: 0, null: false
+      t.integer :hour_13_signature_count, default: 0, null: false
+      t.integer :hour_14_signature_count, default: 0, null: false
+      t.integer :hour_15_signature_count, default: 0, null: false
+      t.integer :hour_16_signature_count, default: 0, null: false
+      t.integer :hour_17_signature_count, default: 0, null: false
+      t.integer :hour_18_signature_count, default: 0, null: false
+      t.integer :hour_19_signature_count, default: 0, null: false
+      t.integer :hour_20_signature_count, default: 0, null: false
+      t.integer :hour_21_signature_count, default: 0, null: false
+      t.integer :hour_22_signature_count, default: 0, null: false
+      t.integer :hour_23_signature_count, default: 0, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :trending_petition_journals, :petition_id
+    add_index :trending_petition_journals, [:petition_id, :date], unique: true
+  end
+
+  def down
+    drop_table :trending_petition_journals
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -836,6 +836,62 @@ ALTER SEQUENCE tasks_id_seq OWNED BY tasks.id;
 
 
 --
+-- Name: trending_petition_journals; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE trending_petition_journals (
+    id integer NOT NULL,
+    petition_id integer NOT NULL,
+    date date NOT NULL,
+    hour_0_signature_count integer DEFAULT 0 NOT NULL,
+    hour_1_signature_count integer DEFAULT 0 NOT NULL,
+    hour_2_signature_count integer DEFAULT 0 NOT NULL,
+    hour_3_signature_count integer DEFAULT 0 NOT NULL,
+    hour_4_signature_count integer DEFAULT 0 NOT NULL,
+    hour_5_signature_count integer DEFAULT 0 NOT NULL,
+    hour_6_signature_count integer DEFAULT 0 NOT NULL,
+    hour_7_signature_count integer DEFAULT 0 NOT NULL,
+    hour_8_signature_count integer DEFAULT 0 NOT NULL,
+    hour_9_signature_count integer DEFAULT 0 NOT NULL,
+    hour_10_signature_count integer DEFAULT 0 NOT NULL,
+    hour_11_signature_count integer DEFAULT 0 NOT NULL,
+    hour_12_signature_count integer DEFAULT 0 NOT NULL,
+    hour_13_signature_count integer DEFAULT 0 NOT NULL,
+    hour_14_signature_count integer DEFAULT 0 NOT NULL,
+    hour_15_signature_count integer DEFAULT 0 NOT NULL,
+    hour_16_signature_count integer DEFAULT 0 NOT NULL,
+    hour_17_signature_count integer DEFAULT 0 NOT NULL,
+    hour_18_signature_count integer DEFAULT 0 NOT NULL,
+    hour_19_signature_count integer DEFAULT 0 NOT NULL,
+    hour_20_signature_count integer DEFAULT 0 NOT NULL,
+    hour_21_signature_count integer DEFAULT 0 NOT NULL,
+    hour_22_signature_count integer DEFAULT 0 NOT NULL,
+    hour_23_signature_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: trending_petition_journals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE trending_petition_journals_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: trending_petition_journals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE trending_petition_journals_id_seq OWNED BY trending_petition_journals.id;
+
+
+--
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -980,6 +1036,13 @@ ALTER TABLE ONLY sponsors ALTER COLUMN id SET DEFAULT nextval('sponsors_id_seq':
 --
 
 ALTER TABLE ONLY tasks ALTER COLUMN id SET DEFAULT nextval('tasks_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY trending_petition_journals ALTER COLUMN id SET DEFAULT nextval('trending_petition_journals_id_seq'::regclass);
 
 
 --
@@ -1148,6 +1211,14 @@ ALTER TABLE ONLY sponsors
 
 ALTER TABLE ONLY tasks
     ADD CONSTRAINT tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: trending_petition_journals_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY trending_petition_journals
+    ADD CONSTRAINT trending_petition_journals_pkey PRIMARY KEY (id);
 
 
 --
@@ -1529,6 +1600,20 @@ CREATE UNIQUE INDEX index_tasks_on_name ON tasks USING btree (name);
 
 
 --
+-- Name: index_trending_petition_journals_on_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_trending_petition_journals_on_petition_id ON trending_petition_journals USING btree (petition_id);
+
+
+--
+-- Name: index_trending_petition_journals_on_petition_id_and_date; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_trending_petition_journals_on_petition_id_and_date ON trending_petition_journals USING btree (petition_id, date);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1802,4 +1887,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160910054223');
 INSERT INTO schema_migrations (version) VALUES ('20161006095752');
 
 INSERT INTO schema_migrations (version) VALUES ('20161006101123');
+
+INSERT INTO schema_migrations (version) VALUES ('20170226133907');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -313,6 +313,11 @@ FactoryGirl.define do
     association :petition
   end
 
+  factory :trending_petition_journal do
+    association :petition
+    date Date.current
+  end
+
   factory :debate_outcome do
     association :petition, factory: :open_petition
     debated_on { 1.month.from_now.to_date }

--- a/spec/jobs/petition_signed_data_update_job_spec.rb
+++ b/spec/jobs/petition_signed_data_update_job_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe PetitionSignedDataUpdateJob, type: :job do
       expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
       run_the_job
     end
+
+    it "tells the relevant trending petition journal to record a new signature" do
+      expect(TrendingPetitionJournal).to receive(:record_new_signature_for).with(signature)
+      run_the_job
+    end
   end
 
   context "when the petition is pending" do
@@ -79,6 +84,11 @@ RSpec.describe PetitionSignedDataUpdateJob, type: :job do
 
     it 'tells the relevant country petition journal to record a new signature' do
       expect(CountryPetitionJournal).to receive(:record_new_signature_for).with(signature)
+      run_the_job
+    end
+
+    it "tells the relevant trending petition journal to record a new signature" do
+      expect(TrendingPetitionJournal).to receive(:record_new_signature_for).with(signature)
       run_the_job
     end
 

--- a/spec/models/signature_interval_spec.rb
+++ b/spec/models/signature_interval_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe SignatureInterval do
+  let(:starts_at) { Time.now }
+  let(:ends_at) { Time.now + 1.hour }
+  let(:count) { 10 }
+  let(:subject) { described_class.new(starts_at: starts_at, ends_at: ends_at, count: count) }
+
+  describe "#starts_at" do
+    it "returns the starts_at passed in" do
+      expect(subject.starts_at).to eq starts_at
+    end
+  end
+
+  describe "#ends_at" do
+    it "returns the ends_at passed in" do
+      expect(subject.ends_at).to eq ends_at
+    end
+  end
+
+  describe "#count" do
+    it "returns the count passed in" do
+      expect(subject.count).to eq count
+    end
+  end
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -615,6 +615,25 @@ RSpec.describe Signature, type: :model do
     end
   end
 
+  describe ".validated_dates" do
+    let(:now) { Time.parse("1 Jan 2017 08:30") }
+
+    around do |example|
+      travel_to(now) { example.run }
+    end
+
+    it "returns an ordered array of unique dates based on the validated at timestamp" do
+      FactoryGirl.create(:validated_signature, validated_at: now)
+      FactoryGirl.create(:validated_signature, validated_at: now)
+      FactoryGirl.create(:validated_signature, validated_at: now - 1.day)
+      FactoryGirl.create(:validated_signature, validated_at: now - 3.days)
+      FactoryGirl.create(:invalidated_signature, validated_at: now - 4.days)
+
+      expect(described_class.validated_dates)
+        .to eq [Date.parse("29 Dec 2016"), Date.parse("31 Dec 2016"), Date.parse("1 Jan 2017")]
+    end
+  end
+
   describe "#number" do
     let(:attributes) { FactoryGirl.attributes_for(:petition) }
     let(:creator) { FactoryGirl.create(:pending_signature) }

--- a/spec/models/trending_petition_journal_spec.rb
+++ b/spec/models/trending_petition_journal_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe TrendingPetitionJournal, type: :model do
+  it "has a valid factory" do
+    expect(FactoryGirl.build(:trending_petition_journal)).to be_valid
+  end
+
+  describe "defaults" do
+    (0..23).each do |hour|
+      it "returns 0 for the hour_#{hour}_signature_count" do
+        expect(subject.public_send("hour_#{hour}_signature_count")).to eq(0)
+      end
+    end
+  end
+
+  describe "indexes" do
+    it { is_expected.to have_db_index(:petition_id) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:petition) }
+    it { is_expected.to validate_presence_of(:date) }
+  end
+end
+

--- a/spec/models/trending_petition_journal_spec.rb
+++ b/spec/models/trending_petition_journal_spec.rb
@@ -21,5 +21,194 @@ RSpec.describe TrendingPetitionJournal, type: :model do
     it { is_expected.to validate_presence_of(:petition) }
     it { is_expected.to validate_presence_of(:date) }
   end
+
+  describe ".for" do
+    let(:petition) { FactoryGirl.create(:petition) }
+
+    context "when there is a journal for the requested petition and date" do
+      let(:date) { Date.current }
+      let!(:existing_record) { FactoryGirl.create(:trending_petition_journal, petition: petition, created_at: date) }
+
+      it "doesn't create a new record" do
+        expect {
+          described_class.for(petition, date)
+        }.not_to change(described_class, :count)
+      end
+
+      it "fetches the instance from the DB" do
+        fetched = described_class.for(petition, date)
+        expect(fetched).to eq(existing_record)
+      end
+    end
+
+    context "when there is no journal for the requested petition" do
+      let!(:journal) { described_class.for(petition) }
+
+      it "returns a newly created instance" do
+        expect(journal).to be_an_instance_of(described_class)
+      end
+
+      it "persists the new instance in the DB" do
+        expect(journal).to be_persisted
+      end
+
+      it "sets the petition of the new instance to the supplied petition" do
+        expect(journal.petition).to eq(petition)
+      end
+    end
+  end
+
+  describe ".record_new_signature_for" do
+    let(:petition) { FactoryGirl.create(:open_petition) }
+    let(:time) { Time.parse("1 Jan 2017 13:05 UTC") }
+
+    def journal
+      described_class.for(petition)
+    end
+
+    around do |example|
+      travel_to(time) { example.run }
+    end
+
+    context "when the supplied signature is valid" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: petition) }
+      let(:now) { 1.hour.from_now.change(usec: 0) }
+
+      it "increments the hour_13_signature_count by 1" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.to change { journal.hour_13_signature_count }.by(1)
+      end
+
+      it "updates the updated_at timestamp" do
+        expect {
+          described_class.record_new_signature_for(signature, now)
+        }.to change { journal.updated_at }.to(now)
+      end
+    end
+
+    context "when the supplied signature is nil" do
+      let(:signature) { nil }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.hour_13_signature_count }
+      end
+    end
+
+    context "when the supplied signature has no petition" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: nil) }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.hour_13_signature_count }
+      end
+    end
+
+    context "when the supplied signature is not validated" do
+      let(:signature) { FactoryGirl.build(:pending_signature, petition: petition) }
+
+      it "does nothing" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.not_to change { journal.hour_13_signature_count }
+      end
+    end
+
+    context "when no journal exists" do
+      let(:signature) { FactoryGirl.build(:validated_signature, petition: petition) }
+
+      it "creates a new journal" do
+        expect {
+          described_class.record_new_signature_for(signature)
+        }.to change(described_class, :count).by(1)
+      end
+    end
+  end
+
+  describe ".invalidate_signature_for" do
+    let!(:petition) { FactoryGirl.create(:open_petition) }
+    let!(:journal) { FactoryGirl.create(:trending_petition_journal, petition: petition, hour_13_signature_count: signature_count, date: time.to_date) }
+    let(:signature_count) { 1 }
+    let(:time) { Time.parse("1 Jan 2017 13:05 UTC") }
+
+    around do |example|
+      travel_to(time) { example.run }
+    end
+
+    context "when the supplied signature is valid" do
+      let(:signature) { FactoryGirl.build(:invalidated_signature, petition: petition) }
+      let(:now) { 1.hour.from_now.change(usec: 0) }
+
+      it "decrements the hour_13_signature_count by 1" do
+        expect {
+          described_class.invalidate_signature_for(signature)
+        }.to change { journal.reload.hour_13_signature_count }.by(-1)
+      end
+
+      it "updates the updated_at timestamp" do
+        expect {
+          described_class.invalidate_signature_for(signature, now)
+        }.to change { journal.reload.updated_at }.to(now)
+      end
+    end
+
+    context "when the supplied signature is nil" do
+      let(:signature) { nil }
+
+      it "does nothing" do
+        expect {
+          described_class.invalidate_signature_for(signature)
+        }.not_to change { journal.reload.hour_13_signature_count }
+      end
+    end
+
+    context "when the supplied signature has no petition" do
+      let(:signature) { FactoryGirl.build(:invalidated_signature, petition: nil) }
+
+      it "does nothing" do
+        expect {
+          described_class.invalidate_signature_for(signature)
+        }.not_to change { journal.reload.hour_13_signature_count }
+      end
+    end
+
+    context "when the supplied signature is not validated" do
+      let(:signature) { FactoryGirl.build(:pending_signature, petition: petition) }
+
+      it "does nothing" do
+        expect {
+          described_class.invalidate_signature_for(signature)
+        }.not_to change { journal.reload.hour_13_signature_count }
+      end
+    end
+
+    context "when the signature count is already zero" do
+      let(:signature) { FactoryGirl.build(:invalidated_signature, petition: petition) }
+      let(:signature_count) { 0 }
+
+      it "does nothing" do
+        expect {
+          described_class.invalidate_signature_for(signature)
+        }.not_to change { journal.reload.hour_13_signature_count }
+      end
+    end
+
+    context "when no journal exists" do
+      let(:signature) { FactoryGirl.build(:invalidated_signature, petition: petition) }
+
+      before do
+        described_class.delete_all
+      end
+
+      it "creates a new journal" do
+        expect {
+          described_class.invalidate_signature_for(signature)
+        }.to change(described_class, :count).by(1)
+      end
+    end
+  end
 end
 

--- a/spec/models/trending_signature_collection_spec.rb
+++ b/spec/models/trending_signature_collection_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe TrendingSignatureCollection do
+  let(:subject) { described_class.new(petition) }
+  let(:petition) { FactoryGirl.build(:open_petition) }
+  let(:time) { Time.parse("1 Jan 2017 05:30:00 GMT") }
+  let(:today) { Date.current }
+  let(:two_days_ago) { today - 2.days }
+
+  around do |example|
+    travel_to(time) { example.run }
+  end
+
+  describe "#hourly_intervals" do
+    it "returns an enumerator" do
+      expect(subject.hourly_intervals).to be_instance_of(Enumerator)
+    end
+
+    context "with a trending petition journal" do
+      before do
+        FactoryGirl.create(
+          :trending_petition_journal, petition: petition, date: time.to_date
+        )
+      end
+
+      it "returns a collection of hourly intervals" do
+        subject.hourly_intervals.each do |interval|
+          expect(interval).to be_instance_of(SignatureInterval)
+        end
+      end
+
+      it "returns an interval for each hour in the past" do
+        expect(subject.hourly_intervals.count).to eq 6
+      end
+    end
+
+    context "with sporadic trending petition journals" do
+      before do
+        FactoryGirl.create(
+          :trending_petition_journal, petition: petition, date: today
+        )
+        FactoryGirl.create(
+          :trending_petition_journal, petition: petition, date: two_days_ago
+        )
+      end
+
+      it "returns a collection of hourly intervals" do
+        subject.hourly_intervals.each do |interval|
+          expect(interval).to be_instance_of(SignatureInterval)
+        end
+      end
+
+      it "returns an interval for each hour in the past" do
+        expect(subject.hourly_intervals.count).to eq 54
+      end
+
+      it "starts on the date of the first journal" do
+        expect(subject.hourly_intervals.first.starts_at.to_date)
+          .to eq two_days_ago
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds trending petition journals for recording signature
counts at hourly intervals and returns them from the petition show
API endpoint as suggested in #458.