### PR TITLE
Add clarification about early closing of petitions

### DIFF
--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -122,6 +122,10 @@ input.back-page {
     display: block;
     margin: em(5) 0;
   }
+  a {
+    color: $white;
+    text-decoration: underline;
+  }
 }
 
 .flash-notice-description {

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -712,4 +712,8 @@ class Petition < ActiveRecord::Base
   def fraudulent_domains?
     !fraudulent_domains.empty?
   end
+
+  def closed_early_due_to_election?(dissolution_at = Parliament.dissolution_at)
+    closed_at == dissolution_at
+  end
 end

--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -12,10 +12,21 @@
     </details>
   <% end %>
 
-  <p class="flash-notice">
-    This petition is closed
-    <span>All petitions run for 6 months</span>
-  </p>
+
+  <% if petition.closed_early_due_to_election? %>
+    <p class="flash-notice">
+      This petition closed early because of a General Election
+
+      <% if Parliament.dissolution_faq_url? %>
+        <span>Find out more on the <%= link_to 'Petitions Committee website', Parliament.dissolution_faq_url %></span>
+      <% end %>
+    </p>
+  <% else %>
+    <p class="flash-notice">
+      This petition is closed
+      <span>All petitions run for 6 months</span>
+    </p>
+  <% end %>
 
   <div class="signature-count">
     <p class="signature-count-number"><%= signature_count(:default, petition.signature_count) %></p>

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -132,6 +132,20 @@ Given(/^a petition "([^"]*)" has been closed$/) do |petition_action|
   @petition = FactoryGirl.create(:closed_petition, :action => petition_action)
 end
 
+Given(/^a petition "([^"]*)" has been closed early because of parliament dissolving$/) do |petition_action|
+  open_at = 3.months.ago
+  closed_at = 1.month.ago
+
+  Parliament.instance.update! dissolution_at: closed_at,
+    dissolution_heading: "Parliament is dissolving",
+    dissolution_message: "This means all petitions will close in 2 weeks",
+    dissolved_heading: "Parliament has been dissolved",
+    dissolved_message: "All petitions have been closed",
+    dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
+
+  @petition = FactoryGirl.create(:closed_petition, action: petition_action, open_at: open_at, closed_at: closed_at)
+end
+
 Given(/^the petition has closed$/) do
   @petition.close!
 end

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -67,6 +67,11 @@ Feature: Suzie views a petition
     When I view the petition
     Then I should see "This petition is closed"
 
+  Scenario: Suzie sees a special 'closed' message when viewing a petition closed early due to parliament being dissolved
+    Given a petition "Spend more money on Defence" has been closed early because of parliament dissolving
+    When I view the petition
+    Then I should see "This petition closed early because of a General Election"
+
   Scenario: Suzie does not see the creator when viewing a closed petition
     Given a petition "Spend more money on Defence" has been closed
     When I view the petition

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2262,5 +2262,51 @@ RSpec.describe Petition, type: :model do
         end
       end
     end
+
+    describe "#closed_early_due_to_election?" do
+      let(:dissolution_at) { "2017-05-03T00:01:00+01:00".in_time_zone }
+
+      before do
+        allow(Parliament).to receive(:dissolution_at).and_return(dissolution_at)
+      end
+
+      context "when the petition was not closed early" do
+        let(:open_at) { "2016-04-01T12:00:00+01:00".in_time_zone }
+        let(:closed_at) { Site.closed_at_for_opening(open_at) }
+
+        subject do
+          FactoryGirl.create(:closed_petition, open_at: open_at, closed_at: closed_at)
+        end
+
+        it "returns false" do
+          expect(subject.closed_early_due_to_election?).to eq(false)
+        end
+      end
+
+      context "when the petition was closed early for other reasons" do
+        let(:open_at) { "2016-11-01T12:00:00+00:00".in_time_zone }
+        let(:closed_at) { "2017-03-03T12:00:00+00:00".in_time_zone }
+
+        subject do
+          FactoryGirl.create(:closed_petition, open_at: open_at, closed_at: closed_at)
+        end
+
+        it "returns false" do
+          expect(subject.closed_early_due_to_election?).to eq(false)
+        end
+      end
+
+      context "when the petition was closed early because parliament was dissolved" do
+        let(:open_at) { "2017-04-01T12:00:00+01:00".in_time_zone }
+
+        subject do
+          FactoryGirl.create(:closed_petition, open_at: open_at, closed_at: dissolution_at)
+        end
+
+        it "returns true" do
+          expect(subject.closed_early_due_to_election?).to eq(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The default closed message confusingly said that all petitions ran for six months which obviously wasn't the case for the petitions that were closed early due to the general election. Since we know that petitions had their closed_at set to the exact time of the dissolution we can compare that and eliminate other possible reasons for closing a petition early.

This currently uses the Parliament singleton but we'll need to switch to using a belongs_to association when we archive the petition.