### PR TITLE
Additional changes require for the dissolution of parliament

### DIFF
--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -1,0 +1,27 @@
+class Admin::ParliamentsController < Admin::AdminController
+  respond_to :html
+
+  before_action :require_sysadmin
+  before_action :fetch_parliament
+
+  def show
+  end
+
+  def update
+    if @parliament.update(parliament_params)
+      redirect_to admin_root_url, notice: :parliament_updated
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def fetch_parliament
+    @parliament = Parliament.instance
+  end
+
+  def parliament_params
+    params.require(:parliament).permit(:dissolution_at, :dissolution_heading, :dissolution_message)
+  end
+end

--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -12,6 +12,9 @@ class Admin::ParliamentsController < Admin::AdminController
       if email_creators?
         NotifyCreatorsThatParliamentIsDissolvingJob.perform_later
         redirect_to admin_root_url, notice: :creators_emailed
+      elsif schedule_closure?
+        ClosePetitionsEarlyJob.schedule_for(@parliament.dissolution_at)
+        redirect_to admin_root_url, notice: :closure_scheduled
       else
         redirect_to admin_root_url, notice: :parliament_updated
       end
@@ -32,5 +35,9 @@ class Admin::ParliamentsController < Admin::AdminController
 
   def email_creators?
     params.key?(:email_creators) && @parliament.dissolution_announced?
+  end
+
+  def schedule_closure?
+    params.key?(:schedule_closure) && @parliament.dissolution_announced?
   end
 end

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -6,6 +6,10 @@ module DateTimeHelper
     date_time && date_time.strftime("%-d %B %Y")
   end
 
+  def short_date_time_format(date_time)
+    date_time && date_time.strftime("%H:%M%P on %-d %B %Y")
+  end
+
   def date_time_format(date_time)
     date_time && date_time.strftime("%d-%m-%Y %H:%M")
   end

--- a/app/jobs/close_petitions_early_job.rb
+++ b/app/jobs/close_petitions_early_job.rb
@@ -1,0 +1,13 @@
+class ClosePetitionsEarlyJob < ApplicationJob
+  queue_as :high_priority
+
+  class << self
+    def schedule_for(time)
+      set(wait_until: time).perform_later(time.iso8601)
+    end
+  end
+
+  def perform(time)
+    Petition.close_petitions_early!(time.in_time_zone)
+  end
+end

--- a/app/jobs/notify_creator_that_parliament_is_dissolving_job.rb
+++ b/app/jobs/notify_creator_that_parliament_is_dissolving_job.rb
@@ -1,0 +1,12 @@
+class NotifyCreatorThatParliamentIsDissolvingJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_creator_of_closing_date_change
+
+  queue_as :low_priority
+
+  def perform(signature)
+    if Parliament.dissolution_announced?
+      mailer.send(email, signature).deliver_now
+    end
+  end
+end

--- a/app/jobs/notify_creators_that_parliament_is_dissolving_job.rb
+++ b/app/jobs/notify_creators_that_parliament_is_dissolving_job.rb
@@ -1,0 +1,15 @@
+class NotifyCreatorsThatParliamentIsDissolvingJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform
+    petitions.find_each do |petition|
+      NotifyCreatorThatParliamentIsDissolvingJob.perform_later(petition.creator_signature)
+    end
+  end
+
+  private
+
+  def petitions
+    Petition.open_at_dissolution
+  end
+end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -65,8 +65,13 @@ class PetitionMailer < ApplicationMailer
       list_unsubscribe: unsubscribe_url
   end
 
-  def notify_creator_of_closing_date_change(signature)
+  def notify_creator_of_closing_date_change(signature, dissolution_at = Parliament.dissolution_at)
     @signature, @petition = signature, signature.petition
+
+    @closing_time = dissolution_at.strftime('%H:%M%P')
+    @closing_date = dissolution_at.strftime('%-d %B')
+    @last_response_date = dissolution_at.yesterday.strftime('%-d %B')
+
     mail to: @signature.email, subject: subject_for(:notify_creator_of_closing_date_change)
   end
 

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -12,6 +12,10 @@ class Parliament < ActiveRecord::Base
       instance.dissolution_at
     end
 
+    def dissolution_heading
+      instance.dissolution_heading
+    end
+
     def dissolution_message
       instance.dissolution_message
     end
