### PR TITLE
Refactor example postcode lookup

### DIFF
--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -6,7 +6,8 @@ class Constituency < ActiveRecord::Base
 
   MAPIT_HOST = "http://mapit"
   MAPIT_AREA_URL = "/area/%{ons_code}"
-  MAPIT_POSTCODE_URL = "http://mapit/area/%{area_id}/example_postcode"
+  MAPIT_GEOMETRY_URL = "/area/%{area_id}/geometry"
+  MAPIT_POSTCODE_URL = "/nearest/%{srid}/%{easting},%{northing}"
 
   has_many :signatures, primary_key: :external_id
   has_many :petitions, through: :signatures
@@ -84,15 +85,17 @@ class Constituency < ActiveRecord::Base
   private
 
   def fetch_and_save_example_postcode
-    area = fetch_area(ons_code)
+    if postcode = fetch_example_postcode
+      constituency = self.class.find_by_postcode(postcode)
 
-    if area
-      postcode = fetch_example_postcode(area["id"])
-    else
-      postcode = nil
-    end
+      if external_id != constituency.external_id
+        raise RuntimeError, <<-ERROR.squish
+          mismatched constituencies when setting
+          example postcode #{postcode.inspect}
+          - expected: #{external_id}, actual: #{constituency.external_id}
+        ERROR
+      end
 
-    if postcode
       update(example_postcode: postcode)
     end
 
@@ -101,6 +104,24 @@ class Constituency < ActiveRecord::Base
   rescue Faraday::Error => e
     Appsignal.send_exception(e) if defined?(Appsignal)
     return nil
+  end
+
+  def fetch_example_postcode
+    if area = fetch_area
+      fetch_central_postcode(area["id"])
+    end
+  end
+
+  def fetch_central_postcode(area_id)
+    if geometry = fetch_geometry(area_id)
+      fetch_nearest_postcode(geometry["centre_e"], geometry["centre_n"])
+    end
+  end
+
+  def fetch_nearest_postcode(easting, northing)
+    if postcode = fetch_postcode(easting, northing)
+      PostcodeSanitizer.call(postcode)
+    end
   end
 
   def faraday
@@ -118,7 +139,7 @@ class Constituency < ActiveRecord::Base
     end
   end
 
-  def fetch_area(ons_code)
+  def fetch_area
     response = get(MAPIT_AREA_URL % { ons_code: ons_code })
 
     if response.success?
@@ -128,11 +149,22 @@ class Constituency < ActiveRecord::Base
     end
   end
 
-  def fetch_example_postcode(area_id)
-    response = get(MAPIT_POSTCODE_URL % { area_id: area_id })
+  def fetch_geometry(area_id)
+    response = get(MAPIT_GEOMETRY_URL % { area_id: area_id })
 
     if response.success?
-      PostcodeSanitizer.call(JSON.load(response.body))
+      JSON.load(response.body)
+    else
+      nil
+    end
+  end
+
+  def fetch_postcode(easting, northing)
+    response = get(MAPIT_POSTCODE_URL % { srid: 27700, easting: easting, northing: northing })
+
+    if response.success?
+      json = JSON.load(response.body)
+      json["postcode"]["postcode"]
     else
       nil
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -313,6 +313,10 @@ FactoryGirl.define do
       example_postcode "S61AR"
     end
 
+    trait(:no_example_postcode) do
+      example_postcode nil
+    end
+
     england
 
     name { Faker::Address.county }

--- a/spec/models/constituency_spec.rb
+++ b/spec/models/constituency_spec.rb
@@ -222,38 +222,60 @@ RSpec.describe Constituency, type: :model do
 
   describe "#example_postcode" do
     context "when the example postcode is not cached" do
-      let!(:constituency) { FactoryGirl.create(:constituency, ons_code: "E14000649") }
+      let!(:constituency) { FactoryGirl.create(:constituency, :coventry_north_east, :no_example_postcode) }
       let!(:area_url) { "http://mapit/area/E14000649" }
-      let!(:postcode_url) { "http://mapit/area/65636/example_postcode" }
+      let!(:geometry_url) { "http://mapit/area/65636/geometry" }
+      let!(:postcode_url) { "http://mapit/nearest/27700/436297.8961978419,281104.15840755054" }
 
       let!(:area_response) do
         { status: 200, headers: { 'Content-Type' => 'application/json' }, body: '{"id":65636}' }
       end
 
+      let!(:geometry_response) do
+        { status: 200, headers: { 'Content-Type' => 'application/json' }, body: '{"centre_e":436297.8961978419,"centre_n":281104.15840755054}' }
+      end
+
       let!(:postcode_response) do
-        { status: 200, headers: { 'Content-Type' => 'application/json' }, body: '"CV2 1PH"' }
+        { status: 200, headers: { 'Content-Type' => 'application/json' }, body: '{"postcode":{"postcode":"CV2 1PH"}}' }
       end
 
       before do
         stub_request(:get, area_url).to_return(area_response)
+        stub_request(:get, geometry_url).to_return(geometry_response)
         stub_request(:get, postcode_url).to_return(postcode_response)
       end
 
-      it "fetches the example postcode from the Mapit API" do
-        expect(constituency.example_postcode).to eq("CV21PH")
+      context "and a postcode lookup mismatch doesn't occur" do
+        before do
+          stub_api_request_for("CV21PH").to_return(api_response(:ok, "coventry_north_east"))
+        end
+
+        it "fetches the example postcode from the Mapit API" do
+          expect(constituency.example_postcode).to eq("CV21PH")
+        end
+
+        it "saves the example postcode in the constituency record" do
+          expect {
+            constituency.example_postcode
+          }.to change {
+            constituency.reload[:example_postcode]
+          }.from(nil).to("CV21PH")
+        end
       end
 
-      it "saves the example postcode in the constituency record" do
-        expect {
-          constituency.example_postcode
-        }.to change {
-          constituency.reload[:example_postcode]
-        }.from(nil).to("CV21PH")
+      context "and a postcode lookup mismatch occurs" do
+        before do
+          stub_api_request_for("CV21PH").to_return(api_response(:ok, "sheffield_brightside_and_hillsborough"))
+        end
+
+        it "raises a RuntimeError" do
+          expect { constituency.example_postcode }.to raise_error(RuntimeError)
+        end
       end
     end
 
     context "when the example postcode is cached" do
-      let!(:constituency) { FactoryGirl.create(:constituency, example_postcode: "CV21PH") }
+      let!(:constituency) { FactoryGirl.create(:constituency, :coventry_north_east) }
 
       it "doesn't make an API request" do
         expect(WebMock).not_to have_requested(:get, "mapit")


### PR DESCRIPTION
MapIt's example postcode returns a random postcode and sometimes this is a the edge of the constituency boundary. This leads to disagreements between Parliament's API and MapIt as to which constituency a postcode belongs to.

To try and fix this use an alternative method to get the nearest postcode to the centroid of the constituency boundary. This is also subject to possible errors where the centroid lies within a 'hole' in the constituency so we add a check for that just in case.