### PR TITLE
Make pagination helper return html

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,8 +9,10 @@ module SearchHelper
       next_link: polymorphic_path(petitions.model, petitions.next_params)
     }
 
-    concat(t :previous_html, options) unless petitions.first_page?
-    concat(t :next_html, options) unless petitions.last_page?
+    capture do
+      concat t(:previous_html, options) unless petitions.first_page?
+      concat t(:next_html, options) unless petitions.last_page?
+    end
   end
 
   def filtered_petition_count(petitions)

--- a/app/views/application/_paginated_results.html.erb
+++ b/app/views/application/_paginated_results.html.erb
@@ -1,3 +1,3 @@
 <div class="search-pagination">
-  <% paginate @petitions %>
+  <%= paginate @petitions %>
 </div>

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,64 +1,98 @@
 require 'rails_helper'
 
 RSpec.describe SearchHelper, type: :helper do
-
   describe "#paginate" do
+    let(:page_stubs) do
+      {
+        total_pages: 3,
+        previous_link: "/petitions?page=1&state=all",
+        next_link: "/petitions?state=all",
+        model: Petition
+      }
+    end
 
-    let (:page_params) {{
-      :total_pages=>3,
-      :previous_link=>"/petitions?page=1&state=all",
-      :next_link=>"/petitions?state=all",
-      "model" => Petition
-    }}
+    context "when viewing the first page of the petitions search results" do
+      let(:first_page_stubs) do
+        {
+          first_page?: true,
+          last_page?: false,
+          previous_params: { state: :all, page: nil },
+          next_params: { state: :all, page: 2 },
+          previous_page: nil,
+          next_page: 2,
+        }
+      end
 
-    let (:first_page_params) {{
-      "first_page?" => true,
-      "last_page?" => false,
-      "previous_params" => {:state=>:all, :page=>nil},
-      "next_params" => {:state=>:all, :page=>2},
-      :previous_page=>nil,
-      :next_page=>2,
-    }}
+      let(:petitions) { double('petitions', page_stubs.merge(first_page_stubs)) }
 
-    let (:intermediary_page_params) {{
-      "first_page?" => false,
-      "last_page?" => false,
-      "previous_params" => {:state=>:all, :page=>1},
-      "next_params" => {:state=>:all, :page=>3},
-      :previous_page=>1,
-      :next_page=>2,
-    }}
-
-    let (:last_page_params) {{
-      "first_page?" => false,
-      "last_page?" => true,
-      "previous_params" => {:state=>:all, :page=>2},
-      "next_params" => {:state=>:all, :page=>nil},
-      :previous_page=>2,
-      :next_page=>nil,
-    }}
-
-    context "when it handles the first page of petitions" do
-      it "only adds a link to the next page" do
-        petitions = double('petitions', page_params.merge(first_page_params))
+      it "adds a link to the next page" do
         expect(paginate(petitions)).to include "Next"
+      end
+
+      it "does not add a link to the previous page" do
         expect(paginate(petitions)).not_to include "Previous"
       end
-    end
 
-    context "when it handles an intermediary page of petitions" do
-      it "adds both pagination links" do
-        petitions = double('petitions', page_params.merge(intermediary_page_params))
-        expect(paginate(petitions)).to include "Next"
-        expect(paginate(petitions)).to include "Previous"
+      it "adds the correct number range for the next page" do
+        expect(paginate(petitions)).to include "2 of 3"
       end
     end
 
-    context "when it handles the last page of petitions" do
-      it "only adds a link to the previous page" do
-        petitions = double('petitions', page_params.merge(last_page_params))
+    context "when viewing an intermediary page of the petitions search results" do
+      let(:intermediary_page_stubs) do
+        {
+          first_page?: false,
+          last_page?: false,
+          previous_params: { state: :all, page: 1 },
+          next_params: { state: :all, page: 3 },
+          previous_page: 1,
+          next_page: 3,
+        }
+      end
+
+      let(:petitions) { double('petitions', page_stubs.merge(intermediary_page_stubs)) }
+
+      it "adds a link to the next page" do
+        expect(paginate(petitions)).to include "Next"
+      end
+
+      it "adds a link to the previous page" do
         expect(paginate(petitions)).to include "Previous"
+      end
+
+      it "adds the correct number range for the next page" do
+        expect(paginate(petitions)).to include "3 of 3"
+      end
+
+      it "adds the correct number range for the previous page" do
+        expect(paginate(petitions)).to include "1 of 3"
+      end
+    end
+
+    context "when viewing the last page of the petitions search results" do
+      let(:last_page_stubs) do
+        {
+          first_page?: false,
+          last_page?: true,
+          previous_params: { state: :all, page: 2 },
+          next_params: { state: :all, page: nil },
+          previous_page: 2,
+          next_page: nil,
+        }
+      end
+
+      let(:petitions) { double('petitions', page_stubs.merge(last_page_stubs)) }
+
+      it "does not add a link to the next page" do
         expect(paginate(petitions)).not_to include "Next"
+      end
+
+      it "adds a link to the previous page" do
+        expect(paginate(petitions)).to include "Previous"
+      end
+
+      it "adds the correct number range for the previous page" do
+        expect(paginate(petitions)).to include "2 of 3"
       end
     end
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,6 +1,68 @@
 require 'rails_helper'
 
 RSpec.describe SearchHelper, type: :helper do
+
+  describe "#paginate" do
+
+    let (:page_params) {{
+      :total_pages=>3,
+      :previous_link=>"/petitions?page=1&state=all",
+      :next_link=>"/petitions?state=all",
+      "model" => Petition
+    }}
+
+    let (:first_page_params) {{
+      "first_page?" => true,
+      "last_page?" => false,
+      "previous_params" => {:state=>:all, :page=>nil},
+      "next_params" => {:state=>:all, :page=>2},
+      :previous_page=>nil,
+      :next_page=>2,
+    }}
+
+    let (:intermediary_page_params) {{
+      "first_page?" => false,
+      "last_page?" => false,
+      "previous_params" => {:state=>:all, :page=>1},
+      "next_params" => {:state=>:all, :page=>3},
+      :previous_page=>1,
+      :next_page=>2,
+    }}
+
+    let (:last_page_params) {{
+      "first_page?" => false,
+      "last_page?" => true,
+      "previous_params" => {:state=>:all, :page=>2},
+      "next_params" => {:state=>:all, :page=>nil},
+      :previous_page=>2,
+      :next_page=>nil,
+    }}
+
+    context "when it handles the first page of petitions" do
+      it "only adds a link to the next page" do
+        petitions = double('petitions', page_params.merge(first_page_params))
+        expect(paginate(petitions)).to include "Next"
+        expect(paginate(petitions)).not_to include "Previous"
+      end
+    end
+
+    context "when it handles an intermediary page of petitions" do
+      it "adds both pagination links" do
+        petitions = double('petitions', page_params.merge(intermediary_page_params))
+        expect(paginate(petitions)).to include "Next"
+        expect(paginate(petitions)).to include "Previous"
+      end
+    end
+
+    context "when it handles the last page of petitions" do
+      it "only adds a link to the previous page" do
+        petitions = double('petitions', page_params.merge(last_page_params))
+        expect(paginate(petitions)).to include "Previous"
+        expect(paginate(petitions)).not_to include "Next"
+      end
+    end
+  end
+
   describe "#filtered_petition_count" do
     context 'when search term is not present' do
       it 'renders correctly with > 1 results' do


### PR DESCRIPTION
The `paginate` helper method was appending its output through a side
effect of `concat`. It now returns its html, and the view was updated
accordingly.