### PR TITLE
Add signature email uuid

### DIFF
--- a/app/jobs/backfill_signature_uuids_job.rb
+++ b/app/jobs/backfill_signature_uuids_job.rb
@@ -1,0 +1,15 @@
+require 'active_support/core_ext/digest/uuid'
+
+class BackfillSignatureUuidsJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform
+    Signature.find_each do |signature|
+      next if signature.uuid?
+
+      if signature.email?
+        signature.update_uuid
+      end
+    end
+  end
+end

--- a/db/migrate/20170501093620_add_uuid_to_signatures.rb
+++ b/db/migrate/20170501093620_add_uuid_to_signatures.rb
@@ -1,0 +1,6 @@
+class AddUuidToSignatures < ActiveRecord::Migration
+  def change
+    add_column :signatures, :uuid, :uuid
+    add_index :signatures, :uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -739,7 +739,8 @@ CREATE TABLE signatures (
     government_response_email_at timestamp without time zone,
     debate_scheduled_email_at timestamp without time zone,
     debate_outcome_email_at timestamp without time zone,
-    petition_email_at timestamp without time zone
+    petition_email_at timestamp without time zone,
+    uuid uuid
 );
 
 
@@ -1568,6 +1569,13 @@ CREATE INDEX index_signatures_on_updated_at ON signatures USING btree (updated_a
 
 
 --
+-- Name: index_signatures_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_signatures_on_uuid ON signatures USING btree (uuid);
+
+
+--
 -- Name: index_signatures_on_validated_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1867,4 +1875,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170428185435');
 INSERT INTO schema_migrations (version) VALUES ('20170428211336');
 
 INSERT INTO schema_migrations (version) VALUES ('20170429023722');
+
+INSERT INTO schema_migrations (version) VALUES ('20170501093620');
 

--- a/lib/tasks/signatures.rake
+++ b/lib/tasks/signatures.rake
@@ -1,0 +1,8 @@
+namespace :epets do
+  namespace :signatures do
+    desc "Backfill signature UUIDs"
+    task :backfill_uuids => :environment do
+      BackfillSignatureUuidsJob.perform_later
+    end
+  end
+end

--- a/spec/jobs/backfill_signature_uuids_job_spec.rb
+++ b/spec/jobs/backfill_signature_uuids_job_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe BackfillSignatureUuidsJob, type: :job do
+  context "when the uuid column is nil" do
+    let(:signature) { FactoryGirl.create(:signature, email: "alice@example.com") }
+    let(:uuid) { "6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6" }
+
+    before do
+      signature.update_column(:uuid, nil)
+      signature.reload
+    end
+
+    it "updates the signature column" do
+      expect(Signature).to receive(:find_each).and_yield(signature)
+      expect(signature).to receive(:update_column).with(:uuid, uuid).and_call_original
+
+      expect {
+        subject.perform_now
+      }.to change {
+        signature.reload.uuid
+      }.from(nil).to(uuid)
+    end
+  end
+
+  context "when the uuid column is not nil" do
+    let(:signature) { FactoryGirl.create(:signature, email: "bob@example.com") }
+    let(:uuid) { "6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6" }
+
+    before do
+      signature.update_column(:uuid, uuid)
+      signature.reload
+    end
+
+    it "skips updating the uuid" do
+      expect(Signature).to receive(:find_each).and_yield(signature)
+      expect(signature).not_to receive(:update_column)
+
+      expect {
+        subject.perform_now
+      }.not_to change {
+        signature.reload.uuid
+      }
+    end
+  end
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -166,6 +166,32 @@ RSpec.describe Signature, type: :model do
         end
       end
     end
+
+    context "when the signature is saved" do
+      context "and the email is blank" do
+        subject { FactoryGirl.build(:signature, email: "") }
+
+        it "doesn't set the uuid column" do
+          expect {
+            subject.save
+          }.not_to change {
+            subject.uuid
+          }
+        end
+      end
+
+      context "and the email is set" do
+        subject { FactoryGirl.build(:signature, email: "alice@example.com") }
+
+        it "sets the uuid column" do
+          expect {
+            subject.save
+          }.to change {
+            subject.uuid
+          }.from(nil).to("6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6")
+        end
+      end
+    end
   end
 
   context "validations" do


### PR DESCRIPTION
We want to be able to count the unique number of signature email addresses but still anonymise them so add a uuid column that contains a RFC 4122 v5 UUID using the URL namespace. The column defaults to nil so that the operation can be performed without taking the site down and then we run a job to backfill the existing signatures.