### PR TITLE
Allow specifiying an FAQ link when dissolving parliament

### DIFF
--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -98,6 +98,11 @@ input.back-page {
     margin-top: 0px;
     @include bold-19();
   }
+
+  a {
+    color: $white;
+    text-decoration: underline;
+  }
 }
 
 // Flash messages

--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -30,7 +30,7 @@ class Admin::ParliamentsController < Admin::AdminController
   end
 
   def parliament_params
-    params.require(:parliament).permit(:dissolution_at, :dissolution_heading, :dissolution_message)
+    params.require(:parliament).permit(:dissolution_at, :dissolution_heading, :dissolution_message, :dissolution_faq_url)
   end
 
   def email_creators?

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -20,6 +20,14 @@ class Parliament < ActiveRecord::Base
       instance.dissolution_message
     end
 
+    def dissolution_faq_url
+      instance.dissolution_faq_url
+    end
+
+    def dissolution_faq_url?
+      instance.dissolution_faq_url?
+    end
+
     def dissolved?(now = Time.current)
       instance.dissolved?(now)
     end
@@ -40,6 +48,7 @@ class Parliament < ActiveRecord::Base
   validates_presence_of :dissolution_heading, :dissolution_message, if: :dissolution_at?
   validates_length_of :dissolution_heading, maximum: 100
   validates_length_of :dissolution_message, maximum: 600
+  validates_length_of :dissolution_faq_url, maximum: 500
 
   after_save { Site.touch }
 

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -24,6 +24,12 @@
         <p class="character-count">500 characters max</p>
       <% end %>
 
+      <%= form_row for: [form.object, :dissolution_faq_url] do %>
+        <%= form.label :dissolution_faq_url, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :dissolution_faq_url %>
+        <%= form.text_field :dissolution_faq_url, tabindex: increment, maxlength: 500, class: 'form-control' %>
+      <% end %>
+
       <%= form.submit 'Save', class: 'button' %>
       <%= form.submit 'Email creators', name: 'email_creators', class: 'button-secondary', data: { confirm: 'Email creators about dissolution?' } %>
       <%= form.submit 'Schedule closure', name: 'schedule_closure', class: 'button-secondary', data: { confirm: 'Schedule early closure of petitions?' } %>

--- a/app/views/application/_parliament_dissolution_warning.html.erb
+++ b/app/views/application/_parliament_dissolution_warning.html.erb
@@ -3,5 +3,8 @@
     <span class="icon icon-warning-white"></span>
     <h3 class="header"><%= Parliament.dissolution_heading %></h3>
     <p class="content"><%= Parliament.dissolution_message %></p>
+    <% if Parliament.dissolution_faq_url? %>
+      <p class="content">Find out more on the <%= link_to 'Petitions Committee website', Parliament.dissolution_faq_url %></p>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/application/_parliament_dissolution_warning.html.erb
+++ b/app/views/application/_parliament_dissolution_warning.html.erb
@@ -1,0 +1,7 @@
+<% if Parliament.dissolution_announced? %>
+  <div class="notification">
+    <span class="icon icon-warning-white"></span>
+    <h3 class="header"><%= Parliament.dissolution_heading %></h3>
+    <p class="content"><%= Parliament.dissolution_message %></p>
+  </div>
+<% end %>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,5 +1,7 @@
 <div class="text-page">
 
+<%= render 'parliament_dissolution_warning' %>
+
 <h1 class="page-title">How petitions work</h1>
 
 <ol class="list-number">

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,6 +1,8 @@
 <%= cache_for :home_page do %>
   <h1 class="visuallyhidden">Petitions – UK Government and Parliament</h1>
 
+  <%= render 'parliament_dissolution_warning' %>
+
   <% if no_petitions_yet? %>
     <div class="section-panel-borderless no-petitions-yet">
       <p class="lede">The new Petitions service launched today</p>

--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -1,12 +1,6 @@
 <h1 class="page-title">Start a petition</h1>
 
