### PR TITLE
Stop unpublished petitions

### DIFF
--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -33,7 +33,8 @@ class Admin::ParliamentsController < Admin::AdminController
     params.require(:parliament).permit(
       :dissolution_heading, :dissolution_message,
       :dissolved_heading, :dissolved_message,
-      :dissolution_at, :dissolution_faq_url
+      :dissolution_at, :dissolution_faq_url,
+      :notification_cutoff_at
     )
   end
 

--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -14,6 +14,7 @@ class Admin::ParliamentsController < Admin::AdminController
         redirect_to admin_root_url, notice: :creators_emailed
       elsif schedule_closure?
         ClosePetitionsEarlyJob.schedule_for(@parliament.dissolution_at)
+        StopPetitionsEarlyJob.schedule_for(@parliament.dissolution_at)
         redirect_to admin_root_url, notice: :closure_scheduled
       else
         redirect_to admin_root_url, notice: :parliament_updated

--- a/app/jobs/notify_creator_of_sponsored_petition_being_stopped_job.rb
+++ b/app/jobs/notify_creator_of_sponsored_petition_being_stopped_job.rb
@@ -1,0 +1,13 @@
+class NotifyCreatorOfSponsoredPetitionBeingStoppedJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_creator_of_sponsored_petition_being_stopped
+
+  queue_as :low_priority
+
+  def perform(signature)
+    if Parliament.dissolved?
+      mailer.send(email, signature).deliver_now
+    end
+  end
+end
+

--- a/app/jobs/notify_creator_of_validated_petition_being_stopped_job.rb
+++ b/app/jobs/notify_creator_of_validated_petition_being_stopped_job.rb
@@ -1,0 +1,13 @@
+class NotifyCreatorOfValidatedPetitionBeingStoppedJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_creator_of_validated_petition_being_stopped
+
+  queue_as :low_priority
+
+  def perform(signature)
+    if Parliament.dissolved?
+      mailer.send(email, signature).deliver_now
+    end
+  end
+end
+

--- a/app/jobs/stop_petitions_early_job.rb
+++ b/app/jobs/stop_petitions_early_job.rb
@@ -1,0 +1,27 @@
+class StopPetitionsEarlyJob < ApplicationJob
+  queue_as :high_priority
+
+  class << self
+    def schedule_for(time)
+      set(wait_until: time).perform_later(time.iso8601)
+    end
+  end
+
+  def perform(time)
+    time = time.in_time_zone
+    cutoff_time = Parliament.notification_cutoff_at
+
+    Petition.in_need_of_stopping.find_each do |petition|
+      if petition.created_at >= cutoff_time
+        case petition.state
+        when Petition::VALIDATED_STATE
+          NotifyCreatorOfValidatedPetitionBeingStoppedJob.perform_later(petition.creator_signature)
+        when Petition::SPONSORED_STATE
+          NotifyCreatorOfSponsoredPetitionBeingStoppedJob.perform_later(petition.creator_signature)
+        end
+      end
+
+      petition.stop!(time)
+    end
+  end
+end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -75,6 +75,16 @@ class PetitionMailer < ApplicationMailer
     mail to: @signature.email, subject: subject_for(:notify_creator_of_closing_date_change)
   end
 
+  def notify_creator_of_sponsored_petition_being_stopped(signature)
+    @signature, @petition = signature, signature.petition
+    mail to: @signature.email, subject: subject_for(:notify_creator_of_sponsored_petition_being_stopped)
+  end
+
+  def notify_creator_of_validated_petition_being_stopped(signature)
+    @signature, @petition = signature, signature.petition
+    mail to: @signature.email, subject: subject_for(:notify_creator_of_validated_petition_being_stopped)
+  end
+
   def gather_sponsors_for_petition(petition)
     @petition, @creator = petition, petition.creator_signature
     mail to: @creator.email, subject: subject_for(:gather_sponsors_for_petition)

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -12,6 +12,10 @@ class Parliament < ActiveRecord::Base
       instance.dissolution_at
     end
 
+    def notification_cutoff_at
+      instance.notification_cutoff_at
+    end
+
     def dissolution_heading
       instance.dissolution_heading
     end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -284,7 +284,8 @@ class Petition < ActiveRecord::Base
     end
 
     def in_need_of_stopping(time = nil)
-      time ? stoppable.created_after(time) : stoppable
+      scope = preload(:creator_signature)
+      time ? scope.stoppable.created_after(time) : scope.stoppable
     end
 
     def created_after(time)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -496,7 +496,11 @@ class Petition < ActiveRecord::Base
   end
 
   def close!(time = deadline)
