### PR TITLE
Remove support for old Registers `/record` response

### DIFF
--- a/app/jobs/fetch_country_register_job.rb
+++ b/app/jobs/fetch_country_register_job.rb
@@ -26,12 +26,7 @@ class FetchCountryRegisterJob < ApplicationJob
   private
 
   def countries
-    values = fetch_register.body.values
-    if !values.empty? && values.first.has_key?('item')
-      values.map { |x| x['item'].first }
-    else
-      values
-    end
+    fetch_register.body.values.map { |x| x['item'].first }
   end
 
   def faraday

--- a/spec/jobs/fetch_petition_register_job_spec.rb
+++ b/spec/jobs/fetch_petition_register_job_spec.rb
@@ -13,289 +13,148 @@ RSpec.describe FetchCountryRegisterJob, type: :job do
     {status: status, headers: {"Content-Type" => "application/json"}, body: body}
   end
 
-  context "latest record schema" do
-    context "when a country does not exist" do
-      before do
-        stub_register.to_return json_response <<-JSON
-        {
-            "GB" : {
-              "index-entry-number": "6",
-              "entry-number": "6",
-              "entry-timestamp": "2016-04-05T13:23:05Z",
-              "key": "GB",
-              "item": [{
-                "citizen-names": "Briton;British citizen",
-                "country": "GB",
-                "name": "United Kingdom",
-                "official-name": "The United Kingdom of Great Britain and Northern Ireland",
-                "start-date": "1707-05-01",
-                "end-date": "2017-12-31"
-              }]
-            }
-        }
-        JSON
-      end
-
-      it "creates a record" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
+  context "when a country does not exist" do
+    before do
+      stub_register.to_return json_response <<-JSON
+      {
+          "GB" : {
+            "index-entry-number": "6",
+            "entry-number": "6",
+            "entry-timestamp": "2016-04-05T13:23:05Z",
+            "key": "GB",
+            "item": [{
+              "citizen-names": "Briton;British citizen",
+              "country": "GB",
+              "name": "United Kingdom",
+              "official-name": "The United Kingdom of Great Britain and Northern Ireland",
+              "start-date": "1707-05-01",
+              "end-date": "2017-12-31"
+            }]
           }
-        }.to change { Location.count }.by(1)
-      end
-
-      describe "attribute assignment" do
-        let(:location) { Location.find_by!(code: "GB") }
-
-        before do
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        end
-
-        it "assigns 'country' to Location#code" do
-          expect(location.code).to eq("GB")
-        end
-
-        it "assigns 'name' to Location#name" do
-          expect(location.name).to eq("United Kingdom")
-        end
-
-        it "assigns 'start-date' to Location#start_date" do
-          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
-        end
-
-        it "assigns 'end-date' to Location#end_date" do
-          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
-        end
-      end
+      }
+      JSON
     end
 
-    context "when a country does exist" do
-      before do
-        FactoryGirl.create(:location, code: "GB")
-
-        stub_register.to_return json_response <<-JSON
-        {
-            "GB" : {
-              "index-entry-number": "6",
-              "entry-number": "6",
-              "entry-timestamp": "2016-04-05T13:23:05Z",
-              "key": "GB",
-              "item": [{
-                "citizen-names": "Briton;British citizen",
-                "country": "GB",
-                "name": "United Kingdom",
-                "official-name": "The United Kingdom of Great Britain and Northern Ireland",
-                "start-date": "1707-05-01",
-                "end-date": "2017-12-31"
-              }]
-            }
+    it "creates a record" do
+      expect {
+        perform_enqueued_jobs {
+          described_class.perform_later
         }
-        JSON
-      end
-
-      it "updates an existing record" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        }.not_to change { Location.count }
-      end
-
-      describe "attribute assignment" do
-        let(:location) { Location.find_by!(code: "GB") }
-
-        before do
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        end
-
-        it "updates Location#name" do
-          expect(location.name).to eq("United Kingdom")
-        end
-
-        it "updates Location#start_date" do
-          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
-        end
-
-        it "updates Location#end_date" do
-          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
-        end
-      end
+      }.to change { Location.count }.by(1)
     end
 
-    context "when a country does not change" do
+    describe "attribute assignment" do
       let(:location) { Location.find_by!(code: "GB") }
 
       before do
-        FactoryGirl.create(:location, code: "GB", name: "United Kingdom")
-
-        stub_register.to_return json_response <<-JSON
-        {
-            "GB" : {
-              "index-entry-number": "6",
-              "entry-number": "6",
-              "entry-timestamp": "2016-04-05T13:23:05Z",
-              "key": "GB",
-              "item": [{
-                "citizen-names": "Briton;British citizen",
-                "country": "GB",
-                "name": "United Kingdom",
-                "official-name": "The United Kingdom of Great Britain and Northern Ireland"
-              }]
-            }
+        perform_enqueued_jobs {
+          described_class.perform_later
         }
-        JSON
       end
 
-      it "doesn't update an existing record" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        }.not_to change { location.reload.updated_at }
+      it "assigns 'country' to Location#code" do
+        expect(location.code).to eq("GB")
+      end
+
+      it "assigns 'name' to Location#name" do
+        expect(location.name).to eq("United Kingdom")
+      end
+
+      it "assigns 'start-date' to Location#start_date" do
+        expect(location.start_date).to eq(Date.civil(1707, 5, 1))
+      end
+
+      it "assigns 'end-date' to Location#end_date" do
+        expect(location.end_date).to eq(Date.civil(2017, 12, 31))
       end
     end
