### PR TITLE
Use our own internal MapIt instance

### DIFF
--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -4,9 +4,9 @@ require_dependency 'constituency/api_query'
 class Constituency < ActiveRecord::Base
   MP_URL = "http://www.parliament.uk/biographies/commons"
 
-  MAPIT_HOST = "https://mapit.mysociety.org"
+  MAPIT_HOST = "http://mapit"
   MAPIT_AREA_URL = "/area/%{ons_code}"
-  MAPIT_POSTCODE_URL = "https://mapit.mysociety.org/area/%{area_id}/example_postcode"
+  MAPIT_POSTCODE_URL = "http://mapit/area/%{area_id}/example_postcode"
 
   has_many :signatures, primary_key: :external_id
   has_many :petitions, through: :signatures

--- a/spec/models/constituency_spec.rb
+++ b/spec/models/constituency_spec.rb
@@ -223,8 +223,8 @@ RSpec.describe Constituency, type: :model do
   describe "#example_postcode" do
     context "when the example postcode is not cached" do
       let!(:constituency) { FactoryGirl.create(:constituency, ons_code: "E14000649") }
-      let!(:area_url) { "https://mapit.mysociety.org/area/E14000649" }
-      let!(:postcode_url) { "https://mapit.mysociety.org/area/65636/example_postcode" }
+      let!(:area_url) { "http://mapit/area/E14000649" }
+      let!(:postcode_url) { "http://mapit/area/65636/example_postcode" }
 
       let!(:area_response) do
         { status: 200, headers: { 'Content-Type' => 'application/json' }, body: '{"id":65636}' }
@@ -256,7 +256,7 @@ RSpec.describe Constituency, type: :model do
       let!(:constituency) { FactoryGirl.create(:constituency, example_postcode: "CV21PH") }
 
       it "doesn't make an API request" do
-        expect(WebMock).not_to have_requested(:get, "mapit.mysociety.org")
+        expect(WebMock).not_to have_requested(:get, "mapit")
         expect(constituency.example_postcode).to eq("CV21PH")
       end
     end


### PR DESCRIPTION
The public server is rate-limited to 50 requests per day and it's cheaper to run our own instances than to pay for higher rate access.