-    update!(state: CLOSED_STATE, closed_at: time)
+    if open?
+      update!(state: CLOSED_STATE, closed_at: time)
+    else
+      raise RuntimeError, "can't stop a petition that is in the #{state} state"
+    end
   end
 
   def validate_creator_signature!

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -32,6 +32,12 @@
 
       <h2>Dissolved</h2>
 
+      <%= form_row for: [form.object, :notification_cutoff_at] do %>
+        <%= form.label :notification_cutoff_at, class: 'form-label' %>
+        <%= error_messages_for_field @parliament, :notification_cutoff_at %>
+        <%= form.datetime_select :notification_cutoff_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+      <% end %>
+
       <%= form_row for: [form.object, :dissolved_heading] do %>
         <%= form.label :dissolved_heading, class: 'form-label' %>
         <%= error_messages_for_field @parliament, :dissolved_heading %>

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.html.erb
@@ -4,13 +4,13 @@
 
 <p>We’re sorry we weren’t able to give you more notice that this would happen.</p>
 
-<p>Your petition will be available for people to read on the site even though it will be closed for signatures. Your petition can't be reopened after the election. You are very welcome to start your petition again when the site reopens after the election, but you will need to collect new signatures. We can't transfer signatures to your new petition.</p>
+<p>Your petition will be available for people to read on the site even though it will be closed for signatures. Your petition can’t be reopened after the election. You are very welcome to start your petition again when the site reopens after the election, but you will need to collect new signatures. We can’t transfer signatures to your new petition.</p>
 
-<p>The Government can't respond to petitions during the election period. This means if your petition has over <%= Site.formatted_threshold_for_response %> signatures, it can't receive a response from the current Government after <%= @last_response_date %>. After the election, the new Government will have to decide whether it wants to respond to petitions from before the election.</p>
+<p>The Government can’t respond to petitions during the election period. This means if your petition has over <%= Site.formatted_threshold_for_response %> signatures, it can’t receive a response from the current Government after <%= @last_response_date %>. After the election, the new Government will have to decide whether it wants to respond to petitions from before the election.</p>
 
-<p>The Petitions Committee, the group of MPs who decide whether petitions are debated, won't exist after <%= @closing_date %>. This means that if your petition has over <%= Site.formatted_threshold_for_debate %> signatures, it can't be scheduled for debate. After the election, there will be a new Petitions Committee, and they will be responsible for deciding which petitions are debated.</p>
+<p>The Petitions Committee, the group of MPs who decide whether petitions are debated, won’t exist after <%= @closing_date %>. This means that if your petition has over <%= Site.formatted_threshold_for_debate %> signatures, it can’t be scheduled for debate. After the election, there will be a new Petitions Committee, and they will be responsible for deciding which petitions are debated.</p>
 
-<p>The petitions site will open again after the election, but at the moment we don't know exactly when. You can follow us on Twitter <a href="https://twitter.com/HoCPetitions">@HoCPetitions</a> for updates, or check back on the petitions site for news if you prefer.</p>
+<p>The petitions site will open again after the election, but at the moment we don’t know exactly when. You can follow us on Twitter <a href="https://twitter.com/HoCPetitions">@HoCPetitions</a> for updates, or check back on the petitions site for news if you prefer.</p>
 
 <p>Many thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_closing_date_change.text.erb
@@ -4,13 +4,13 @@ Because of the General Election, the closing date for your petition has changed.
 
 We’re sorry we weren’t able to give you more notice that this would happen.
 
-Your petition will be available for people to read on the site even though it will be closed for signatures. Your petition can't be reopened after the election. You are very welcome to start your petition again when the site reopens after the election, but you will need to collect new signatures. We can't transfer signatures to your new petition.
+Your petition will be available for people to read on the site even though it will be closed for signatures. Your petition can’t be reopened after the election. You are very welcome to start your petition again when the site reopens after the election, but you will need to collect new signatures. We can’t transfer signatures to your new petition.
 
-The Government can't respond to petitions during the election period. This means if your petition has over <%= Site.formatted_threshold_for_response %> signatures, it can't receive a response from the current Government after <%= @last_response_date %>. After the election, the new Government will have to decide whether it wants to respond to petitions from before the election.
+The Government can’t respond to petitions during the election period. This means if your petition has over <%= Site.formatted_threshold_for_response %> signatures, it can’t receive a response from the current Government after <%= @last_response_date %>. After the election, the new Government will have to decide whether it wants to respond to petitions from before the election.
 
