### PR TITLE
Fix display of closing date

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -251,7 +251,9 @@ class Petition < ActiveRecord::Base
     end
 
     def close_petitions!(time = Time.current)
-      in_need_of_closing(time).update_all(state: CLOSED_STATE, closed_at: time, updated_at: time)
+      in_need_of_closing(time).find_each do |petition|
+        petition.close!
+      end
     end
 
     def in_need_of_closing(time = Time.current)
@@ -472,7 +474,7 @@ class Petition < ActiveRecord::Base
     update(state: FLAGGED_STATE)
   end
 
-  def close!(time = Time.current)
+  def close!(time = deadline)
     update!(state: CLOSED_STATE, closed_at: time)
   end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1655,14 +1655,14 @@ RSpec.describe Petition, type: :model do
   end
 
   describe '#close!' do
-    subject(:petition) { FactoryGirl.create(:petition, debate_state: debate_state) }
+    subject(:petition) { FactoryGirl.create(:open_petition, debate_state: debate_state) }
     let(:now) { Time.current }
     let(:duration) { Site.petition_duration.months }
     let(:closing_date) { (now + duration).end_of_day }
     let(:debate_state) { 'pending' }
 
     before do
-      petition.close!
+      petition.close!(now)
     end
 
     it "sets the state to CLOSED" do
@@ -1680,6 +1680,16 @@ RSpec.describe Petition, type: :model do
         it "doesn't change the debate state" do
           expect(petition.debate_state).to eq(state)
         end
+      end
+    end
+
+    context "when called without an argument" do
+      before do
+        petition.close!
+      end
+
+      it "sets the closing date to the deadline" do
+        expect(petition.closed_at).to be_within(1.second).of(petition.deadline)
       end
     end
   end


### PR DESCRIPTION
The `Petition#close!` method was taking the time that the job ran as the closing time of the petition. Whilst this is technically accurate it's confusing when displayed the next day because people see the petition as closed when it's still that day.

Fix this by using the deadline when closing the petition.