### PR TITLE
Add 'Stopped' to the admin filter menu

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -146,6 +146,10 @@ class Petition < ActiveRecord::Base
       where(state: SPONSORED_STATE)
     end
 
+    def stopped_state
+      where(state: STOPPED_STATE)
+    end
+
     def awaiting_debate
       where(debate_state: %w[awaiting scheduled])
     end

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -65,6 +65,7 @@ en-GB:
         - :closed
         - :rejected
         - :hidden
+        - :stopped
         - :awaiting_response
         - :with_response
         - :awaiting_debate_date
@@ -79,6 +80,7 @@ en-GB:
           closed: "Closed (%{quantity})"
           rejected: "Rejected (%{quantity})"
           hidden: "Hidden (%{quantity})"
+          stopped: "Stopped (%{quantity})"
           awaiting_response: "Awaiting a government response (%{quantity})"
           with_response: "With a government response (%{quantity})"
           awaiting_debate_date: "Awaiting a debate in parliament (%{quantity})"

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -6,17 +6,16 @@ RSpec.describe AdminHelper, type: :helper do
 
     let(:facets) do
       {
-        all: 1, collecting_sponsors: 2, in_moderation: 3, open: 4,
-        closed: 5, rejected: 6, hidden: 7, awaiting_response: 8,
-        with_response: 9, awaiting_debate_date: 10,
-        with_debate_outcome: 11, in_debate_queue: 12
+        all: 1, collecting_sponsors: 2, in_moderation: 3, open: 4, closed: 5,
+        rejected: 6, hidden: 7, stopped: 8, awaiting_response: 9, with_response: 10,
+        awaiting_debate_date: 11, with_debate_outcome: 12, in_debate_queue: 13
       }
     end
 
     subject { helper.admin_petition_facets_for_select(facets, selected) }
 
     it "generates the correct number of options" do
-      expect(subject).to have_css("option", count: 12)
+      expect(subject).to have_css("option", count: 13)
     end
 
     it "generates the correct option for 'all'" do
@@ -47,24 +46,28 @@ RSpec.describe AdminHelper, type: :helper do
       expect(subject).to have_css("option:nth-of-type(7)[value='hidden']", text: "Hidden (7)")
     end
 
+    it "generates the correct option for 'hidden'" do
+      expect(subject).to have_css("option:nth-of-type(8)[value='stopped']", text: "Stopped (8)")
+    end
+
     it "generates the correct option for 'awaiting_response'" do
-      expect(subject).to have_css("option:nth-of-type(8)[value='awaiting_response']", text: "Awaiting a government response (8)")
+      expect(subject).to have_css("option:nth-of-type(9)[value='awaiting_response']", text: "Awaiting a government response (9)")
     end
 
     it "generates the correct option for 'with_response'" do
-      expect(subject).to have_css("option:nth-of-type(9)[value='with_response']", text: "With a government response (9)")
+      expect(subject).to have_css("option:nth-of-type(10)[value='with_response']", text: "With a government response (10)")
     end
 
     it "generates the correct option for 'awaiting_debate_date'" do
-      expect(subject).to have_css("option:nth-of-type(10)[value='awaiting_debate_date']", text: "Awaiting a debate in parliament (10)")
+      expect(subject).to have_css("option:nth-of-type(11)[value='awaiting_debate_date']", text: "Awaiting a debate in parliament (11)")
     end
 
     it "generates the correct option for 'with_debate_outcome'" do
-      expect(subject).to have_css("option:nth-of-type(11)[value='with_debate_outcome']", text: "Has been debated in parliament (11)")
+      expect(subject).to have_css("option:nth-of-type(12)[value='with_debate_outcome']", text: "Has been debated in parliament (12)")
     end
 
     it "generates the correct option for 'in_debate_queue'" do
-      expect(subject).to have_css("option:nth-of-type(12)[value='in_debate_queue']", text: "In debate queue (12)")
+      expect(subject).to have_css("option:nth-of-type(13)[value='in_debate_queue']", text: "In debate queue (13)")
     end
 
     it "marks the correct option as selected" do


### PR DESCRIPTION
It probably won't be needed but just in case the team need to access the list of stopped petitions for some reason.