-
   end
 
-  context "old record schema" do
-    context "when a country does not exist" do
-      before do
-        stub_register.to_return json_response <<-JSON
-        {
-            "GB" : {
-              "entry-number": "6",
-              "item-hash": "sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb",
-              "entry-timestamp": "2016-04-05T13:23:05Z",
+  context "when a country does exist" do
+    before do
+      FactoryGirl.create(:location, code: "GB")
+
+      stub_register.to_return json_response <<-JSON
+      {
+          "GB" : {
+            "index-entry-number": "6",
+            "entry-number": "6",
+            "entry-timestamp": "2016-04-05T13:23:05Z",
+            "key": "GB",
+            "item": [{
               "citizen-names": "Briton;British citizen",
               "country": "GB",
               "name": "United Kingdom",
               "official-name": "The United Kingdom of Great Britain and Northern Ireland",
               "start-date": "1707-05-01",
               "end-date": "2017-12-31"
-            }
-        }
-        JSON
-      end
-
-      it "creates a record" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
+            }]
           }
-        }.to change { Location.count }.by(1)
-      end
-
-      describe "attribute assignment" do
-        let(:location) { Location.find_by!(code: "GB") }
-
-        before do
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        end
-
-        it "assigns 'country' to Location#code" do
-          expect(location.code).to eq("GB")
-        end
-
-        it "assigns 'name' to Location#name" do
-          expect(location.name).to eq("United Kingdom")
-        end
-
-        it "assigns 'start-date' to Location#start_date" do
-          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
-        end
-
-        it "assigns 'end-date' to Location#end_date" do
-          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
-        end
-      end
+      }
+      JSON
     end
 
-    context "when a country does exist" do
-      before do
-        FactoryGirl.create(:location, code: "GB")
-
-        stub_register.to_return json_response <<-JSON
-        {
-            "GB" : {
-              "entry-number": "6",
-              "item-hash": "sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb",
-              "entry-timestamp": "2016-04-05T13:23:05Z",
-              "citizen-names": "Briton;British citizen",
-              "country": "GB",
-              "name": "United Kingdom",
-              "official-name": "The United Kingdom of Great Britain and Northern Ireland",
-              "start-date": "1707-05-01",
-              "end-date": "2017-12-31"
-            }
+    it "updates an existing record" do
+      expect {
+        perform_enqueued_jobs {
+          described_class.perform_later
         }
-        JSON
-      end
-
-      it "updates an existing record" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        }.not_to change { Location.count }
-      end
-
-      describe "attribute assignment" do
-        let(:location) { Location.find_by!(code: "GB") }
-
-        before do
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        end
-
-        it "updates Location#name" do
-          expect(location.name).to eq("United Kingdom")
-        end
-
-        it "updates Location#start_date" do
-          expect(location.start_date).to eq(Date.civil(1707, 5, 1))
-        end
-
-        it "updates Location#end_date" do
-          expect(location.end_date).to eq(Date.civil(2017, 12, 31))
-        end
-      end
+      }.not_to change { Location.count }
     end
 
-    context "when a country does not change" do
+    describe "attribute assignment" do
       let(:location) { Location.find_by!(code: "GB") }
 
       before do
-        FactoryGirl.create(:location, code: "GB", name: "United Kingdom")
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      end
 
-        stub_register.to_return json_response <<-JSON
-        {
-            "GB" : {
-              "entry-number": "6",
-              "item-hash": "sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb",
-              "entry-timestamp": "2016-04-05T13:23:05Z",
+      it "updates Location#name" do
+        expect(location.name).to eq("United Kingdom")
+      end
+
+      it "updates Location#start_date" do
+        expect(location.start_date).to eq(Date.civil(1707, 5, 1))
+      end
+
+      it "updates Location#end_date" do
+        expect(location.end_date).to eq(Date.civil(2017, 12, 31))
+      end
+    end
+  end
+
+  context "when a country does not change" do
+    let(:location) { Location.find_by!(code: "GB") }
+
+    before do
+      FactoryGirl.create(:location, code: "GB", name: "United Kingdom")
+
+      stub_register.to_return json_response <<-JSON
+      {
+          "GB" : {
+            "index-entry-number": "6",
+            "entry-number": "6",
+            "entry-timestamp": "2016-04-05T13:23:05Z",
+            "key": "GB",
+            "item": [{
               "citizen-names": "Briton;British citizen",
               "country": "GB",
               "name": "United Kingdom",
               "official-name": "The United Kingdom of Great Britain and Northern Ireland"
-            }
-        }
-        JSON
-      end
-
-      it "doesn't update an existing record" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
+            }]
           }
-        }.not_to change { location.reload.updated_at }
-      end
+      }
+      JSON
+    end
+
+    it "doesn't update an existing record" do
+      expect {
+        perform_enqueued_jobs {
+          described_class.perform_later
+        }
+      }.not_to change { location.reload.updated_at }
     end
   end
 


### PR DESCRIPTION
We've deployed our breaking API changes so there's no need to keep around support for the old API responses.

Thanks again for helping us get out our changes so quickly! 😄 