@@ -33,8 +37,14 @@ class Parliament < ActiveRecord::Base
     end
   end
 
+  validates_presence_of :dissolution_heading, :dissolution_message, if: :dissolution_at?
+  validates_length_of :dissolution_heading, maximum: 100
+  validates_length_of :dissolution_message, maximum: 600
+
+  after_save { Site.touch }
+
   def dissolved?(now = Time.current)
-    dissolution_at? && dissolution_at < now
+    dissolution_at? && dissolution_at <= now
   end
 
   def dissolution_announced?

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -549,8 +549,12 @@ class Petition < ActiveRecord::Base
     debate_outcome_at? && debate_outcome
   end
 
-  def deadline(dissolution_at = Parliament.dissolution_at)
-    open_at && [dissolution_at, closed_at, Site.closed_at_for_opening(open_at)].compact.min
+  def deadline
+    open_at && (closed_at || Site.closed_at_for_opening(open_at))
+  end
+
+  def closing_early_for_dissolution?(dissolution_at = Parliament.dissolution_at)
+    open_at && dissolution_at ? deadline > dissolution_at : false
   end
 
   # need this callback since the relationship is circular

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -256,6 +256,12 @@ class Petition < ActiveRecord::Base
       end
     end
 
+    def close_petitions_early!(time = Parliament.dissolution_at)
+      open_at_dissolution(time).find_each do |petition|
+        petition.close!(time)
+      end
+    end
+
     def in_need_of_closing(time = Time.current)
       where(state: OPEN_STATE).where(arel_table[:open_at].lt(Site.opened_at_for_closing(time)))
     end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -260,6 +260,21 @@ class Petition < ActiveRecord::Base
       where(state: OPEN_STATE).where(arel_table[:open_at].lt(Site.opened_at_for_closing(time)))
     end
 
+    def open_at_dissolution(dissolution_at = Parliament.dissolution_at)
+      if dissolution_at
+        opened_at_for_closing = Site.opened_at_for_closing(dissolution_at)
+
+        where(
+          arel_table[:state].eq(OPEN_STATE).
+          and(arel_table[:open_at].gteq(opened_at_for_closing).
+          and(arel_table[:closed_at].eq(nil)).
+          or(arel_table[:closed_at].gteq(dissolution_at)))
+        )
+      else
+        none
+      end
+    end
+
     def with_invalid_signature_counts
       where(id: Signature.petition_ids_with_invalid_signature_counts).to_a
     end

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -1,0 +1,33 @@
+<h1>Edit Parliament</h1>
+
+<div class="grid-row">
+  <div class="column-two-thirds extra-gutter">
+    <%= form_for @parliament, url: admin_parliament_url do |form| %>
+      <h2>Dissolution</h2>
+
+      <%= form_row for: [form.object, :dissolution_at] do %>
+        <%= form.label :dissolution_at, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :dissolution_at %>
+        <%= form.datetime_select :dissolution_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+      <% end %>
+
+      <%= form_row for: [form.object, :dissolution_heading] do %>
+        <%= form.label :dissolution_heading, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :dissolution_heading %>
+        <%= form.text_field :dissolution_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [form.object, :dissolution_message] do %>
+        <%= form.label :dissolution_message, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :dissolution_message %>
+        <%= form.text_area :dissolution_message, tabindex: increment, rows: 5, data: { max_length: 500 }, class: 'form-control' %>
+        <p class="character-count">500 characters max</p>
+      <% end %>
+
+      <%= form.submit 'Save', class: 'button' %>
+      <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>
+    <% end %>
+  </div>
+</div>
+
+<%= javascript_include_tag 'character-counter' %>

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -25,6 +25,7 @@
       <% end %>
 
       <%= form.submit 'Save', class: 'button' %>
+      <%= form.submit 'Email creators', name: 'email_creators', class: 'button-secondary' %>
       <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>
     <% end %>
   </div>

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -25,7 +25,8 @@
       <% end %>
 
       <%= form.submit 'Save', class: 'button' %>
