### PR TITLE
Refresh constituency data every night

### DIFF
--- a/app/jobs/refresh_constituencies_job.rb
+++ b/app/jobs/refresh_constituencies_job.rb
@@ -1,0 +1,7 @@
+class RefreshConstituenciesJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform
+    Constituency.refresh
+  end
+end

--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -36,6 +36,10 @@ class Constituency < ActiveRecord::Base
       end
     end
 
+    def refresh
+      find_each { |c| c.refresh }
+    end
+
     private
 
     def query
@@ -61,6 +65,20 @@ class Constituency < ActiveRecord::Base
 
   def reset_example_postcode
     update(example_postcode: nil)
+  end
+
+  def refresh
+    if example_postcode
+      constituency = self.class.find_by_postcode(example_postcode)
+
+      if external_id != constituency.external_id
+        raise RuntimeError, <<-ERROR.squish
+          mismatched constituencies when refreshing
+          with example postcode #{example_postcode.inspect}
+          - expected: #{external_id}, actual: #{constituency.external_id}
+        ERROR
+      end
+    end
   end
 
   private

--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -4,6 +4,10 @@ require_dependency 'constituency/api_query'
 class Constituency < ActiveRecord::Base
   MP_URL = "http://www.parliament.uk/biographies/commons"
 
+  MAPIT_HOST = "https://mapit.mysociety.org"
+  MAPIT_AREA_URL = "/area/%{ons_code}"
+  MAPIT_POSTCODE_URL = "https://mapit.mysociety.org/area/%{area_id}/example_postcode"
+
   has_many :signatures, primary_key: :external_id
   has_many :petitions, through: :signatures
 
@@ -49,5 +53,70 @@ class Constituency < ActiveRecord::Base
 
   def to_param
     slug
+  end
+
+  def example_postcode
+    super || fetch_and_save_example_postcode
+  end
+
+  def reset_example_postcode
+    update(example_postcode: nil)
+  end
+
+  private
+
+  def fetch_and_save_example_postcode
+    area = fetch_area(ons_code)
+
+    if area
+      postcode = fetch_example_postcode(area["id"])
+    else
+      postcode = nil
+    end
+
+    if postcode
+      update(example_postcode: postcode)
+    end
+
+    postcode
+
+  rescue Faraday::Error => e
+    Appsignal.send_exception(e) if defined?(Appsignal)
+    return nil
+  end
+
+  def faraday
+    @faraday ||= Faraday.new(MAPIT_HOST) do |f|
+      f.response :follow_redirects
+      f.response :raise_error
+      f.adapter  :net_http_persistent
+    end
+  end
+
+  def get(path)
+    faraday.get(path) do |request|
+      request.options[:timeout] = 5
+      request.options[:open_timeout] = 5
+    end
+  end
+
+  def fetch_area(ons_code)
+    response = get(MAPIT_AREA_URL % { ons_code: ons_code })
+
+    if response.success?
+      JSON.load(response.body)
+    else
+      nil
+    end
+  end
+
+  def fetch_example_postcode(area_id)
+    response = get(MAPIT_POSTCODE_URL % { area_id: area_id })
+
+    if response.success?
+      PostcodeSanitizer.call(JSON.load(response.body))
+    else
+      nil
+    end
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -29,6 +29,10 @@ every :day, at: '1.15am' do
   rake "epets:countries:fetch", output: nil
 end
 
+every :day, at: '1.45am' do
+  rake "epets:constituencies:refresh", output: nil
+end
+
 every :day, at: '2.30am' do
   rake "epets:petitions:count", output: nil
 end

--- a/db/migrate/20170503192115_add_example_postcode_to_constituencies.rb
+++ b/db/migrate/20170503192115_add_example_postcode_to_constituencies.rb
@@ -1,0 +1,5 @@
+class AddExamplePostcodeToConstituencies < ActiveRecord::Migration
+  def change
+    add_column :constituencies, :example_postcode, :string, limit: 30
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -127,7 +127,8 @@ CREATE TABLE constituencies (
     mp_name character varying(100),
     mp_date date,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    example_postcode character varying(30)
 );
 
 
@@ -1880,4 +1881,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170429023722');
 INSERT INTO schema_migrations (version) VALUES ('20170501093620');
 
 INSERT INTO schema_migrations (version) VALUES ('20170502155040');
+
+INSERT INTO schema_migrations (version) VALUES ('20170503192115');
 

--- a/lib/tasks/constituencies.rake
+++ b/lib/tasks/constituencies.rake
@@ -1,0 +1,10 @@
+namespace :epets do
+  namespace :constituencies do
+    desc "Add task to the queue to refresh constituency information from the Parliament API"
+    task :refresh => :environment do
+      Task.run("epets:constituencies:refresh") do
+        RefreshConstituenciesJob.perform_later
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -288,16 +288,18 @@ FactoryGirl.define do
       mp_id "4378"
       mp_name "Colleen Fletcher MP"
       mp_date "2015-05-07"