-<% if Parliament.dissolution_announced? %>
-  <div class="notification">
-    <span class="icon icon-warning-white"></span>
-    <h3 class="header"><%= Parliament.dissolution_heading %></h3>
-    <p class="content"><%= Parliament.dissolution_message %></p>
-  </div>
-<% end %>
+<%= render 'parliament_dissolution_warning' %>
 
 <form method="get" action="/petitions/check_results">
   <div class="form-group">

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -20,6 +20,7 @@ footer:
 
 home_page:
   keys:
+    - :site_updated_at
     - :last_government_response_updated_at
     - :last_debate_outcome_updated_at
   options:

--- a/db/migrate/20170424145119_add_dissolution_faq_url_to_parliament.rb
+++ b/db/migrate/20170424145119_add_dissolution_faq_url_to_parliament.rb
@@ -1,0 +1,5 @@
+class AddDissolutionFaqUrlToParliament < ActiveRecord::Migration
+  def change
+    add_column :parliaments, :dissolution_faq_url, :string, limit: 500
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -519,7 +519,8 @@ CREATE TABLE parliaments (
     dissolution_message text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    dissolution_heading character varying(100)
+    dissolution_heading character varying(100),
+    dissolution_faq_url character varying(500)
 );
 
 
@@ -1854,4 +1855,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161006101123');
 INSERT INTO schema_migrations (version) VALUES ('20170419165419');
 
 INSERT INTO schema_migrations (version) VALUES ('20170422104143');
+
+INSERT INTO schema_migrations (version) VALUES ('20170424145119');
 

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -21,8 +21,11 @@ Scenario: Charlie starts to creates a petition when parliament is not dissolving
 Scenario: Charlie starts to creates a petition when parliament is dissolving
   Given Parliament is dissolving
   And I am on the check for existing petitions page
-  Then I should see "Parliament is dissolving"
-  And I should see "This means all petitions will close in 2 weeks"
+  Then I should see the Parliament dissolution warning message
+  When I am on the home page
+  Then I should see the Parliament dissolution warning message
+  When I am on the help page
+  Then I should see the Parliament dissolution warning message
 
 @search
 Scenario: Charlie cannot craft an xss attack when searching for petitions

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -17,7 +17,8 @@ end
 Given(/^Parliament is dissolving$/) do
   Parliament.instance.update! dissolution_at: 2.weeks.from_now,
     dissolution_heading: "Parliament is dissolving",
-    dissolution_message: "This means all petitions will close in 2 weeks"
+    dissolution_message: "This means all petitions will close in 2 weeks",
+    dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
 end
 
 Given(/^the request is not local$/) do
@@ -64,4 +65,12 @@ end
 
 Then(/^I should index the page$/) do
   expect(page).not_to have_css('meta[name=robots]', visible: false)
+end
+
+Then(/^I should see the Parliament dissolution warning message$/) do
+  within(:css, ".notification") do
+    expect(page).to have_content "Parliament is dissolving"
+    expect(page).to have_content "This means all petitions will close in 2 weeks"
+    expect(page).to have_link "Petitions Committee website", href: "https://parliament.example.com/parliament-is-closing"
+  end
 end

--- a/spec/controllers/admin/parliaments_controller_spec.rb
+++ b/spec/controllers/admin/parliaments_controller_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: 2.weeks.from_now.iso8601,
               dissolution_heading: "",
-              dissolution_message: ""
+              dissolution_message: "",
+              dissolution_faq_url: ""
             }
           end
 
@@ -83,7 +84,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: 2.weeks.from_now.iso8601,
               dissolution_heading: "Parliament is dissolving",
-              dissolution_message: "This means all petitions will close in 2 weeks"
+              dissolution_message: "This means all petitions will close in 2 weeks",
+              dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
             }
           end
 
@@ -105,7 +107,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: 2.weeks.from_now.iso8601,
               dissolution_heading: "",
-              dissolution_message: ""
+              dissolution_message: "",
+              dissolution_faq_url: ""
             }
           end
 