-      <%= form.submit 'Email creators', name: 'email_creators', class: 'button-secondary' %>
+      <%= form.submit 'Email creators', name: 'email_creators', class: 'button-secondary', data: { confirm: 'Email creators about dissolution?' } %>
+      <%= form.submit 'Schedule closure', name: 'schedule_closure', class: 'button-secondary', data: { confirm: 'Schedule early closure of petitions?' } %>
       <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>
     <% end %>
   </div>

--- a/app/views/admin/shared/_header_user_actions.html.erb
+++ b/app/views/admin/shared/_header_user_actions.html.erb
@@ -2,6 +2,7 @@
   <ul>
     <li><%= link_to current_user.pretty_name, edit_admin_profile_path(current_user) %></li>
     <% if current_user.is_a_sysadmin? %>
+      <li><%= link_to "Parliament", admin_parliament_path %></li>
       <li><%= link_to "Invalidations", admin_invalidations_path %></li>
       <li><%= link_to "Rate Limits", edit_admin_rate_limits_path %></li>
       <li><%= link_to "Users", admin_admin_users_path %></li>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
@@ -1,15 +1,17 @@
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Unfortunately we’re closing all petitions on 31 March 2015, including your petition "<%= @petition.action %>":<br />
-<%= petition_url(@petition) %></p>
+<p>Because of the General Election, the closing date for your petition has changed. All petitions now have to close at <%= @closing_time %> on <%= @closing_date %>. This is because Parliament will be dissolved and all parliamentary business – including petitions – must stop until after the election. This means the petitions site will be closed and people will not be able to start or sign petitions.</p>
 
-<p>Parliament will be dissolved on 30 March 2015 and it’s not possible for petitions to remain open once Parliament has been dissolved.</p>
+<p>We’re sorry we weren’t able to give you more notice that this would happen.</p>
 
-<p>Sorry you won't have as long to collect signatures as you expected.</p>
+<p>Your petition will be available for people to read on the site even though it will be closed for signatures. Your petition can't be reopened after the election. You are very welcome to start your petition again when the site reopens after the election, but you will need to collect new signatures. We can't transfer signatures to your new petition.</p>
 
-<p>If you want to give feedback, please contact us at:<br />
-<%= link_to nil, feedback_url %></p>
+<p>The Government can't respond to petitions during the election period. This means if your petition has over <%= Site.formatted_threshold_for_response %> signatures, it can't receive a response from the current Government after <%= @last_response_date %>. After the election, the new Government will have to decide whether it wants to respond to petitions from before the election.</p>
 
-<p>Thanks,<br />
+<p>The Petitions Committee, the group of MPs who decide whether petitions are debated, won't exist after <%= @closing_date %>. This means that if your petition has over <%= Site.formatted_threshold_for_debate %> signatures, it can't be scheduled for debate. After the election, there will be a new Petitions Committee, and they will be responsible for deciding which petitions are debated.</p>
+
+<p>The petitions site will open again after the election, but at the moment we don't know exactly when. You can follow us on Twitter <a href="https://twitter.com/HoCPetitions">@HoCPetitions</a> for updates, or check back on the petitions site for news if you prefer.</p>
+
+<p>Many thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
@@ -1,15 +1,17 @@
 Dear <%= @signature.name %>,
 
-Unfortunately we’re closing all petitions on 31 March 2015, including your petition "<%= @petition.action %>":
-<%= petition_url(@petition) %>
+Because of the General Election, the closing date for your petition has changed. All petitions now have to close at <%= @closing_time %> on <%= @closing_date %>. This is because Parliament will be dissolved and all parliamentary business – including petitions – must stop until after the election. This means the petitions site will be closed and people will not be able to start or sign petitions.
 
-Parliament will be dissolved on 30 March 2015 and it’s not possible for petitions to remain open once Parliament has been dissolved.
+We’re sorry we weren’t able to give you more notice that this would happen.
 
-Sorry you won't have as long to collect signatures as you expected.
+Your petition will be available for people to read on the site even though it will be closed for signatures. Your petition can't be reopened after the election. You are very welcome to start your petition again when the site reopens after the election, but you will need to collect new signatures. We can't transfer signatures to your new petition.
 
-If you want to give feedback, please contact us at:
-<%= feedback_url %>
+The Government can't respond to petitions during the election period. This means if your petition has over <%= Site.formatted_threshold_for_response %> signatures, it can't receive a response from the current Government after <%= @last_response_date %>. After the election, the new Government will have to decide whether it wants to respond to petitions from before the election.
 