+      example_postcode "CV21PH"
     end
 
     trait(:bethnal_green_and_bow) do
       name "Bethnal Green and Bow"
       slug "bethnal-green-and-bow"
       external_id "3320"
-      ons_code "E14000649"
+      ons_code "E14000555"
       mp_id "4138"
       mp_name "Rushanara Ali MP"
       mp_date "2015-05-07"
+      example_postcode "E27AX"
     end
 
     england

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -302,6 +302,17 @@ FactoryGirl.define do
       example_postcode "E27AX"
     end
 
+    trait(:sheffield_brightside_and_hillsborough) do
+      name "Sheffield, Brightside and Hillsborough"
+      slug "sheffield-brightside-and-hillsborough"
+      external_id "3724"
+      ons_code "E14000921"
+      mp_id "4571"
+      mp_name "Gill Furniss"
+      mp_date "2016-05-05"
+      example_postcode "S61AR"
+    end
+
     england
 
     name { Faker::Address.county }

--- a/spec/fixtures/constituency_api/coventry_north_east.xml
+++ b/spec/fixtures/constituency_api/coventry_north_east.xml
@@ -1,0 +1,21 @@
+<Constituencies>
+  <Constituency>
+    <Constituency_Id>3427</Constituency_Id>
+    <Name>Coventry North East</Name>
+    <ONSCode>E14000649</ONSCode>
+    <RepresentingMembers>
+      <RepresentingMember>
+        <Member_Id>4378</Member_Id>
+        <Member>Colleen Fletcher</Member>
+        <StartDate>2015-05-07T00:00:00</StartDate>
+        <EndDate>2017-05-03T00:00:00</EndDate>
+      </RepresentingMember>
+      <RepresentingMember>
+        <Member_Id>306</Member_Id>
+        <Member>Rt Hon Bob Ainsworth</Member>
+        <StartDate>2010-05-06T00:00:00</StartDate>
+        <EndDate>2015-03-30T00:00:00</EndDate>
+      </RepresentingMember>
+    </RepresentingMembers>
+  </Constituency>
+</Constituencies>

--- a/spec/fixtures/constituency_api/sheffield_brightside_and_hillsborough.xml
+++ b/spec/fixtures/constituency_api/sheffield_brightside_and_hillsborough.xml
@@ -1,0 +1,27 @@
+<Constituencies>
+  <Constituency>
+    <Constituency_Id>3724</Constituency_Id>
+    <Name>Sheffield, Brightside and Hillsborough</Name>
+    <ONSCode>E14000921</ONSCode>
+    <RepresentingMembers>
+      <RepresentingMember>
+        <Member_Id>4571</Member_Id>
+        <Member>Gill Furniss</Member>
+        <StartDate>2016-05-05T00:00:00</StartDate>
+        <EndDate>2017-05-03T00:00:00</EndDate>
+      </RepresentingMember>
+      <RepresentingMember>
+        <Member_Id>4477</Member_Id>
+        <Member>Harry Harpham</Member>
+        <StartDate>2015-05-07T00:00:00</StartDate>
+        <EndDate>2016-02-04T00:00:00</EndDate>
+      </RepresentingMember>
+      <RepresentingMember>
+        <Member_Id>395</Member_Id>
+        <Member>The Rt Hon. the Lord Blunkett</Member>
+        <StartDate>2010-05-06T00:00:00</StartDate>
+        <EndDate>2015-03-30T00:00:00</EndDate>
+      </RepresentingMember>
+    </RepresentingMembers>
+  </Constituency>
+</Constituencies>

--- a/spec/jobs/refresh_constituencies_job_spec.rb
+++ b/spec/jobs/refresh_constituencies_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe RefreshConstituenciesJob, type: :job do
+  context "when Parliament has dissolved" do
+    let!(:constituency_1) do
+      FactoryGirl.create(:constituency, :coventry_north_east)
+    end
+
+    let!(:constituency_2) do
+      FactoryGirl.create(:constituency, :sheffield_brightside_and_hillsborough)
+    end
+
+    before do
+      stub_api_request_for("CV21PH").to_return(api_response(:ok, "coventry_north_east"))
+      stub_api_request_for("S61AR").to_return(api_response(:ok, "sheffield_brightside_and_hillsborough"))
+    end
+
+    it "updates the existing constituencies" do
+      expect {
+        described_class.perform_now
+      }.to change {
+        [
+          constituency_1.reload.mp_name,
+          constituency_2.reload.mp_name
+        ]
+      }.from(["Colleen Fletcher MP", "Gill Furniss"]).to([nil, nil])
+    end
+  end
+end


### PR DESCRIPTION
Even though we lazily refresh in places where the user enters a postcode we need to add a nightly task to refresh all the constituency information since it's available in non-interactive areas like API requests for petition data (e.g. signatures by constituency).

In an ideal world we'd refresh by constituency id but the API doesn't appear to accept that. We need the example postcode for anonymising signatures anyway so it's not a redundant feature.