### PR TITLE
Redirect to all popular petitions when dissolved

### DIFF
--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -59,7 +59,11 @@ class LocalPetitionsController < ApplicationController
   end
 
   def redirect_to_constituency
-    redirect_to local_petition_url(@constituency.slug)
+    if Parliament.dissolved?
+      redirect_to all_local_petition_url(@constituency.slug)
+    else
+      redirect_to local_petition_url(@constituency.slug)
+    end
   end
 
   def csv_request?

--- a/spec/controllers/local_petitions_controller_spec.rb
+++ b/spec/controllers/local_petitions_controller_spec.rb
@@ -15,8 +15,21 @@ RSpec.describe LocalPetitionsController, type: :controller do
         expect(assigns(:postcode)).to eq("N11TY")
       end
 
-      it "redirects to the constituency page" do
+      it "redirects to the constituency page for current popular petitions" do
         expect(response).to redirect_to("/petitions/local/holborn")
+      end
+    end
+
+    context "when the postcode is valid but parliament is dissolved" do
+      before do
+        expect(Parliament).to receive(:dissolved?).and_return(true)
+        expect(Constituency).to receive(:find_by_postcode).with("N11TY").and_return(constituency)
+
+        get :index, postcode: "n1 1ty"
+      end
+
+      it "redirects to the constituency page for all popular petitions" do
+        expect(response).to redirect_to("/petitions/local/holborn/all")
       end
     end
 


### PR DESCRIPTION
When parliament has been dissolved there is no point showing the current popular petitions page as they have all been closed so redirect to the all popular petitions in a constituency page instead.