### PR TITLE
First stage of closing the website for the GE 2017

### DIFF
--- a/app/assets/stylesheets/petitions/views/_home.scss
+++ b/app/assets/stylesheets/petitions/views/_home.scss
@@ -94,6 +94,27 @@ a.threshold-panel:hover, a.threshold-panel:focus {
   }
 }
 
+.register-to-vote {
+  font-weight: bold;
+  margin-top: $gutter-half;
+  display: block;
+  padding: $gutter-one-third;
+  background-color: $panel-colour;
+  @include media(tablet) {
+  margin-top: $gutter;
+    padding: $gutter-one-third $gutter-half;
+  }
+  text-decoration: underline;
+}
+
+.local-to-you,
+.start-petition {
+  border-top: 1px solid #dee0e2;
+  border-bottom: none;
+  margin-top: $gutter;
+  padding-bottom: 0;
+}
+
 .local-to-you h2,
 .start-petition h2 {
   @include bold-24();

--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -30,7 +30,11 @@ class Admin::ParliamentsController < Admin::AdminController
   end
 
   def parliament_params
-    params.require(:parliament).permit(:dissolution_at, :dissolution_heading, :dissolution_message, :dissolution_faq_url)
+    params.require(:parliament).permit(
+      :dissolution_heading, :dissolution_message,
+      :dissolved_heading, :dissolved_message,
+      :dissolution_at, :dissolution_faq_url
+    )
   end
 
   def email_creators?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,14 @@ class ApplicationController < ActionController::Base
     Site.protected? unless request.local?
   end
 
+  def parliament_dissolved?
+    Parliament.dissolved?
+  end
+
+  def redirect_to_home_page
+    redirect_to home_url
+  end
+
   def set_seen_cookie_message
     cookies[:seen_cookie_message] = { value: 'yes', expires: 1.year.from_now, httponly: true }
   end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -4,6 +4,8 @@ class PetitionsController < ApplicationController
   before_action :avoid_unknown_state_filters, only: :index
   before_action :do_not_cache, except: %i[index show]
 
+  before_action :redirect_to_home_page, if: :parliament_dissolved?, only: [:new, :check, :check_results, :create]
+
   before_action :retrieve_petition, only: [:show, :count, :gathering_support, :moderation_info]
   before_action :redirect_to_gathering_support_url, if: :collecting_sponsors?, only: [:moderation_info, :show]
   before_action :redirect_to_moderation_info_url, if: :in_moderation?, only: [:gathering_support, :show]

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -20,6 +20,14 @@ class Parliament < ActiveRecord::Base
       instance.dissolution_message
     end
 
+    def dissolved_heading
+      instance.dissolved_heading
+    end
+
+    def dissolved_message
+      instance.dissolved_message
+    end
+
     def dissolution_faq_url
       instance.dissolution_faq_url
     end
@@ -46,8 +54,9 @@ class Parliament < ActiveRecord::Base
   end
 
   validates_presence_of :dissolution_heading, :dissolution_message, if: :dissolution_at?
-  validates_length_of :dissolution_heading, maximum: 100
-  validates_length_of :dissolution_message, maximum: 600
+  validates_presence_of :dissolved_heading, :dissolved_message, if: :dissolved?
+  validates_length_of :dissolution_heading, :dissolved_heading, maximum: 100
+  validates_length_of :dissolution_message, :dissolved_message, maximum: 600
   validates_length_of :dissolution_faq_url, maximum: 500
 
   after_save { Site.touch }

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -30,6 +30,21 @@
         <%= form.text_field :dissolution_faq_url, tabindex: increment, maxlength: 500, class: 'form-control' %>
       <% end %>
 
+      <h2>Dissolved</h2>
+
+      <%= form_row for: [form.object, :dissolved_heading] do %>
+        <%= form.label :dissolved_heading, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :dissolved_heading %>
+        <%= form.text_field :dissolved_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [form.object, :dissolved_message] do %>
+        <%= form.label :dissolved_message, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :dissolved_message %>
+        <%= form.text_area :dissolved_message, tabindex: increment, rows: 5, data: { max_length: 500 }, class: 'form-control' %>
+        <p class="character-count">500 characters max</p>
+      <% end %>
+
       <%= form.submit 'Save', class: 'button' %>
       <%= form.submit 'Email creators', name: 'email_creators', class: 'button-secondary', data: { confirm: 'Email creators about dissolution?' } %>
       <%= form.submit 'Schedule closure', name: 'schedule_closure', class: 'button-secondary', data: { confirm: 'Schedule early closure of petitions?' } %>

--- a/app/views/application/_parliament_dissolution_warning.html.erb
+++ b/app/views/application/_parliament_dissolution_warning.html.erb
@@ -1,8 +1,13 @@
 <% if Parliament.dissolution_announced? %>
   <div class="notification">
     <span class="icon icon-warning-white"></span>
-    <h3 class="header"><%= Parliament.dissolution_heading %></h3>
-    <p class="content"><%= Parliament.dissolution_message %></p>
+    <% if Parliament.dissolved? %>
+      <h3 class="header"><%= Parliament.dissolved_heading %></h3>
+      <p class="content"><%= Parliament.dissolved_message %></p>
+    <% else %>
+      <h3 class="header"><%= Parliament.dissolution_heading %></h3>
+      <p class="content"><%= Parliament.dissolution_message %></p>
+    <% end %>
     <% if Parliament.dissolution_faq_url? %>
       <p class="content">Find out more on the <%= link_to 'Petitions Committee website', Parliament.dissolution_faq_url %></p>
     <% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,6 +3,12 @@
 
   <%= render 'parliament_dissolution_warning' %>
 
+  <% if Parliament.dissolved? %>
+    <a href="https://www.gov.uk/register-to-vote" class="register-to-vote">
+      Register to vote in the General Election
+    </a>
+  <% end %>
+
   <% if no_petitions_yet? %>
     <div class="section-panel-borderless no-petitions-yet">
       <p class="lede">The new Petitions service launched today</p>
@@ -68,7 +74,7 @@
           <p>If a petition gets <%= Site.formatted_threshold_for_debate %> signatures, it will be considered for debate in Parliament</p>
         <% end %>
       <% end %>
-      <div class="section-panel">
+      <div class="section-panel-borderless">
         <%= render "home_debated_petitions", actioned: actioned %>
       </div>
     </section>
@@ -82,9 +88,11 @@
     </section>
   <% end %>
 
-  <section class="section-panel-borderless start-petition" aria-labelledby="start-a-petition-heading">
-    <h2 id="start-a-petition-heading">Start a petition</h2>
-    <p>Anyone can start a petition as long as they are a British citizen or UK resident</p>
-    <%= link_to "Start a petition", check_petitions_path, :class => 'button' %>
-  </section>
+  <% unless Parliament.dissolved? %>
+    <section class="section-panel start-petition" aria-labelledby="start-a-petition-heading">
+      <h2 id="start-a-petition-heading">Start a petition</h2>
+      <p>Anyone can start a petition as long as they are a British citizen or UK resident</p>
+      <%= link_to "Start a petition", check_petitions_path, :class => 'button' %>
+    </section>
+  <% end %>
 <% end %>

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -138,6 +138,8 @@ en-GB:
       parliament:
         dissolution_heading: "Heading"
         dissolution_message: "Message"
+        dissolved_heading: "Heading"
+        dissolved_message: "Message"
         dissolution_at: "Date and time"
     select:
       prompt: Please select

--- a/db/migrate/20170428185435_add_dissolved_message_fields_to_parliament.rb
+++ b/db/migrate/20170428185435_add_dissolved_message_fields_to_parliament.rb
@@ -1,0 +1,6 @@
+class AddDissolvedMessageFieldsToParliament < ActiveRecord::Migration
+  def up
+    add_column :parliaments, :dissolved_heading, :string, limit: 100
+    add_column :parliaments, :dissolved_message, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -520,7 +520,9 @@ CREATE TABLE parliaments (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     dissolution_heading character varying(100),
-    dissolution_faq_url character varying(500)
+    dissolution_faq_url character varying(500),
+    dissolved_heading character varying(100),
+    dissolved_message text
 );
 
 
@@ -1857,4 +1859,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170419165419');
 INSERT INTO schema_migrations (version) VALUES ('20170422104143');
 
 INSERT INTO schema_migrations (version) VALUES ('20170424145119');
+
+INSERT INTO schema_migrations (version) VALUES ('20170428185435');
 

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -14,11 +14,11 @@ Scenario: Charlie has to search for a petition before creating one
   Then I should be on the new petition page
   And I should see my search query already filled in as the action of the petition
 
-Scenario: Charlie starts to creates a petition when parliament is not dissolving
+Scenario: Charlie starts to create a petition when parliament is not dissolving
   Given I am on the check for existing petitions page
   Then I should not see "Parliament is dissolving"
 
-Scenario: Charlie starts to creates a petition when parliament is dissolving
+Scenario: Charlie starts to create a petition when parliament is dissolving
   Given Parliament is dissolving
   And I am on the check for existing petitions page
   Then I should see the Parliament dissolution warning message
@@ -26,6 +26,14 @@ Scenario: Charlie starts to creates a petition when parliament is dissolving
   Then I should see the Parliament dissolution warning message
   When I am on the help page
   Then I should see the Parliament dissolution warning message
+
+Scenario: Charlie starts to create a petition when parliament is dissolved
+  Given Parliament is dissolved
+  And I am on the check for existing petitions page
+  Then I should be on the home page
+  And I should see the Parliament dissolved warning message
+  When I am on the help page
+  Then I should see the Parliament dissolved warning message
 
 @search
 Scenario: Charlie cannot craft an xss attack when searching for petitions

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -21,6 +21,15 @@ Given(/^Parliament is dissolving$/) do
     dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
 end
 
+Given(/^Parliament is dissolved$/) do
+  Parliament.instance.update! dissolution_at: 1.day.ago,
+    dissolution_heading: "Parliament is dissolving",
+    dissolution_message: "This means all petitions will close in 2 weeks",
+    dissolved_heading: "Parliament has been dissolved",
+    dissolved_message: "All petitions have been closed",
+    dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
+end
+
 Given(/^the request is not local$/) do
   page.driver.options[:headers] = { "REMOTE_ADDR" => "192.168.1.128" }
 end
@@ -71,6 +80,14 @@ Then(/^I should see the Parliament dissolution warning message$/) do
   within(:css, ".notification") do
     expect(page).to have_content "Parliament is dissolving"
     expect(page).to have_content "This means all petitions will close in 2 weeks"
+    expect(page).to have_link "Petitions Committee website", href: "https://parliament.example.com/parliament-is-closing"
+  end
+end
+
+Then(/^I should see the Parliament dissolved warning message$/) do
+  within(:css, ".notification") do
+    expect(page).to have_content "Parliament has been dissolved"
+    expect(page).to have_content "All petitions have been closed"
     expect(page).to have_link "Petitions Committee website", href: "https://parliament.example.com/parliament-is-closing"
   end
 end

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe PetitionsController, type: :controller do
       get :new, :petition_action => action
       expect(assigns[:stage_manager].petition.action).to eq action
     end
+
+    context "when parliament is dissolved" do
+      before do
+        allow(Parliament).to receive(:dissolved?).and_return(true)
+      end
+
+      it "redirects to the home page" do
+        get :new
+        expect(response).to redirect_to("https://petition.parliament.uk/")
+      end
+    end
   end
 
   describe "create" do
@@ -214,6 +225,17 @@ RSpec.describe PetitionsController, type: :controller do
         end
       end
     end
+
+    context "when parliament is dissolved" do
+      before do
+        allow(Parliament).to receive(:dissolved?).and_return(true)
+      end
+
+      it "redirects to the home page" do
+        post :create, petition: {}
+        expect(response).to redirect_to("https://petition.parliament.uk/")
+      end
+    end
   end
 
   describe "show" do
@@ -280,6 +302,35 @@ RSpec.describe PetitionsController, type: :controller do
     it "is successful" do
       get :check
       expect(response).to be_success
+    end
+
+    context "when parliament is dissolved" do
+      before do
+        allow(Parliament).to receive(:dissolved?).and_return(true)
+      end
+
+      it "redirects to the home page" do
+        get :check
+        expect(response).to redirect_to("https://petition.parliament.uk/")
+      end
+    end
+  end
+
+  describe "GET #check_results" do
+    it "is successful" do
+      get :check_results, q: "action"
+      expect(response).to be_success
+    end
+
+    context "when parliament is dissolved" do
+      before do
+        allow(Parliament).to receive(:dissolved?).and_return(true)
+      end
+
+      it "redirects to the home page" do
+        get :check_results, q: "action"
+        expect(response).to redirect_to("https://petition.parliament.uk/")
+      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -403,6 +403,8 @@ FactoryGirl.define do
     trait :dissolved do
       dissolution_heading "Parliament is dissolving"
       dissolution_message "This means all petitions will close in 2 weeks"
+      dissolved_heading "Parliament is dissolved"
+      dissolved_message "All petitions are now closed"
       dissolution_at { 2.weeks.ago }
     end
   end

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Parliament, type: :model do
     it { is_expected.to have_db_column(:dissolution_heading).of_type(:string).with_options(limit: 100, null: true) }
     it { is_expected.to have_db_column(:dissolution_message).of_type(:text).with_options(null: true) }
     it { is_expected.to have_db_column(:dissolution_faq_url).of_type(:string).with_options(limit: 500, null: true) }
+    it { is_expected.to have_db_column(:dissolved_heading).of_type(:string).with_options(limit: 100, null: true) }
+    it { is_expected.to have_db_column(:dissolved_message).of_type(:text).with_options(null: true) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   end
@@ -37,9 +39,13 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.not_to validate_presence_of(:dissolution_heading) }
       it { is_expected.not_to validate_presence_of(:dissolution_message) }
+      it { is_expected.not_to validate_presence_of(:dissolved_heading) }
+      it { is_expected.not_to validate_presence_of(:dissolved_message) }
       it { is_expected.not_to validate_presence_of(:dissolution_faq_url) }
       it { is_expected.to validate_length_of(:dissolution_heading).is_at_most(100) }
       it { is_expected.to validate_length_of(:dissolution_message).is_at_most(600) }
+      it { is_expected.to validate_length_of(:dissolved_heading).is_at_most(100) }
+      it { is_expected.to validate_length_of(:dissolved_message).is_at_most(600) }
       it { is_expected.to validate_length_of(:dissolution_faq_url).is_at_most(500) }
     end
 
@@ -48,9 +54,28 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.to validate_presence_of(:dissolution_heading) }
       it { is_expected.to validate_presence_of(:dissolution_message) }