-The Petitions Committee, the group of MPs who decide whether petitions are debated, won't exist after <%= @closing_date %>. This means that if your petition has over <%= Site.formatted_threshold_for_debate %> signatures, it can't be scheduled for debate. After the election, there will be a new Petitions Committee, and they will be responsible for deciding which petitions are debated.
+The Petitions Committee, the group of MPs who decide whether petitions are debated, won’t exist after <%= @closing_date %>. This means that if your petition has over <%= Site.formatted_threshold_for_debate %> signatures, it can’t be scheduled for debate. After the election, there will be a new Petitions Committee, and they will be responsible for deciding which petitions are debated.
 
-The petitions site will open again after the election, but at the moment we don't know exactly when. You can follow us on Twitter @HoCPetitions for updates, or check back on the petitions site for news if you prefer.
+The petitions site will open again after the election, but at the moment we don’t know exactly when. You can follow us on Twitter @HoCPetitions for updates, or check back on the petitions site for news if you prefer.
 
 Many thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petition_mailer/notify_creator_of_sponsored_petition_being_stopped.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_sponsored_petition_being_stopped.html.erb
@@ -1,0 +1,17 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Because of the General Election, the petitions site had to close. This is because Parliament is now dissolved which means that all parliamentary business – including petitions – must stop for a few weeks before the vote.</p>
+
+<p>We’re very sorry that we didn’t have time to check your petition before this happened.</p>
+
+<p>Petitions started before the election won’t restart when the site opens again. You are very welcome to resubmit your petition once the site reopens, but you’ll need to collect your five sponsor signatures again.</p>
+
+<p>The petitions site will open again after the election, but at the moment we don’t know exactly when. You can follow us on Twitter <a href="https://twitter.com/HoCPetitions">@HoCPetitions</a> for updates, or check back on the petitions site for news if you prefer.</p>
+
+<% if Parliament.dissolution_faq_url? %>
+<p>You can find out more about what the General Election means for your petitions on our website: <%= link_to(nil, Parliament.dissolution_faq_url) %></p>
+<% end %>
+
+<p>Many thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_creator_of_sponsored_petition_being_stopped.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_sponsored_petition_being_stopped.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @signature.name %>,
+
+Because of the General Election, the petitions site had to close. This is because Parliament is now dissolved which means that all parliamentary business – including petitions – must stop for a few weeks before the vote.
+
+We’re very sorry that we didn’t have time to check your petition before this happened.
+
+Petitions started before the election won’t restart when the site opens again. You are very welcome to resubmit your petition once the site reopens, but you’ll need to collect your five sponsor signatures again.
+
+The petitions site will open again after the election, but at the moment we don’t know exactly when. You can follow us on Twitter @HoCPetitions for updates, or check back on the petitions site for news if you prefer.
+
+<% if Parliament.dissolution_faq_url? %>
+You can find out more about what the General Election means for your petitions on our website: <%= Parliament.dissolution_faq_url %>
+<% end %>
+
+Many thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/notify_creator_of_validated_petition_being_stopped.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_validated_petition_being_stopped.html.erb
@@ -1,0 +1,17 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Because of the General Election, the petitions site had to close. This is because Parliament is now dissolved which means that all parliamentary business – including petitions – must stop for a few weeks before the vote.</p>
+
+<p>We’re very sorry that you didn’t have time to collect your five signatures before this happened.</p>
+
+<p>Petitions started before the election won’t restart when the site opens again. You are very welcome to resubmit your petition once the site reopens, but you’ll need to collect your sponsor signatures again.</p>
+
+<p>The petitions site will open again after the election, but at the moment we don’t know exactly when. You can follow us on Twitter <a href="https://twitter.com/HoCPetitions">@HoCPetitions</a> for updates, or check back on the petitions site for news if you prefer.</p>
+
+<% if Parliament.dissolution_faq_url? %>
+<p>You can find out more about what the General Election means for your petitions on our website: <%= link_to(nil, Parliament.dissolution_faq_url) %></p>
+<% end %>
+
+<p>Many thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_creator_of_validated_petition_being_stopped.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_validated_petition_being_stopped.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @signature.name %>,
+
+Because of the General Election, the petitions site had to close. This is because Parliament is now dissolved which means that all parliamentary business – including petitions – must stop for a few weeks before the vote.
+
+We’re very sorry that you didn’t have time to collect your five signatures before this happened.
+
+Petitions started before the election won’t restart when the site opens again. You are very welcome to resubmit your petition once the site reopens, but you’ll need to collect your sponsor signatures again.
+
+The petitions site will open again after the election, but at the moment we don’t know exactly when. You can follow us on Twitter @HoCPetitions for updates, or check back on the petitions site for news if you prefer.
+
+<% if Parliament.dissolution_faq_url? %>
+You can find out more about what the General Election means for your petitions on our website: <%= Parliament.dissolution_faq_url %>
+<% end %>
+
+Many thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -141,6 +141,7 @@ en-GB:
         dissolved_heading: "Heading"
         dissolved_message: "Message"
         dissolution_at: "Date and time"