@@ -123,7 +126,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: 2.weeks.from_now.iso8601,
               dissolution_heading: "Parliament is dissolving",
-              dissolution_message: "This means all petitions will close in 2 weeks"
+              dissolution_message: "This means all petitions will close in 2 weeks",
+              dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
             }
           end
 
@@ -149,7 +153,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: "",
               dissolution_heading: "",
-              dissolution_message: ""
+              dissolution_message: "",
+              dissolution_faq_url: ""
             }
           end
 
@@ -175,7 +180,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: 2.weeks.from_now.iso8601,
               dissolution_heading: "",
-              dissolution_message: ""
+              dissolution_message: "",
+              dissolution_faq_url: ""
             }
           end
 
@@ -194,7 +200,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: dissolution_at.iso8601,
               dissolution_heading: "Parliament is dissolving",
-              dissolution_message: "This means all petitions will close in 2 weeks"
+              dissolution_message: "This means all petitions will close in 2 weeks",
+              dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
             }
           end
 
@@ -225,7 +232,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             {
               dissolution_at: "",
               dissolution_heading: "",
-              dissolution_message: ""
+              dissolution_message: "",
+              dissolution_faq_url: ""
             }
           end
 

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Parliament, type: :model do
     it { is_expected.to have_db_column(:dissolution_at).of_type(:datetime).with_options(null: true) }
     it { is_expected.to have_db_column(:dissolution_heading).of_type(:string).with_options(limit: 100, null: true) }
     it { is_expected.to have_db_column(:dissolution_message).of_type(:text).with_options(null: true) }
+    it { is_expected.to have_db_column(:dissolution_faq_url).of_type(:string).with_options(limit: 500, null: true) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   end
@@ -36,8 +37,10 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.not_to validate_presence_of(:dissolution_heading) }
       it { is_expected.not_to validate_presence_of(:dissolution_message) }
+      it { is_expected.not_to validate_presence_of(:dissolution_faq_url) }
       it { is_expected.to validate_length_of(:dissolution_heading).is_at_most(100) }
       it { is_expected.to validate_length_of(:dissolution_message).is_at_most(600) }
+      it { is_expected.to validate_length_of(:dissolution_faq_url).is_at_most(500) }
     end
 
     context "when dissolution_at is not nil" do
@@ -45,8 +48,10 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.to validate_presence_of(:dissolution_heading) }
       it { is_expected.to validate_presence_of(:dissolution_message) }
+      it { is_expected.not_to validate_presence_of(:dissolution_faq_url) }
       it { is_expected.to validate_length_of(:dissolution_heading).is_at_most(100) }
       it { is_expected.to validate_length_of(:dissolution_message).is_at_most(600) }
+      it { is_expected.to validate_length_of(:dissolution_faq_url).is_at_most(500) }
     end
   end
 
@@ -75,6 +80,16 @@ RSpec.describe Parliament, type: :model do
     it "delegates dissolution_message to the instance" do
       expect(parliament).to receive(:dissolution_message).and_return("Parliament is dissolving")
       expect(Parliament.dissolution_message).to eq("Parliament is dissolving")
+    end
+
+    it "delegates dissolution_faq_url to the instance" do
+      expect(parliament).to receive(:dissolution_faq_url).and_return("https://parliament.example.com/parliament-is-closing")
+      expect(Parliament.dissolution_faq_url).to eq("https://parliament.example.com/parliament-is-closing")
+    end
+
+    it "delegates dissolution_faq_url? to the instance" do
+      expect(parliament).to receive(:dissolution_faq_url?).and_return(true)
+      expect(Parliament.dissolution_faq_url?).to eq(true)
     end
 
     it "delegates dissolution_announced? to the instance" do


### PR DESCRIPTION
If present this link will be displayed at the bottom of the message as follows:

> Find out more on the **Petitions Committee website**

Where the part in bold will be the clickable link.  If no url is provided that sentence is not included in the warning notification at all.
