### PR TITLE
Update specs using opened_at_for_closing in the past

### DIFF
--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1019,7 +1019,7 @@ RSpec.describe Petition, type: :model do
     end
 
     context "when a petition is in the open state and closed_at has passed" do
-      let(:open_at) { Site.opened_at_for_closing(1.day.ago) }
+      let(:open_at) { Site.opened_at_for_closing(2.days.ago) }
       let!(:petition) { FactoryGirl.create(:open_petition, open_at: open_at) }
 
       it "does close the petition" do
@@ -1049,7 +1049,7 @@ RSpec.describe Petition, type: :model do
     end
 
     context "when a petition is in the open state and the closing date has passed" do
-      let(:open_at) { Site.opened_at_for_closing(1.day.ago) }
+      let(:open_at) { Site.opened_at_for_closing(2.days.ago) }
       let!(:petition) { FactoryGirl.create(:open_petition, open_at: open_at) }
 
       it "finds the petition" do


### PR DESCRIPTION
Due to the special cases in the Site#opened_at_for_closing method when
the specs are run on the day after a special case 1.day.ago being passed
to the method results in the same time being returned as for the current
time which causes no petitions to be returned from the
Petition#in_need_of_closing method.