+        notification_cutoff_at: "Notify unpublished petitions created after"
     select:
       prompt: Please select
     submit:

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -130,6 +130,10 @@ en-GB:
           Please confirm your email address
         notify_creator_of_closing_date_change: |-
           We’re closing your petition early
+        notify_creator_of_sponsored_petition_being_stopped: |-
+          We’ve stopped your petition early
+        notify_creator_of_validated_petition_being_stopped: |-
+          We’ve stopped your petition early
       signoff_prefix: "The Petitions team"
       signoff_suffix: "UK Government and Parliament"
 

--- a/db/migrate/20170428211336_add_stopped_at_to_petitions.rb
+++ b/db/migrate/20170428211336_add_stopped_at_to_petitions.rb
@@ -1,0 +1,5 @@
+class AddStoppedAtToPetitions < ActiveRecord::Migration
+  def change
+    add_column :petitions, :stopped_at, :datetime
+  end
+end

--- a/db/migrate/20170429023722_add_notification_cutoff_at_to_parliament.rb
+++ b/db/migrate/20170429023722_add_notification_cutoff_at_to_parliament.rb
@@ -1,0 +1,5 @@
+class AddNotificationCutoffAtToParliament < ActiveRecord::Migration
+  def change
+    add_column :parliaments, :notification_cutoff_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -522,7 +522,8 @@ CREATE TABLE parliaments (
     dissolution_heading character varying(100),
     dissolution_faq_url character varying(500),
     dissolved_heading character varying(100),
-    dissolved_message text
+    dissolved_message text,
+    notification_cutoff_at timestamp without time zone
 );
 
 
@@ -1864,4 +1865,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170424145119');
 INSERT INTO schema_migrations (version) VALUES ('20170428185435');
 
 INSERT INTO schema_migrations (version) VALUES ('20170428211336');
+
+INSERT INTO schema_migrations (version) VALUES ('20170429023722');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -605,7 +605,8 @@ CREATE TABLE petitions (
     rejected_at timestamp without time zone,
     debate_outcome_at timestamp without time zone,
     moderation_threshold_reached_at timestamp without time zone,
-    debate_state character varying(30) DEFAULT 'pending'::character varying
+    debate_state character varying(30) DEFAULT 'pending'::character varying,
+    stopped_at timestamp without time zone
 );
 
 
@@ -1861,4 +1862,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170422104143');
 INSERT INTO schema_migrations (version) VALUES ('20170424145119');
 
 INSERT INTO schema_migrations (version) VALUES ('20170428185435');
+
+INSERT INTO schema_migrations (version) VALUES ('20170428211336');
 

--- a/spec/controllers/admin/parliaments_controller_spec.rb
+++ b/spec/controllers/admin/parliaments_controller_spec.rb
@@ -214,6 +214,15 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
+          let :stop_petitions_early_job do
+            {
+              job: StopPetitionsEarlyJob,
+              args: [dissolution_at.iso8601],
+              queue: "high_priority",
+              at: dissolution_at.to_f
+            }
+          end
+
           it "redirects to the admin dashboard page" do
             expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
           end
@@ -222,8 +231,12 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             expect(flash[:notice]).to eq("Petitions have been scheduled to close early")
           end
 
-          it "enqueues a job to notify creators" do
-            expect(enqueued_jobs).to eq([close_petitions_early_job])
+          it "enqueues a job to close petitions" do
+            expect(enqueued_jobs).to include(close_petitions_early_job)
+          end
+
+          it "enqueues a job to stop petitions" do
+            expect(enqueued_jobs).to include(stop_petitions_early_job)
           end
         end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -122,6 +122,11 @@ FactoryGirl.define do
     closed_at  { 1.day.ago }
   end
 
+  factory :stopped_petition, :parent => :petition do
+    state  Petition::STOPPED_STATE
+    stopped_at { 1.day.ago }
+  end
+
   factory :rejected_petition, :parent => :petition do
     state Petition::REJECTED_STATE
 

--- a/spec/jobs/email_job_spec.rb
+++ b/spec/jobs/email_job_spec.rb
@@ -179,6 +179,72 @@ RSpec.describe NotifyCreatorThatParliamentIsDissolvingJob, type: :job do
   end
 end
 
