### PR TITLE
Refactor signature uuid backfill

### DIFF
--- a/app/jobs/backfill_signature_uuids_job.rb
+++ b/app/jobs/backfill_signature_uuids_job.rb
@@ -1,15 +1,20 @@
-require 'active_support/core_ext/digest/uuid'
-
 class BackfillSignatureUuidsJob < ApplicationJob
   queue_as :low_priority
 
-  def perform
-    Signature.find_each do |signature|
+  def perform(id = 0)
+    signatures = Signature.where(uuid: nil).batch(id).to_a
+    max_id = signatures.map(&:id).max
+
+    signatures.each do |signature|
       next if signature.uuid?
 
       if signature.email?
         signature.update_uuid
       end
+    end
+
+    if Signature.exists?(uuid: nil)
+      self.class.perform_later(max_id)
     end
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -90,6 +90,10 @@ class Signature < ActiveRecord::Base
     raise ArgumentError, "Unknown petition email timestamp: #{timestamp.inspect}"
   end
 
+  def self.batch(id = 0, limit: 1000)
+    where(arel_table[:id].gteq(id)).order(id: :asc).limit(limit)
+  end
+
   def self.fraudulent_domains
     where(state: FRAUDULENT_STATE).
     select("SUBSTRING(email FROM POSITION('@' IN email) + 1) AS domain").

--- a/lib/tasks/signatures.rake
+++ b/lib/tasks/signatures.rake
@@ -2,7 +2,11 @@ namespace :epets do
   namespace :signatures do
     desc "Backfill signature UUIDs"
     task :backfill_uuids => :environment do
-      BackfillSignatureUuidsJob.perform_later
+      signature = Signature.where(uuid: nil).first
+
+      if signature
+        BackfillSignatureUuidsJob.perform_later(signature.id)
+      end
     end
   end
 end

--- a/spec/jobs/backfill_signature_uuids_job_spec.rb
+++ b/spec/jobs/backfill_signature_uuids_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe BackfillSignatureUuidsJob, type: :job do
+  let(:relation) { double(:relation) }
+
   context "when the uuid column is nil" do
     let(:signature) { FactoryGirl.create(:signature, email: "alice@example.com") }
     let(:uuid) { "6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6" }
@@ -11,9 +13,6 @@ RSpec.describe BackfillSignatureUuidsJob, type: :job do
     end
 
     it "updates the signature column" do
-      expect(Signature).to receive(:find_each).and_yield(signature)
-      expect(signature).to receive(:update_column).with(:uuid, uuid).and_call_original
-
       expect {
         subject.perform_now
       }.to change {
@@ -32,9 +31,6 @@ RSpec.describe BackfillSignatureUuidsJob, type: :job do
     end
 
     it "skips updating the uuid" do
-      expect(Signature).to receive(:find_each).and_yield(signature)
-      expect(signature).not_to receive(:update_column)
-
       expect {
         subject.perform_now
       }.not_to change {

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -89,7 +89,9 @@ RSpec.describe Parliament, type: :model do
       allow(Parliament).to receive(:last_or_create).and_return(parliament)
     end
 
-    after do
+    around do |example|
+      Parliament.reload
+      example.run
       Parliament.reload
     end
 


### PR DESCRIPTION
It's big ask for Active Record to iterate over 38 million rows and update them within the maximum runtime for a delayed job so refactor to run the task as a sequence of small jobs. This allows us to shutdown workers and deploy a new version and the task will pick up where it left off.