-Thanks,
+The Petitions Committee, the group of MPs who decide whether petitions are debated, won't exist after <%= @closing_date %>. This means that if your petition has over <%= Site.formatted_threshold_for_debate %> signatures, it can't be scheduled for debate. After the election, there will be a new Petitions Committee, and they will be responsible for deciding which petitions are debated.
+
+The petitions site will open again after the election, but at the moment we don't know exactly when. You can follow us on Twitter @HoCPetitions for updates, or check back on the petitions site for news if you prefer.
+
+Many thanks,
 <%= t("petitions.emails.signoff_prefix") %>
 <%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -38,7 +38,11 @@
       <span class="label">Created by</span> <%= petition.creator_signature.name %>
     </li>
     <li class="meta-deadline">
-      <span class="label">Deadline</span> <%= short_date_format petition.deadline %>
+      <% if petition.closing_early_for_dissolution? %>
+        <span class="label">Deadline</span> <%= short_date_time_format Parliament.dissolution_at %>
+      <% else %>
+        <span class="label">Deadline</span> <%= short_date_format petition.deadline %>
+      <% end %>
       <% unless Parliament.dissolution_announced? %>
         <span class="note">All petitions run for 6 months</span>
       <% end %>

--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -3,7 +3,7 @@
 <% if Parliament.dissolution_announced? %>
   <div class="notification">
     <span class="icon icon-warning-white"></span>
-    <h3 class="header">All petitions will now close on <%= short_date_format(Parliament.dissolution_at) %></h3>
+    <h3 class="header"><%= Parliament.dissolution_heading %></h3>
     <p class="content"><%= Parliament.dissolution_message %></p>
   </div>
 <% end %>

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -41,6 +41,7 @@ petition:
   keys:
     - :petition
     - :reveal_response
+    - :site_updated_at
   options:
     expires_in: 300
 

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -31,6 +31,7 @@ en-GB:
     flash:
       admin_required: "You must be logged in as an administrator to view this page"
       change_password: "Please change your password before continuing"
+      creators_emailed: "Petition creators will be notified of the early closing of their petitions"
       debate_date_updated: "Updated the scheduled debate date successfully"
       debate_outcome_updated: "Updated debate outcome successfully"
       email_sent_overnight: "Email will be sent overnight"

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -55,6 +55,7 @@ en-GB:
       invalid_login: "Invalid email/password combination"
       logged_out: "You have been logged out"
       password_updated: "Password was successfully updated"
+      parliament_updated: "Parliament updated successfully"
       petition_email_created: "Created other parliamentary business successfully"
       petition_email_updated: "Updated other parliamentary business successfully"
       petition_email_deleted: "Deleted other parliamentary business successfully"

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -31,6 +31,7 @@ en-GB:
     flash:
       admin_required: "You must be logged in as an administrator to view this page"
       change_password: "Please change your password before continuing"
+      closure_scheduled: "Petitions have been scheduled to close early"
       creators_emailed: "Petition creators will be notified of the early closing of their petitions"
       debate_date_updated: "Updated the scheduled debate date successfully"
       debate_outcome_updated: "Updated debate outcome successfully"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -134,6 +134,11 @@ en-GB:
           one: 1 error prohibited this %{model} from being saved
           other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
+    label:
+      parliament:
+        dissolution_heading: "Heading"
+        dissolution_message: "Message"
+        dissolution_at: "Date and time"
     select:
       prompt: Please select
     submit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
 
       mount Delayed::Web::Engine, at: '/delayed'
 
+      resource :parliament, :only => [:show, :update]
       resource :search, :only => [:show]
 
       resources :admin_users

