### PR TITLE
Fix clearing the petition notes field

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,5 +2,4 @@ class Note < ActiveRecord::Base
   belongs_to :petition, touch: true
 
   validates :petition, presence: true
-  validates :details, presence: true
 end

--- a/features/admin/notes.feature
+++ b/features/admin/notes.feature
@@ -32,3 +32,19 @@ Feature: A moderator user updates records notes
     Then I should be on the admin petition page for "Solidarity with the Unions"
     And I follow "Notes"
     Then I should see "I think we can debate this, will check with unions select committee first"
+
+  Scenario: Removing notes
+    Given an open petition exists with action: "Solidarity with the Unions"
+    When I am on the admin all petitions page
+    And I follow "Solidarity with the Unions"
+    And I follow "Notes"
+    Then I should see a "Notes" textarea field
+    And the markup should be valid
+    When I fill in "Notes" with "I think we can debate this, will check with unions select committee first"
+    And I press "Save"
+    Then I should be on the admin petition page for "Solidarity with the Unions"
+    And I follow "Notes"
+    Then I should see "I think we can debate this, will check with unions select committee first"
+    When I fill in "Notes" with ""
+    And I press "Save"
+    Then I should be on the admin petition page for "Solidarity with the Unions"

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -117,26 +117,6 @@ RSpec.describe Admin::NotesController, type: :controller, admin: true do
             expect(petition.note.details).to eq notes_attributes[:details]
           end
         end
-
-        describe 'with invalid params' do
-          it 're-renders the notes/show template' do
-            do_patch(note: { details: "" })
-            expect(response).to be_success
-            expect(response).to render_template('petitions/show')
-          end
-
-          it 'leaves the in-memory instance with errors' do
-            do_patch(note: { details: "" })
-            expect(assigns(:note)).to be_present
-            expect(assigns(:note).errors).not_to be_empty
-          end
-
-          it 'does not stores the supplied notes in the db' do
-            do_patch(note: { details: "" })
-            petition.reload
-            expect(petition.note).to be_nil
-          end
-        end
       end
 
       describe 'for an open petition' do

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe Note, type: :model do
     subject { FactoryGirl.build(:note) }
 
     it { is_expected.to validate_presence_of(:petition) }
-    it { is_expected.to validate_presence_of(:details) }
+    it { is_expected.not_to validate_presence_of(:details) }
   end
 end


### PR DESCRIPTION
We were validating the presence of the details field but this this meant that a petition couldn't be untagged if the notes just consisted of tags. To work around this moderators would fill the notes field with a single '.' but we should just not validate the presence of the details attribute.