+      it { is_expected.not_to validate_presence_of(:dissolved_heading) }
+      it { is_expected.not_to validate_presence_of(:dissolved_message) }
       it { is_expected.not_to validate_presence_of(:dissolution_faq_url) }
       it { is_expected.to validate_length_of(:dissolution_heading).is_at_most(100) }
       it { is_expected.to validate_length_of(:dissolution_message).is_at_most(600) }
+      it { is_expected.to validate_length_of(:dissolved_heading).is_at_most(100) }
+      it { is_expected.to validate_length_of(:dissolved_message).is_at_most(600) }
+      it { is_expected.to validate_length_of(:dissolution_faq_url).is_at_most(500) }
+    end
+
+    context "when dissolution_at is in the past" do
+      subject { Parliament.new(dissolution_at: 1.day.ago) }
+
+      it { is_expected.to validate_presence_of(:dissolution_heading) }
+      it { is_expected.to validate_presence_of(:dissolution_message) }
+      it { is_expected.to validate_presence_of(:dissolved_heading) }
+      it { is_expected.to validate_presence_of(:dissolved_message) }
+      it { is_expected.not_to validate_presence_of(:dissolution_faq_url) }
+      it { is_expected.to validate_length_of(:dissolution_heading).is_at_most(100) }
+      it { is_expected.to validate_length_of(:dissolution_message).is_at_most(600) }
+      it { is_expected.to validate_length_of(:dissolved_heading).is_at_most(100) }
+      it { is_expected.to validate_length_of(:dissolved_message).is_at_most(600) }
       it { is_expected.to validate_length_of(:dissolution_faq_url).is_at_most(500) }
     end
   end