+RSpec.describe NotifyCreatorOfValidatedPetitionBeingStoppedJob, type: :job do
+  let(:petition) { FactoryGirl.create(:validated_petition) }
+  let(:signature) { FactoryGirl.create(:signature, petition: petition) }
+
+  context "when parliament is not dissolved" do
+    before do
+      allow(Parliament).to receive(:dissolved?).and_return(false)
+    end
+
+    it "does not send the PetitionMailer#notify_creator_of_validated_petition_being_stopped email" do
+      expect(PetitionMailer).not_to receive(:notify_creator_of_validated_petition_being_stopped).with(signature).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(signature)
+      end
+    end
+  end
+
+  context "when parliament is dissolved" do
+    before do
+      allow(Parliament).to receive(:dissolved?).and_return(true)
+    end
+
+    it "sends the PetitionMailer#notify_creator_of_validated_petition_being_stopped email" do
+      expect(PetitionMailer).to receive(:notify_creator_of_validated_petition_being_stopped).with(signature).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(signature)
+      end
+    end
+  end
+end
+
+RSpec.describe NotifyCreatorOfSponsoredPetitionBeingStoppedJob, type: :job do
+  let(:petition) { FactoryGirl.create(:sponsored_petition) }
+  let(:signature) { FactoryGirl.create(:signature, petition: petition) }
+
+  context "when parliament is not dissolved" do
+    before do
+      allow(Parliament).to receive(:dissolved?).and_return(false)
+    end
+
+    it "does not send the PetitionMailer#notify_creator_of_sponsored_petition_being_stopped email" do
+      expect(PetitionMailer).not_to receive(:notify_creator_of_sponsored_petition_being_stopped).with(signature).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(signature)
+      end
+    end
+  end
+
+  context "when parliament is dissolved" do
+    before do
+      allow(Parliament).to receive(:dissolved?).and_return(true)
+    end
+
+    it "sends the PetitionMailer#notify_creator_of_sponsored_petition_being_stopped email" do
+      expect(PetitionMailer).to receive(:notify_creator_of_sponsored_petition_being_stopped).with(signature).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(signature)
+      end
+    end
+  end
+end
+
 RSpec.describe NotifyCreatorThatPetitionIsPublishedEmailJob, type: :job do
   let(:petition) { FactoryGirl.create(:petition) }
   let(:signature) { FactoryGirl.create(:signature, petition: petition) }

