### PR TITLE
Sometimes we need to give a petition special handling

### DIFF
--- a/app/controllers/admin/petition_details_controller.rb
+++ b/app/controllers/admin/petition_details_controller.rb
@@ -20,6 +20,9 @@ class Admin::PetitionDetailsController < Admin::AdminController
   end
 
   def petition_params
-    params.require(:petition).permit(:action, :background, :additional_details, :creator_signature_attributes => [:name])
+    params.require(:petition).permit(
+      :action, :background, :additional_details,
+      :special_consideration, :creator_signature_attributes => [:name]
+    )
   end
 end

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -33,6 +33,13 @@
         <% end %>
       <% end %>
 
+      <%= form_row for: [f.object, :special_consideration] do %>
+        <%= f.label :special_consideration do %>
+          <%= f.check_box :special_consideration, tabindex: increment %> Special consideration when dealing with this petition
+        <% end %>
+        <%= error_messages_for_field @petition, :special_consideration %>
+      <% end %>
+
       <%= f.submit 'Save', class: 'button' %>
 
       <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>

--- a/db/migrate/20170502155040_add_special_consideration_to_petitions.rb
+++ b/db/migrate/20170502155040_add_special_consideration_to_petitions.rb
@@ -1,0 +1,5 @@
+class AddSpecialConsiderationToPetitions < ActiveRecord::Migration
+  def change
+    add_column :petitions, :special_consideration, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -607,7 +607,8 @@ CREATE TABLE petitions (
     debate_outcome_at timestamp without time zone,
     moderation_threshold_reached_at timestamp without time zone,
     debate_state character varying(30) DEFAULT 'pending'::character varying,
-    stopped_at timestamp without time zone
+    stopped_at timestamp without time zone,
+    special_consideration boolean
 );
 
 
@@ -1877,4 +1878,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170428211336');
 INSERT INTO schema_migrations (version) VALUES ('20170429023722');
 
 INSERT INTO schema_migrations (version) VALUES ('20170501093620');
+
+INSERT INTO schema_migrations (version) VALUES ('20170502155040');
 


### PR DESCRIPTION
Add a flag that prevents automated emails being sent to a petition creator where we may be dealing with them via other channels.