@@ -80,6 +105,16 @@ RSpec.describe Parliament, type: :model do
     it "delegates dissolution_message to the instance" do
       expect(parliament).to receive(:dissolution_message).and_return("Parliament is dissolving")
       expect(Parliament.dissolution_message).to eq("Parliament is dissolving")
+    end
+
+    it "delegates dissolved_heading to the instance" do
+      expect(parliament).to receive(:dissolved_heading).and_return("Parliament is dissolved")
+      expect(Parliament.dissolved_heading).to eq("Parliament is dissolved")
+    end
+
+    it "delegates dissolved_message to the instance" do
+      expect(parliament).to receive(:dissolved_message).and_return("Parliament is dissolved")
+      expect(Parliament.dissolved_message).to eq("Parliament is dissolved")
     end
 
     it "delegates dissolution_faq_url to the instance" do
@@ -222,7 +257,7 @@ RSpec.describe Parliament, type: :model do
         FactoryGirl.create(:parliament, :dissolved)
       end
 
-      it "returns false" do
+      it "returns true" do
         expect(parliament.dissolved?).to eq(true)
       end
     end


### PR DESCRIPTION
This adds dissolved messaging for when the dissolution has occurred and prevents the creation of new petitions after that date. Since archiving of the petitions and signature statistics can't happen instantaneously we'll continue to show the petitions and popular local petitions until that process is complete. Also adds a link on the home page to the Register to Vote service.