--- a/db/migrate/20170422104143_add_dissolution_heading_to_parliaments.rb
+++ b/db/migrate/20170422104143_add_dissolution_heading_to_parliaments.rb
@@ -1,0 +1,23 @@
+class AddDissolutionHeadingToParliaments < ActiveRecord::Migration
+  class Parliament < ActiveRecord::Base; end
+
+  def up
+    add_column :parliaments, :dissolution_heading, :string, limit: 100
+
+    parliament = Parliament.first_or_initialize
+    parliament.update!(
+      dissolution_at: Time.utc(2017, 5, 2, 23, 1, 0),
+      dissolution_heading: "All petitions will now close at 00:01am\u00A0on\u00A03\u00A0May\u00A02017",
+      dissolution_message: <<-EOF.squish
+        There will be an early General Election on Thursday 8 June.
+        This means that Parliament has to be dissolved at 00:01am
+        (just after midnight) on Wednesday 3 May, and that all
+        parliamentary business – including petitions – has to stop.
+      EOF
+    )
+  end
+
+  def down
+    remove_column :parliaments, :dissolution_heading
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -518,7 +518,8 @@ CREATE TABLE parliaments (
     dissolution_at timestamp without time zone,
     dissolution_message text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    dissolution_heading character varying(100)
 );
 
 
@@ -1851,4 +1852,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161006095752');
 INSERT INTO schema_migrations (version) VALUES ('20161006101123');
 
 INSERT INTO schema_migrations (version) VALUES ('20170419165419');
+
+INSERT INTO schema_migrations (version) VALUES ('20170422104143');
 

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -16,12 +16,13 @@ Scenario: Charlie has to search for a petition before creating one
 
 Scenario: Charlie starts to creates a petition when parliament is not dissolving
   Given I am on the check for existing petitions page
-  Then I should not see "All petitions will now close"
+  Then I should not see "Parliament is dissolving"
 
 Scenario: Charlie starts to creates a petition when parliament is dissolving
   Given Parliament is dissolving
   And I am on the check for existing petitions page
-  Then I should see "All petitions will now close"
+  Then I should see "Parliament is dissolving"
+  And I should see "This means all petitions will close in 2 weeks"
 
 @search
 Scenario: Charlie cannot craft an xss attack when searching for petitions

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -15,7 +15,9 @@ Given(/^the site is protected$/) do
 end
 
 Given(/^Parliament is dissolving$/) do
-  Parliament.instance.update! dissolution_at: 2.weeks.from_now, dissolution_message: "Parliament is dissolving"
+  Parliament.instance.update! dissolution_at: 2.weeks.from_now,
+    dissolution_heading: "Parliament is dissolving",
+    dissolution_message: "This means all petitions will close in 2 weeks"
 end
 
 Given(/^the request is not local$/) do

--- a/spec/controllers/admin/parliaments_controller_spec.rb
+++ b/spec/controllers/admin/parliaments_controller_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
+  context "when not logged in" do
+    [
+      ["GET", "/admin/parliament", :show, {}],
+      ["PATCH", "/admin/parliament", :update, {}]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method, params }
+
+        it "redirects to the login page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a moderator" do
+    let(:moderator) { FactoryGirl.create(:moderator_user) }
+    before { login_as(moderator) }
+
+    [
+      ["GET", "/admin/parliament", :show, {}],
+      ["PATCH", "/admin/parliament", :update, {}]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method, params }
+
+        it "redirects to the admin hub page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a sysadmin" do
+    let(:sysadmin) { FactoryGirl.create(:sysadmin_user) }
+    before { login_as(sysadmin) }
+
+    describe "GET /admin/parliament" do
+      before { get :show }
+
+      it "returns 200 OK" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the :show template" do
+        expect(response).to render_template("admin/parliaments/show")
+      end
+    end
+
+    describe "PATCH /admin/parliament" do
+      before { patch :update, parliament: params }
+
+      let(:parliament) { FactoryGirl.create(:parliament) }
+
+      context "and the params are invalid" do
+        let :params do
+          {
+            dissolution_at: 2.weeks.from_now.iso8601,
+            dissolution_heading: "",
+            dissolution_message: ""
+          }
+        end
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :show template" do
+          expect(response).to render_template("admin/parliaments/show")
+        end
+      end
+
+      context "and the params are valid" do
+        let :params do
+          {
+            dissolution_at: 2.weeks.from_now.iso8601,
+            dissolution_heading: "Parliament is dissolving",
+            dissolution_message: "This means all petitions will close in 2 weeks"
+          }
+        end
+
+        it "redirects to the admin dashboard page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Parliament updated successfully")
+        end
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -392,4 +392,18 @@ FactoryGirl.define do
       started_at { Time.current }
     end
   end
