### PR TITLE
Only validate emails on create

### DIFF
--- a/app/models/staged/validations/email.rb
+++ b/app/models/staged/validations/email.rb
@@ -4,7 +4,7 @@ module Staged
       extend ActiveSupport::Concern
 
       included do
-        validates :email, presence: true, email: { allow_blank: true }
+        validates :email, presence: true, email: { allow_blank: true }, on: :create
       end
     end
   end

--- a/app/models/staged/validations/multiple_signers.rb
+++ b/app/models/staged/validations/multiple_signers.rb
@@ -4,7 +4,7 @@ module Staged
       extend ActiveSupport::Concern
 
       included do
-        validate do |signature|
+        validate on: :create do |signature|
           matcher = ::Signature.where(:email => signature.email, :petition_id => signature.petition_id)
           matcher = matcher.where("signatures.id != ?", signature.id) unless signature.new_record?
           existing_email_address_count = matcher.count

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1897,6 +1897,31 @@ RSpec.describe Petition, type: :model do
         end
       end
     end
+
+    context "when the creator's signature is now invalid" do
+      let(:creator) { petition.creator_signature }
+
+      before do
+        creator.update_column(:email, "jo+123@public.com")
+        creator.reload
+      end
+
+      it "sets the state to STOPPED" do
+        expect {
+          petition.stop!(dissolution_at)
+        }.to change {
+          petition.state
+        }.from(Petition::PENDING_STATE).to(Petition::STOPPED_STATE)
+      end
+
+      it "sets the stopped date to the dissolution time" do
+        expect {
+          petition.stop!(dissolution_at)
+        }.to change {
+          petition.stopped_at
+        }.from(nil).to(dissolution_at)
+      end
+    end
   end
 
   describe '#flag' do


### PR DESCRIPTION
Previously we had allowed '+' style addressing but it was removed due to fraud concerns. However the validation for this now causes a petition save to fail if the original email address is now valid and the creator_signature association is loaded.

We can fix this by moving the email validations to on creation only since the email address shouldn't be updated other than when it is anonymised after the 12 month window.