--- a/spec/jobs/stop_petitions_early_job_spec.rb
+++ b/spec/jobs/stop_petitions_early_job_spec.rb
@@ -1,0 +1,234 @@
+require 'rails_helper'
+
+RSpec.describe StopPetitionsEarlyJob, type: :job do
+  let(:state) { Petition::PENDING_STATE }
+  let(:created_at) { dissolution_at - 1.month }
+  let(:dissolution_at) { "2017-05-02T23:00:01Z".in_time_zone }
+  let(:scheduled_at) { dissolution_at - 2.weeks }
+  let(:before_dissolution) { dissolution_at - 1.week }
+  let(:notification_cutoff_at) { "2017-03-31T23:00:00Z".in_time_zone }
+  let(:job) { Delayed::Job.last }
+  let(:jobs) { Delayed::Job.all.to_a }
+  let(:creator) { petition.creator_signature }
+
+  let!(:petition) { FactoryGirl.create(:"#{state}_petition", created_at: created_at) }
+
+  before do
+    ActiveJob::Base.queue_adapter = :delayed_job
+
+    allow(Parliament).to receive(:notification_cutoff_at).and_return(notification_cutoff_at)
+    allow(Parliament).to receive(:dissolved?).and_return(true)
+
+    travel_to(scheduled_at) {
+      described_class.schedule_for(dissolution_at)
+    }
+  end
+
+  after do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  it "enqueues the job" do
+    expect(jobs).to eq([job])
+  end
+
+  context "before the scheduled date" do
+    it "doesn't perform the enqueued job" do
+      expect {
+        travel_to(before_dissolution) {
+          Delayed::Worker.new.work_off
+        }
+      }.not_to change {
+        petition.reload.state
+      }
+    end
+  end
+
+  context "after the scheduled date" do
+    it "stops the petition" do
+      expect {
+        travel_to(dissolution_at) {
+          Delayed::Worker.new.work_off
+        }
+      }.to change {
+        petition.reload.state
+      }.from("pending").to("stopped")
+    end
+
+    it "sets the stopped_at to the correct timestamp" do
+      expect {
+        travel_to(dissolution_at) {
+          Delayed::Worker.new.work_off
+        }
+      }.to change {
+        petition.reload.stopped_at
+      }.from(nil).to(dissolution_at)
+    end
+  end
+
+  context "when the petition is pending" do
+    let(:state) { Petition::PENDING_STATE }
+
+    context "and was created before the cutoff date" do
+      let(:created_at) { notification_cutoff_at - 1.week }
+
+      it "doesn't send a notification email" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.not_to change {
+          deliveries.size
+        }
+      end
+
+      it "stops the petition" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          petition.reload.state
+        }.from("pending").to("stopped")
+      end
+    end
+
+    context "and was created after the cutoff date" do
+      let(:created_at) { notification_cutoff_at + 1.week }
+
+      it "doesn't send a notification email" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.not_to change {
+          deliveries.size
+        }
+      end
+
+      it "stops the petition" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          petition.reload.state
+        }.from("pending").to("stopped")
+      end
+    end
+  end
+
+  context "when the petition is validated" do
+    let(:state) { Petition::VALIDATED_STATE }
+    let(:email) { :notify_creator_of_validated_petition_being_stopped }
+
+    context "and was created before the cutoff date" do
+      let(:created_at) { notification_cutoff_at - 1.week }
+
+      it "doesn't send a notification email" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.not_to change {
+          deliveries.size
+        }
+      end
+
+      it "stops the petition" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          petition.reload.state
+        }.from("validated").to("stopped")
+      end
+    end
+
+    context "and was created after the cutoff date" do
+      let(:created_at) { notification_cutoff_at + 1.week }
+
+      before do
+        expect(PetitionMailer).to receive(email).with(creator).and_call_original
+      end
+
+      it "sends a notification email" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          deliveries.size
+        }.by(1)
+      end
+
+      it "stops the petition" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          petition.reload.state
+        }.from("validated").to("stopped")
+      end
+    end
+  end
+
+  context "when the petition is sponsored" do
+    let(:state) { Petition::SPONSORED_STATE }
+    let(:email) { :notify_creator_of_sponsored_petition_being_stopped }
+
+    context "and was created before the cutoff date" do
+      let(:created_at) { notification_cutoff_at - 1.week }
+
+      it "doesn't send a notification email" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.not_to change {
+          deliveries.size
+        }
+      end
+
+      it "stops the petition" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          petition.reload.state
+        }.from("sponsored").to("stopped")
+      end
+    end
+
+    context "and was created after the cutoff date" do
+      let(:created_at) { notification_cutoff_at + 1.week }
+
+      before do
+        expect(PetitionMailer).to receive(email).with(creator).and_call_original
+      end
+
+      it "sends a notification email" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          deliveries.size
+        }.by(1)
+      end
+
+      it "stops the petition" do
+        expect {
+          travel_to(dissolution_at) {
+            Delayed::Worker.new.work_off
+          }
+        }.to change {
+          petition.reload.state
+        }.from("sponsored").to("stopped")
+      end
+    end
+  end
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -207,6 +207,68 @@ RSpec.describe PetitionMailer, type: :mailer do
     end
   end
 
+  describe "notifying creator of their sponsored petition being stopped" do
+    let! :petition do
+      FactoryGirl.create(:sponsored_petition,
+        creator_signature: creator,
+        action: "Allow organic vegetable vans to use red diesel",
+        background: "Add vans to permitted users of red diesel",
+        additional_details: "To promote organic vegetables"
+      )
+    end
+
+    let(:mail) { PetitionMailer.notify_creator_of_sponsored_petition_being_stopped(creator) }
+
+    it "is sent to the right address" do
+      expect(mail.to).to eq(%w[bazbutler@gmail.com])
+      expect(mail.cc).to be_blank
+      expect(mail.bcc).to be_blank
+    end
+
+    it "has an appropriate subject heading" do
+      expect(mail).to have_subject("We’ve stopped your petition early")
+    end
+
+    it "is addressed to the creator" do
+      expect(mail).to have_body_text("Dear Barry Butler,")
+    end
+
+    it "informs the creator of the change" do
+      expect(mail).to have_body_text("We’re very sorry that we didn’t have time to check your petition before this happened")
+    end
+  end
+
+  describe "notifying creator of their validated petition being stopped" do
+    let! :petition do
+      FactoryGirl.create(:validated_petition,
+        creator_signature: creator,
+        action: "Allow organic vegetable vans to use red diesel",
+        background: "Add vans to permitted users of red diesel",
+        additional_details: "To promote organic vegetables"
+      )
+    end
+
+    let(:mail) { PetitionMailer.notify_creator_of_validated_petition_being_stopped(creator) }
+
+    it "is sent to the right address" do
+      expect(mail.to).to eq(%w[bazbutler@gmail.com])
+      expect(mail.cc).to be_blank
+      expect(mail.bcc).to be_blank
+    end
+
+    it "has an appropriate subject heading" do
+      expect(mail).to have_subject("We’ve stopped your petition early")
+    end
+
+    it "is addressed to the creator" do
+      expect(mail).to have_body_text("Dear Barry Butler,")
+    end
+
+    it "informs the creator of the change" do
+      expect(mail).to have_body_text("We’re very sorry that you didn’t have time to collect your five signatures before this happened")
+    end
+  end
+
   describe "gathering sponsors for petition" do
     subject(:mail) { described_class.gather_sponsors_for_petition(petition) }
 

