### PR TITLE
Add Parliament model for to handle dissolution

### DIFF
--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -89,6 +89,11 @@ input.back-page {
     left: $gutter-half;
   }
 
+  .header {
+    margin-top: 0px;
+    @include bold-24();
+  }
+
   .content {
     margin-top: 0px;
     @include bold-19();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :reload_site
+  before_action :reload_parliament
   before_action :service_unavailable, unless: :site_enabled?
   before_action :authenticate, if: :site_protected?
   before_action :redirect_to_url_without_format, if: :unknown_format?
@@ -39,6 +40,10 @@ class ApplicationController < ActionController::Base
 
   def reload_site
     Site.reload
+  end
+
+  def reload_parliament
+    Parliament.reload
   end
 
   def service_unavailable

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,14 @@
 class ApplicationJob < ActiveJob::Base
   before_perform :reload_site
+  before_perform :reload_parliament
 
   private
 
   def reload_site
     Site.reload
+  end
+
+  def reload_parliament
+    Parliament.reload
   end
 end

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -1,0 +1,43 @@
+class Parliament < ActiveRecord::Base
+  class << self
+    def before_remove_const
+      Thread.current[:__parliament__] = nil
+    end
+
+    def instance
+      Thread.current[:__parliament__] ||= last_or_create
+    end
+
+    def dissolution_at
+      instance.dissolution_at
+    end
+
+    def dissolution_message
+      instance.dissolution_message
+    end
+
+    def dissolved?(now = Time.current)
+      instance.dissolved?(now)
+    end
+
+    def dissolution_announced?
+      instance.dissolution_announced?
+    end
+
+    def reload
+      Thread.current[:__parliament__] = nil
+    end
+
+    def last_or_create
+      order(created_at: :desc).first_or_create
+    end
+  end
+
+  def dissolved?(now = Time.current)
+    dissolution_at? && dissolution_at < now
+  end
+
+  def dissolution_announced?
+    dissolution_at?
+  end
+end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -549,8 +549,8 @@ class Petition < ActiveRecord::Base
     debate_outcome_at? && debate_outcome
   end
 
-  def deadline
-    open_at && (closed_at || Site.closed_at_for_opening(open_at))
+  def deadline(dissolution_at = Parliament.dissolution_at)
+    open_at && [dissolution_at, closed_at, Site.closed_at_for_opening(open_at)].compact.min
   end
 
   # need this callback since the relationship is circular

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -39,7 +39,9 @@
     </li>
     <li class="meta-deadline">
       <span class="label">Deadline</span> <%= short_date_format petition.deadline %>
-      <span class="note">All petitions run for 6 months</span>
+      <% unless Parliament.dissolution_announced? %>
+        <span class="note">All petitions run for 6 months</span>
+      <% end %>
     </li>
     <li class="meta-json">
       <span class="note"><%= link_to "Get petition data (json format)", petition_path(petition, :json) %></span>

--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -1,5 +1,13 @@
 <h1 class="page-title">Start a petition</h1>
 
+<% if Parliament.dissolution_announced? %>
+  <div class="notification">
+    <span class="icon icon-warning-white"></span>
+    <h3 class="header">All petitions will now close on <%= short_date_format(Parliament.dissolution_at) %></h3>
+    <p class="content"><%= Parliament.dissolution_message %></p>
+  </div>
+<% end %>
+
 <form method="get" action="/petitions/check_results">
   <div class="form-group">
     <label for="q" class="form-label">What do you want us to do?</label>

--- a/db/migrate/20170419165419_create_parliaments.rb
+++ b/db/migrate/20170419165419_create_parliaments.rb
@@ -1,0 +1,26 @@
+class CreateParliaments < ActiveRecord::Migration
+  class Parliament < ActiveRecord::Base; end
+
+  def up
+    create_table :parliaments do |t|
+      t.datetime :dissolution_at
+      t.text :dissolution_message
+      t.timestamps null: false
+    end
+
+    Parliament.create!(
+      dissolution_at: Date.civil(2017, 5, 3).end_of_day,
+      dissolution_message: <<-EOF.squish
+        The House of Commons has voted in favour of holding an early
+        General Election, on Thursday 8 June. This means that Parliament
+        will be dissolved at midnight on Wednesday 3 May, and that all
+        parliamentary business – including petitions – will stop until
+        the new Parliament meets.
+      EOF
+    )
+  end
+
+  def down
+    drop_table :parliaments
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -510,6 +510,38 @@ ALTER SEQUENCE notes_id_seq OWNED BY notes.id;
 
 
 --
+-- Name: parliaments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE parliaments (
+    id integer NOT NULL,
+    dissolution_at timestamp without time zone,
+    dissolution_message text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: parliaments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE parliaments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: parliaments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE parliaments_id_seq OWNED BY parliaments.id;
+
+
+--
 -- Name: petition_emails; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -930,6 +962,13 @@ ALTER TABLE ONLY notes ALTER COLUMN id SET DEFAULT nextval('notes_id_seq'::regcl
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY parliaments ALTER COLUMN id SET DEFAULT nextval('parliaments_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY petition_emails ALTER COLUMN id SET DEFAULT nextval('petition_emails_id_seq'::regclass);
 
 
@@ -1084,6 +1123,14 @@ ALTER TABLE ONLY locations
 
 ALTER TABLE ONLY notes
     ADD CONSTRAINT notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: parliaments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY parliaments
+    ADD CONSTRAINT parliaments_pkey PRIMARY KEY (id);
 
 
 --
@@ -1802,4 +1849,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160910054223');
 INSERT INTO schema_migrations (version) VALUES ('20161006095752');
 
 INSERT INTO schema_migrations (version) VALUES ('20161006101123');
+
+INSERT INTO schema_migrations (version) VALUES ('20170419165419');
 

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -14,6 +14,15 @@ Scenario: Charlie has to search for a petition before creating one
   Then I should be on the new petition page
   And I should see my search query already filled in as the action of the petition
 
+Scenario: Charlie starts to creates a petition when parliament is not dissolving
+  Given I am on the check for existing petitions page
+  Then I should not see "All petitions will now close"
+
+Scenario: Charlie starts to creates a petition when parliament is dissolving
+  Given Parliament is dissolving
+  And I am on the check for existing petitions page
+  Then I should see "All petitions will now close"
+
 @search
 Scenario: Charlie cannot craft an xss attack when searching for petitions
   Given I am on the home page

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -14,6 +14,10 @@ Given(/^the site is protected$/) do
   Site.instance.update! protected: true, username: "username", password: "password"
 end
 
+Given(/^Parliament is dissolving$/) do
+  Parliament.instance.update! dissolution_at: 2.weeks.from_now, dissolution_message: "Parliament is dissolving"
+end
+
 Given(/^the request is not local$/) do
   page.driver.options[:headers] = { "REMOTE_ADDR" => "192.168.1.128" }
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -22,6 +22,7 @@ end
 
 After do
   Site.reload
+  Parliament.reload
 end
 
 Before('@admin') do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -20,6 +20,9 @@ module NavigationHelpers
     when /^the feedback page$/
       feedback_url
 
+    when /^the check for existing petitions page$/
+      check_petitions_url
+
     when /^the new petition page$/
       new_petition_url
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe ApplicationController, type: :controller do
     get :index
   end
 
+  it "reloads the parliament instance on every request" do
+    expect(Parliament).to receive(:reload)
+    get :index
+  end
+
   it "sets cache control headers when asked" do
     get :index
     expect(cache_control).to eq('no-store, no-cache')

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -7,11 +7,17 @@ RSpec.describe ApplicationJob, type: :job do
     end
   end
 
-  before do
+  it "reloads the site instance" do
     expect(Site).to receive(:reload).and_call_original
+
+    perform_enqueued_jobs {
+      AnApplicationJob.perform_later
+    }
   end
 
-  it "reloads the site instance" do
+  it "reloads the parliament instance" do
+    expect(Parliament).to receive(:reload).and_call_original
+
     perform_enqueued_jobs {
       AnApplicationJob.perform_later
     }

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe Parliament, type: :model do
+  describe "schema" do
+    it { is_expected.to have_db_column(:dissolution_at).of_type(:datetime).with_options(null: true) }
+    it { is_expected.to have_db_column(:dissolution_message).of_type(:text).with_options(null: true) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  end
+
+  describe "singleton methods" do
+    let(:parliament) { Parliament.create! }
+    let(:now) { Time.current }
+
+    before do
+      allow(Parliament).to receive(:last_or_create).and_return(parliament)
+    end
+
+    after do
+      Parliament.reload
+    end
+
+    it "delegates dissolution_at to the instance" do
+      expect(parliament).to receive(:dissolution_at).and_return(now)
+      expect(Parliament.dissolution_at).to eq(now)
+    end
+
+    it "delegates dissolution_message to the instance" do
+      expect(parliament).to receive(:dissolution_message).and_return("Parliament is dissolving")
+      expect(Parliament.dissolution_message).to eq("Parliament is dissolving")
+    end
+
+    it "delegates dissolution_announced? to the instance" do
+      expect(parliament).to receive(:dissolution_announced?).and_return(true)
+      expect(Parliament.dissolution_announced?).to eq(true)
+    end
+
+    it "delegates dissolved? to the instance" do
+      expect(parliament).to receive(:dissolved?).and_return(true)
+      expect(Parliament.dissolved?).to eq(true)
+    end
+  end
+
+  describe ".reload" do
+    let(:parliament) { Parliament.create! }
+
+    context "when it is cached in Thread.current" do
+      before do
+        Thread.current[:__parliament__] = parliament
+      end
+
+      it "clears the cached instance in Thread.current" do
+        expect{ Parliament.reload }.to change {
+          Thread.current[:__parliament__]
+        }.from(parliament).to(nil)
+      end
+    end
+  end
+
+  describe ".instance" do
+    let(:parliament) { Parliament.create! }
+
+    context "when it isn't cached in Thread.current" do
+      before do
+        Thread.current[:__parliament__] = nil
+      end
+
+      after do
+        Parliament.reload
+      end
+
+      it "finds the last record" do
+        expect(Parliament).to receive(:last_or_create).and_return(parliament)
+        expect(Parliament.instance).to equal(parliament)
+      end
+
+      it "caches it in Thread.current" do
+        expect(Parliament).to receive(:last_or_create).and_return(parliament)
+        expect(Parliament.instance).to equal(Thread.current[:__parliament__])
+      end
+    end
+
+    context "when it is cached in Thread.current" do
+      before do
+        Thread.current[:__parliament__] = parliament
+      end
+
+      after do
+        Parliament.reload
+      end
+
+      it "returns the cached instance" do
+        expect(Parliament).not_to receive(:last_or_create)
+        expect(Parliament.instance).to equal(parliament)
+      end
+    end
+  end
+
+  describe ".before_remove_const" do
+    let(:parliament) { Parliament.create! }
+
+    context "when it is cached in Thread.current" do
+      before do
+        Thread.current[:__parliament__] = parliament
+      end
+
+      it "clears the cached instance in Thread.current" do
+        expect{ Parliament.before_remove_const }.to change {
+          Thread.current[:__parliament__]
+        }.from(parliament).to(nil)
+      end
+    end
+  end
+
+  describe "#dissolution_announced?" do
+    context "when dissolution_at is nil" do
+      subject :parliament do
+        Parliament.create!(dissolution_at: nil)
+      end
+
+      it "returns false" do
+        expect(parliament.dissolution_announced?).to eq(false)
+      end
+    end
+
+    context "when dissolution_at is not nil" do
+      subject :parliament do
+        Parliament.create!(dissolution_at: 2.weeks.from_now)
+      end
+
+      it "returns true" do
+        expect(parliament.dissolution_announced?).to eq(true)
+      end
+    end
+  end
+
+  describe "#dissolved?" do
+    context "when dissolution_at is nil" do
+      subject :parliament do
+        Parliament.create!(dissolution_at: nil)
+      end
+
+      it "returns false" do
+        expect(parliament.dissolved?).to eq(false)
+      end
+    end
+
+    context "when dissolution_at is in the future" do
+      subject :parliament do
+        Parliament.create!(dissolution_at: 2.weeks.from_now)
+      end
+
+      it "returns false" do
+        expect(parliament.dissolved?).to eq(false)
+      end
+    end
+
+    context "when dissolution_at is in the past" do
+      subject :parliament do
+        Parliament.create!(dissolution_at: 2.weeks.ago)
+      end
+
+      it "returns false" do
+        expect(parliament.dissolved?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This could've been handle with hard-coded text and a constant for the date but things aren't completely settled yet so add a model that will give us some flexibility. It will also probably be needed once a new parliament is sitting to split petitions into their respective parliaments.