### PR TITLE
Tweak parliament dissolved home page

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,7 +3,7 @@
 
   <%= render 'parliament_dissolution_warning' %>
 
-  <% if Parliament.dissolved? %>
+  <% if Parliament.dissolution_announced? %>
     <a href="https://www.gov.uk/register-to-vote" class="register-to-vote">
       Register to vote in the General Election
     </a>
@@ -40,7 +40,9 @@
           </ul>
         </section>
       <% end %>
-      <%= link_to 'View all open petitions', petitions_path(state: 'open'), :class => 'view-all' %>
+      <% unless Parliament.dissolved? %>
+        <%= link_to 'View all open petitions', petitions_path(state: 'open'), :class => 'view-all' %>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
Hide the open petitions link after parliament has dissolved and show the register to vote link before it has happened.