+
+  factory :parliament do
+    trait :dissolving do
+      dissolution_heading "Parliament is dissolving"
+      dissolution_message "This means all petitions will close in 2 weeks"
+      dissolution_at { 2.weeks.from_now }
+    end
+
+    trait :dissolved do
+      dissolution_heading "Parliament is dissolving"
+      dissolution_message "This means all petitions will close in 2 weeks"
+      dissolution_at { 2.weeks.ago }
+    end
+  end
 end

--- a/spec/jobs/close_petitions_early_job_spec.rb
+++ b/spec/jobs/close_petitions_early_job_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe ClosePetitionsEarlyJob, type: :job do
+  let(:dissolution_at) { "2017-05-02T23:00:01Z".in_time_zone }
+  let(:open_at) { dissolution_at - 4.weeks }
+  let(:scheduled_at) { dissolution_at - 2.weeks }
+  let(:before_dissolution) { dissolution_at - 1.week }
+  let(:job) { Delayed::Job.last }
+  let(:jobs) { Delayed::Job.all.to_a }
+
+  let!(:petition) { FactoryGirl.create(:open_petition, open_at: open_at) }
+
+  before do
+    ActiveJob::Base.queue_adapter = :delayed_job
+
+    travel_to(scheduled_at) {
+      described_class.schedule_for(dissolution_at)
+    }
+  end
+
+  after do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  it "enqueues the job" do
+    expect(jobs).to eq([job])
+  end
+
+  context "before the scheduled date" do
+    it "doesn't perform the enqueued job" do
+      expect {
+        travel_to(before_dissolution) {
+          Delayed::Worker.new.work_off
+        }
+      }.not_to change {
+        petition.reload.state
+      }
+    end
+  end
+
+  context "after the scheduled date" do
+    it "closes the petition" do
+      expect {
+        travel_to(dissolution_at) {
+          Delayed::Worker.new.work_off
+        }
+      }.to change {
+        petition.reload.state
+      }.from("open").to("closed")
+    end
+
+    it "sets the closed_at to the correct timestamp" do
+      expect {
+        travel_to(dissolution_at) {
+          Delayed::Worker.new.work_off
+        }
+      }.to change {
+        petition.reload.closed_at
+      }.from(nil).to(dissolution_at)
+    end
+  end
+end

--- a/spec/jobs/notify_creators_that_parliament_is_dissolving_job_spec.rb
+++ b/spec/jobs/notify_creators_that_parliament_is_dissolving_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe NotifyCreatorsThatParliamentIsDissolvingJob, type: :job do
+  let(:petition) { FactoryGirl.create(:open_petition, open_at: 3.months.ago) }
+  let(:signature) { petition.creator_signature }
+
+  let(:notify_creator_job) do
+    {
+      job: NotifyCreatorThatParliamentIsDissolvingJob,
+      args: [{ "_aj_globalid" => "gid://epets/Signature/#{signature.id}" }],
+      queue: "low_priority"
+    }
+  end
+
+  before do
+    expect(Petition).to receive_message_chain(:open_at_dissolution, :find_each).and_yield(petition)
+  end
+
+  it "enqueues a job for every petition that is open at dissolution" do
+    expect {
+      described_class.perform_now
+    }.to change {
+      enqueued_jobs
+    }.from([]).to([notify_creator_job])
+  end
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe PetitionMailer, type: :mailer do
 
     before do
       petition.publish
+      allow(Parliament).to receive(:dissolution_at).and_return(2.weeks.from_now)
     end
 
     it "is sent to the right address" do
@@ -202,7 +203,7 @@ RSpec.describe PetitionMailer, type: :mailer do
     end
 
     it "informs the creator of the change" do
-      expect(mail).to have_body_text("Unfortunately we’re closing all petitions")
+      expect(mail).to have_body_text("the closing date for your petition has changed")
     end
   end
 

--- a/spec/mailers/previews/petition_mailer_preview.rb
+++ b/spec/mailers/previews/petition_mailer_preview.rb
@@ -38,6 +38,13 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.notify_creator_of_threshold_response(petition, signature)
   end
 