--- a/spec/mailers/previews/petition_mailer_preview.rb
+++ b/spec/mailers/previews/petition_mailer_preview.rb
@@ -45,6 +45,20 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.notify_creator_of_closing_date_change(signature)
   end
 
+  def notify_creator_of_sponsored_petition_being_stopped
+    petition = Petition.where(state: "sponsored").last
+    signature = petition.creator_signature
+
+    PetitionMailer.notify_creator_of_sponsored_petition_being_stopped(signature)
+  end
+
+  def notify_creator_of_validated_petition_being_stopped
+    petition = Petition.where(state: "validated").last
+    signature = petition.creator_signature
+
+    PetitionMailer.notify_creator_of_validated_petition_being_stopped(signature)
+  end
+
   def debated_petition_signer_notification
     petition = Petition.debated.last
     signature = petition.signatures.validated.last

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Parliament, type: :model do
     it { is_expected.to have_db_column(:dissolution_faq_url).of_type(:string).with_options(limit: 500, null: true) }
     it { is_expected.to have_db_column(:dissolved_heading).of_type(:string).with_options(limit: 100, null: true) }
     it { is_expected.to have_db_column(:dissolved_message).of_type(:text).with_options(null: true) }
+    it { is_expected.to have_db_column(:notification_cutoff_at).of_type(:datetime).with_options(null: true) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   end
@@ -95,6 +96,11 @@ RSpec.describe Parliament, type: :model do
     it "delegates dissolution_at to the instance" do
       expect(parliament).to receive(:dissolution_at).and_return(now)
       expect(Parliament.dissolution_at).to eq(now)
+    end
+
+    it "delegates notification_cutoff_at to the instance" do
+      expect(parliament).to receive(:notification_cutoff_at).and_return(now)
+      expect(Parliament.notification_cutoff_at).to eq(now)
     end
 
     it "delegates dissolution_heading to the instance" do

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -440,6 +440,24 @@ RSpec.describe Petition, type: :model do
       end
     end
 
+    context "stoppable" do
+      let!(:open_petition) { FactoryGirl.create(:open_petition) }
+      let!(:closed_petition) { FactoryGirl.create(:open_petition) }
+      let!(:rejected_petition) { FactoryGirl.create(:rejected_petition) }
+      let!(:hidden_petition) { FactoryGirl.create(:hidden_petition) }
+
+      let!(:stoppable_1) { FactoryGirl.create(:pending_petition) }
+      let!(:stoppable_2) { FactoryGirl.create(:validated_petition) }
+      let!(:stoppable_3) { FactoryGirl.create(:sponsored_petition) }
+      let!(:stoppable_4) { FactoryGirl.create(:flagged_petition) }
+
+      let(:stoppable_petitions) { [stoppable_1, stoppable_2, stoppable_3, stoppable_4] }
+
+      it "returns only stoppable petitions" do
+        expect(Petition.stoppable).to include(*stoppable_petitions)
+      end
+    end
+
     context 'in_debate_queue' do
       let!(:petition_1) { FactoryGirl.create(:open_petition, debate_threshold_reached_at: 1.day.ago) }
       let!(:petition_2) { FactoryGirl.create(:open_petition, debate_threshold_reached_at: nil) }
@@ -893,6 +911,26 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe "stopped?" do
+    context "when the state is stopped" do
+      let(:petition) { FactoryGirl.build(:petition, state: Petition::STOPPED_STATE) }
+
+      it "returns true" do
+        expect(petition.stopped?).to be_truthy
+      end
+    end
+
+    context "for other states" do
+      (Petition::STATES - [Petition::STOPPED_STATE]).each do |state|
+        let(:petition) { FactoryGirl.build(:petition, state: state) }
+
+        it "is not stopped when state is #{state}" do
+          expect(petition.stopped?).to be_falsey
+        end
+      end
+    end
+  end
+
   describe "hidden?" do
     context "when the state is hidden" do
       it "returns true" do
@@ -1048,6 +1086,23 @@ RSpec.describe Petition, type: :model do
     end
   end
 
+  describe ".stop_petitions_early!" do
+    let(:dissolution_at) { Time.utc(2017, 5, 2, 23, 1, 0).in_time_zone }
+    let!(:petition) { FactoryGirl.create(:pending_petition) }
+
+    it "stops the petition" do
+      expect{
+        described_class.stop_petitions_early!(dissolution_at)
+      }.to change{ petition.reload.state }.from('pending').to('stopped')
+    end
+
+    it "sets stopped_at to the dissolution timestamp" do
+      expect{
+        described_class.stop_petitions_early!(dissolution_at)
+      }.to change{ petition.reload.stopped_at }.from(nil).to(dissolution_at)
+    end
+  end
+
   describe ".in_need_of_closing" do
     context "when a petition is in the closed state" do
       let!(:petition) { FactoryGirl.create(:closed_petition) }
@@ -1072,6 +1127,38 @@ RSpec.describe Petition, type: :model do
 
       it "finds the petition" do
         expect(described_class.in_need_of_closing.to_a).to include(petition)
+      end
+    end
+  end
+
+  describe ".in_need_of_stopping" do
+    let!(:open_petition) { FactoryGirl.create(:open_petition, created_at: 2.weeks.ago) }
+    let!(:pending_petition) { FactoryGirl.create(:pending_petition, created_at: 6.weeks.ago) }
+    let!(:validated_petition) { FactoryGirl.create(:validated_petition, created_at: 2.weeks.ago) }
+    let!(:sponsored_petition) { FactoryGirl.create(:sponsored_petition, created_at: 6.weeks.ago) }
+    let!(:flagged_petition) { FactoryGirl.create(:flagged_petition, created_at: 2.weeks.ago) }
+    let!(:stoppable_petitions) { [pending_petition, validated_petition, sponsored_petition, flagged_petition] }
+    let!(:recent_petitions) { [validated_petition, flagged_petition] }
+
+    context "when not passing a date" do
+      it "does not find open petitions" do
+        expect(described_class.in_need_of_stopping).not_to include(open_petition)
+      end
+
+      it "includes all stoppable petitions" do
+        expect(described_class.in_need_of_stopping).to include(*stoppable_petitions)
+      end
+    end
+
+    context "when passing a date" do
+      let(:cutoff_date) { 1.month.ago }
+
+      it "does not find open petitions" do
+        expect(described_class.in_need_of_stopping(cutoff_date)).not_to include(open_petition)
+      end
+
+      it "includes only the stoppable petitions created after that date" do
+        expect(described_class.in_need_of_stopping(cutoff_date)).to include(*recent_petitions)
       end
     end
   end
@@ -1766,6 +1853,47 @@ RSpec.describe Petition, type: :model do
 
         it "raises a RuntimeError" do
           expect { petition.close! }.to raise_error(RuntimeError)
+        end
+      end
+    end
+  end
+
+  describe '#stop!' do
+    subject(:petition) { FactoryGirl.create(:pending_petition) }
+    let(:dissolution_at) { 1.day.ago }
+
+    it "sets the state to STOPPED" do
+      expect {
+        petition.stop!(dissolution_at)
+      }.to change {
+        petition.state
+      }.from(Petition::PENDING_STATE).to(Petition::STOPPED_STATE)
+    end
+
+    it "sets the stopped date to the dissolution time" do
+      expect {
+        petition.stop!(dissolution_at)
+      }.to change {
+        petition.stopped_at
+      }.from(nil).to(dissolution_at)
+    end
+
+    context "when called without an argument" do
+      it "sets the closing date to current time" do
+        expect {
+          petition.stop!
+        }.to change {
+          petition.stopped_at
+        }.from(nil).to(be_within(1.second).of(Time.current))
+      end
+    end
+
+    Petition::MODERATED_STATES.each do |state|
+      context "when called on a #{state} petition" do
+        subject(:petition) { FactoryGirl.create(:"#{state}_petition") }
+
+        it "raises a RuntimeError" do
+          expect { petition.stop! }.to raise_error(RuntimeError)
         end
       end
     end


### PR DESCRIPTION
Notify those creators who have either reached the threshold or are in the process of gathering sponsors where the petition was created after a specified cutoff date. This adds a new 'stopped' state to represent a final petition state for those petitions that should remain unpublished (closed petitions are considered published).