### PR TITLE
Add a CSV index response

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def csv_request?
+    request.format.symbol == :csv
+  end
+
   def json_request?
     request.format.symbol == :json
   end

--- a/app/controllers/local_petitions_controller.rb
+++ b/app/controllers/local_petitions_controller.rb
@@ -66,10 +66,6 @@ class LocalPetitionsController < ApplicationController
     end
   end
 
-  def csv_request?
-    request.format.symbol == :csv
-  end
-
   def csv_filename
     if action_name == 'all'
       "all-popular-petitions-in-#{@constituency.slug}.csv"

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class PetitionsController < ApplicationController
   include ManagingMoveParameter
 
@@ -13,9 +15,11 @@ class PetitionsController < ApplicationController
   before_action :redirect_to_petition_url, if: :moderated?, only: [:gathering_support, :moderation_info]
 
   before_action :set_cors_headers, only: [:index, :show, :count], if: :json_request?
+  after_action :set_content_disposition, if: :csv_request?, only: [:index]
 
   respond_to :html
   respond_to :json, only: [:index, :show]
+  respond_to :csv, only: [:index]
 
   def index
     @petitions = Petition.visible.search(params)
@@ -172,5 +176,13 @@ class PetitionsController < ApplicationController
 
   def parse_emails(emails)
     emails.strip.split(/\r?\n/).map { |e| e.strip }
+  end
+
+  def csv_filename
+    "#{@petitions.scope}-petitions.csv"
+  end
+
+  def set_content_disposition
+    response.headers['Content-Disposition'] = "attachment; filename=#{csv_filename}"
   end
 end

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -77,6 +77,10 @@ module Browseable
       results.each(&block)
     end
 
+    def find_each(&block)
+      execute_search.find_each(&block)
+    end
+
     def facets
       @facets ||= Facets.new(klass)
     end
@@ -101,7 +105,7 @@ module Browseable
       @page_size ||= [[params.fetch(:count, 50).to_i, 50].min, 1].max
     end
 
-    def previous_params 
+    def previous_params
       {}.tap do |params|
         params[:q] = query if query.present?
         params[:state] = scope
@@ -109,7 +113,7 @@ module Browseable
       end
     end
 
-    def next_params 
+    def next_params
       {}.tap do |params|
         params[:q] = query if query.present?
         params[:state] = scope

--- a/app/views/petitions/index.csv.ruby
+++ b/app/views/petitions/index.csv.ruby
@@ -1,0 +1,20 @@
+csv_builder = lambda do |csv|
+  csv << ['Petition', 'URL', 'State', 'Signatures Count']
+
+  @petitions.find_each do |petition|
+    csv << [
+      petition.action,
+      petition_url(petition),
+      petition.state,
+      petition.signature_count
+    ]
+  end
+end
+
+if @petitions.query.present?
+  CSV.generate(&csv_builder)
+else
+  csv_cache [:petitions, @petitions.scope], expires_in: 5.minutes do
+    CSV.generate(&csv_builder)
+  end
+end

--- a/app/views/petitions/search/_results.html.erb
+++ b/app/views/petitions/search/_results.html.erb
@@ -10,6 +10,6 @@
       <% end -%>
     </ol>
     <%= render 'paginated_results' %>
-    <p><%= link_to "Get this data (json format)", petitions_path(:json, params.slice(:page, :state)) %></p>
+    <p>Get this data in <%= link_to "JSON", petitions_path(:json, params.slice(:q, :page, :state)) %> or <%= link_to 'CSV', petitions_path(:csv, params.slice(:q, :state)) %> format</p>
   <% end %>
 </div>

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -20,6 +20,12 @@ module NavigationHelpers
     when /^the feedback page$/
       feedback_url
 
+    when /^the all petitions page$/
+      petitions_url
+
+    when /^the all petitions JSON page$/
+      petitions_url(:json)
+
     when /^the check for existing petitions page$/
       check_petitions_url
 
@@ -46,9 +52,6 @@ module NavigationHelpers
 
     when /^the new signature page for "([^\"]*)"$/
       new_petition_signature_url(Petition.find_by(action: $1))
-
-    when /^the search results page$/
-      search_url
 
     when /^the Admin (.*)$/i
       admin_url($1)

--- a/features/suzie_views_all_petitions.feature
+++ b/features/suzie_views_all_petitions.feature
@@ -95,3 +95,19 @@ Feature: Suzy Signer views all petitions
     And I navigate to the next page of petitions
     Then I should see "2 of 3"
 
+  Scenario: Downloading the JSON data for petitions
+    Given a set of petitions
+    And I am on the all petitions page
+    Then I should see all petitions
+    And the markup should be valid
+    When I click the JSON link
+    Then I should be on the all petitions JSON page
+    And the JSON should be valid
+
+  Scenario: Downloading the CSV data for petitions
+    Given a set of petitions
+    And I am on the all petitions page
+    Then I should see all petitions
+    And the markup should be valid
+    When I click the CSV link
+    Then I should get a download with the filename "all-petitions.csv"

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -167,16 +167,18 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     end
   end
 
-  simple_html_and_json_urls = [
-    'petitions', 'archived/petitions'
-  ]
-  simple_html_and_json_urls.each do |simple_url|
-    context "the #{simple_url} url" do
-      let(:url) { "/#{simple_url}" }
-      let(:params) { {} }
+  context "the petitions url" do
+    let(:url) { "/petitions" }
+    let(:params) { {} }
 
-      it_behaves_like 'a route that supports html and json formats'
-    end
+    it_behaves_like 'a route that supports html, json and csv formats'
+  end
+
+  context "the archived/petitions url" do
+    let(:url) { "/archived/petitions" }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that supports html and json formats'
   end
 
   context 'the petitions/local results url' do


### PR DESCRIPTION
To make it easier to fetch petition data for a whole set of petitions add the option to return a CSV index response that allows importing into a tool like [OpenRefine][1]. Using OpenRefine you can take the CSV index file as a starting point and then add a column which stores the JSON for each petition by [fetching URLs][2]. Once you have the JSON you can then use the parseJson function to extract out any data you need into another column and then sort and facet however you need.

[1]: http://openrefine.org
[2]: https://github.com/OpenRefine/OpenRefine/wiki/Fetching-URLs-From-Web-Services