+  def notify_creator_of_closing_date_change
+    petition = Petition.open_at_dissolution.first
+    signature = petition.creator_signature
+
+    PetitionMailer.notify_creator_of_closing_date_change(signature)
+  end
+
   def debated_petition_signer_notification
     petition = Petition.debated.last
     signature = petition.signatures.validated.last

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1030,6 +1030,24 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe ".close_petitions_early!" do
+    let(:open_at) { Date.civil(2017, 4, 1).noon }
+    let(:dissolution_at) { Time.utc(2017, 5, 2, 23, 1, 0).in_time_zone }
+    let!(:petition) { FactoryGirl.create(:open_petition, open_at: open_at) }
+
+    it "closes the petition" do
+      expect{
+        described_class.close_petitions_early!(dissolution_at)
+      }.to change{ petition.reload.state }.from('open').to('closed')
+    end
+
+    it "sets closed_at to the dissolution timestamp" do
+      expect{
+        described_class.close_petitions_early!(dissolution_at)
+      }.to change{ petition.reload.closed_at }.from(nil).to(dissolution_at)
+    end
+  end
+
   describe ".in_need_of_closing" do
     context "when a petition is in the closed state" do
       let!(:petition) { FactoryGirl.create(:closed_petition) }

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1742,11 +1742,27 @@ RSpec.describe Petition, type: :model do
         expect(petition.deadline).to be_nil
       end
     end
+  end
+
+  describe "#closing_early_for_dissolution?" do
+    let(:now) { Time.current }
+    let(:duration) { Site.petition_duration.months }
+    subject(:petition) { FactoryGirl.build(:open_petition, open_at: open_at) }
+
+    context "when the dissolution of parliament has not been announced" do
+      let(:open_at) { now - duration + 1.month }
+
+      before do
+        allow(Parliament).to receive(:dissolution_announced?).and_return(false)
+      end
+
+      it "returns false" do
+        expect(subject.closing_early_for_dissolution?).to eq(false)
+      end
+    end
 
     context "when the dissolution of parliament has been announced" do
-      subject(:petition) { FactoryGirl.build(:open_petition, open_at: open_at) }
       let(:dissolution_at) { 6.weeks.since(now).end_of_day }
-      let(:duration) { Site.petition_duration.months }
 
       before do
         allow(Parliament).to receive(:dissolution_announced?).and_return(true)
@@ -1757,15 +1773,8 @@ RSpec.describe Petition, type: :model do
         let(:open_at) { now - duration + 1.month }
         let(:closing_date) { (open_at + duration).end_of_day }
 
-        it "returns the end of the day, #{Site.petition_duration} months after the open_at" do
-          expect(petition.open_at).to eq(open_at)
-          expect(petition.deadline).to eq(closing_date)
-        end
-
-        it "prefers any closed_at stamp that has been set" do
-          petition.closed_at = now + 1.day
-          expect(petition.deadline).not_to eq(closing_date)
-          expect(petition.deadline).to eq(petition.closed_at)
+        it "returns false" do
+          expect(subject.closing_early_for_dissolution?).to eq(false)
         end
       end
 
@@ -1773,21 +1782,8 @@ RSpec.describe Petition, type: :model do
         let(:open_at) { now - duration + 2.months }
         let(:closing_date) { (open_at + duration).end_of_day }
 
-        it "returns the dissolution_at timestamp" do
-          expect(petition.open_at).to eq(open_at)
-          expect(petition.deadline).to eq(dissolution_at)
-        end
-
-        it "prefers closed_at timestamp if before dissolution_at" do
-          petition.closed_at = now + 1.day
-          expect(petition.deadline).not_to eq(closing_date)
-          expect(petition.deadline).to eq(petition.closed_at)
-        end
-
-        it "prefers dissolution_at timestamp if closed_at after dissolution_at" do
-          petition.closed_at = now + 7.weeks
-          expect(petition.deadline).not_to eq(closing_date)
-          expect(petition.deadline).to eq(dissolution_at)
+        it "returns true" do
+          expect(subject.closing_early_for_dissolution?).to eq(true)
         end
       end
     end


### PR DESCRIPTION
* Adds admin CRUD for updating the parliament instance
* Adds a dissolution heading since it's no longer at midnight so needs to be editable
* Updates the existing early closing email to the latest copy
* Adds a button to the admin CRUD to send the early closing email
* Adds a job for closing petitions early at the scheduled dissolution date/time
* Adds a button to the admin CRUD to schedule the job to close petitions early