### PR TITLE
Fix variable petition duration for coalition government

### DIFF
--- a/app/helpers/archived_petition_helper.rb
+++ b/app/helpers/archived_petition_helper.rb
@@ -22,4 +22,18 @@ module ArchivedPetitionHelper
   def archived_petition_facets_with_counts(petitions)
     petitions.facets.slice(*archived_petition_facets)
   end
+
+  def petition_duration_to_words(duration)
+    duration = duration.to_d
+
+    if duration.frac.zero?
+      pluralize(duration.floor, "month")
+    elsif duration.frac > 0.75
+      "nearly #{pluralize(duration.ceil, "month")}"
+    elsif duration.frac < 0.25
+      "just over #{pluralize(duration.floor, "month")}"
+    else
+      "over #{pluralize(duration.floor, "month")}"
+    end
+  end
 end

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -61,7 +61,13 @@ module Archived
     end
 
     def duration
-      parliament.petition_duration
+      if parliament.petition_duration?
+        parliament.petition_duration
+      elsif opened_at?
+        calculate_petition_duration
+      else
+        0
+      end
     end
 
     def closed_early_due_to_election?
@@ -74,6 +80,22 @@ module Archived
 
     def threshold_for_response_reached?
       signature_count >= parliament.threshold_for_response
+    end
+
+    private
+
+    def calculate_petition_duration
+      if opened_at + 3.months == closed_at
+        3
+      elsif opened_at + 6.months == closed_at
+        6
+      elsif opened_at + 9.months == closed_at
+        9
+      elsif opened_at + 12.months == closed_at
+        12
+      else
+        Rational(closed_at - opened_at, 86400 * 30).to_f
+      end
     end
   end
 end

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -83,16 +83,16 @@ class Parliament < ActiveRecord::Base
     end
   end
 
-  validates_presence_of :government, :opening_at, :petition_duration
+  validates_presence_of :government, :opening_at
   validates_presence_of :dissolution_heading, :dissolution_message, if: :dissolution_at?
   validates_presence_of :dissolved_heading, :dissolved_message, if: :dissolved?
   validates_length_of :government, maximum: 100
   validates_length_of :dissolution_heading, :dissolved_heading, maximum: 100
   validates_length_of :dissolution_message, :dissolved_message, maximum: 600
   validates_length_of :dissolution_faq_url, maximum: 500
-  validates_numericality_of :petition_duration, only_integer: true
-  validates_numericality_of :petition_duration, greater_than_or_equal_to: 1
-  validates_numericality_of :petition_duration, less_than_or_equal_to: 12
+  validates_numericality_of :petition_duration, only_integer: true, allow_blank: true
+  validates_numericality_of :petition_duration, greater_than_or_equal_to: 1, allow_blank: true
+  validates_numericality_of :petition_duration, less_than_or_equal_to: 12, allow_blank: true
 
   after_save { Site.touch }
 

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -40,7 +40,7 @@
   <% else %>
     <p class="flash-notice">
       This petition is closed
-      <span>This petition ran for <%= @petition.duration %> months</span>
+      <span>This petition ran for <%= petition_duration_to_words(@petition.duration) %></span>
     </p>
   <% end %>
 

--- a/db/migrate/20170615133536_nullify_previous_parliament_petition_duration.rb
+++ b/db/migrate/20170615133536_nullify_previous_parliament_petition_duration.rb
@@ -1,0 +1,17 @@
+class NullifyPreviousParliamentPetitionDuration < ActiveRecord::Migration
+  class Parliament < ActiveRecord::Base; end
+
+  def up
+    change_column_null(:parliaments, :petition_duration, true)
+
+    parliament = Parliament.find_by!(opening_at: "2010-05-18T00:00:00".in_time_zone)
+    parliament.update(petition_duration: nil)
+  end
+
+  def down
+    parliament = Parliament.find_by!(opening_at: "2010-05-18T00:00:00".in_time_zone)
+    parliament.update(petition_duration: 12)
+
+    change_column_null(:parliaments, :petition_duration, false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -532,7 +532,7 @@ CREATE TABLE parliaments (
     archived_at timestamp without time zone,
     threshold_for_response integer DEFAULT 10000 NOT NULL,
     threshold_for_debate integer DEFAULT 100000 NOT NULL,
-    petition_duration integer DEFAULT 6 NOT NULL
+    petition_duration integer DEFAULT 6
 );
 
 
@@ -1918,4 +1918,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170611131130');
 INSERT INTO schema_migrations (version) VALUES ('20170611190354');
 
 INSERT INTO schema_migrations (version) VALUES ('20170612120307');
+
+INSERT INTO schema_migrations (version) VALUES ('20170615133536');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -49,6 +49,8 @@ FactoryGirl.define do
     trait :rejected do
       reason_for_rejection "Petition rejection"
       state "rejected"
+      opened_at nil
+      closed_at nil
     end
   end
 

--- a/spec/helpers/archived_petition_helper_spec.rb
+++ b/spec/helpers/archived_petition_helper_spec.rb
@@ -157,4 +157,42 @@ RSpec.describe ArchivedPetitionHelper, type: :helper do
       end
     end
   end
+
+  describe "#petition_duration_to_words" do
+    context "when the duration is an integer" do
+      it "returns the exact number of months as a string" do
+        expect(helper.petition_duration_to_words(3)).to eq("3 months")
+      end
+    end
+
+    context "when the duration is 0 months" do
+      it "pluralizes the string correctly" do
+        expect(helper.petition_duration_to_words(0)).to eq("0 months")
+      end
+    end
+
+    context "when the duration is 1 month" do
+      it "pluralizes the string correctly" do
+        expect(helper.petition_duration_to_words(1)).to eq("1 month")
+      end
+    end
+
+    context "when the duration fraction is less than 0.25" do
+      it "returns an approximate number of months" do
+        expect(helper.petition_duration_to_words(3.2)).to eq("just over 3 months")
+      end
+    end
+
+    context "when the duration fraction is between 0.25 and 0.75" do
+      it "returns an approximate number of months" do
+        expect(helper.petition_duration_to_words(3.5)).to eq("over 3 months")
+      end
+    end
+
+    context "when the duration fraction is greater than 0.75" do
+      it "returns an approximate number of months" do
+        expect(helper.petition_duration_to_words(3.8)).to eq("nearly 4 months")
+      end
+    end
+  end
 end

--- a/spec/models/archived_petition_spec.rb
+++ b/spec/models/archived_petition_spec.rb
@@ -199,7 +199,76 @@ RSpec.describe Archived::Petition, type: :model do
   end
 
   describe "#duration" do
-    it { is_expected.to delegate_method(:duration).to(:parliament).as(:petition_duration) }
+    context "when the parliament petition duration is nil" do
+      let(:parliament) { FactoryGirl.create(:parliament, petition_duration: nil) }
+
+      context "and the petition was not published" do
+        let(:petition) { FactoryGirl.create(:archived_petition, :rejected, parliament: parliament) }
+
+        it "returns 0" do
+          expect(petition.duration).to eq(0)
+        end
+      end
+
+      context "and the petition was published for three months" do
+        let(:opened_at) { 2.years.ago }
+        let(:closed_at) { opened_at + 3.months }
+        let(:petition) { FactoryGirl.create(:archived_petition, opened_at: opened_at, closed_at: closed_at, parliament: parliament) }
+
+        it "returns 3" do
+          expect(petition.duration).to eq(3)
+        end
+      end
+
+      context "and the petition was published for six months" do
+        let(:opened_at) { 2.years.ago }
+        let(:closed_at) { opened_at + 6.months }
+        let(:petition) { FactoryGirl.create(:archived_petition, opened_at: opened_at, closed_at: closed_at, parliament: parliament) }
+
+        it "returns 3" do
+          expect(petition.duration).to eq(6)
+        end
+      end
+
+      context "and the petition was published for nine months" do
+        let(:opened_at) { 2.years.ago }
+        let(:closed_at) { opened_at + 9.months }
+        let(:petition) { FactoryGirl.create(:archived_petition, opened_at: opened_at, closed_at: closed_at, parliament: parliament) }
+
+        it "returns 3" do
+          expect(petition.duration).to eq(9)
+        end
+      end
+
+      context "and the petition was published for twelve months" do
+        let(:opened_at) { 2.years.ago }
+        let(:closed_at) { opened_at + 12.months }
+        let(:petition) { FactoryGirl.create(:archived_petition, opened_at: opened_at, closed_at: closed_at, parliament: parliament) }
+
+        it "returns 3" do
+          expect(petition.duration).to eq(12)
+        end
+      end
+
+      context "and the petition was published for an arbitrary length of time" do
+        let(:opened_at) { 2.years.ago }
+        let(:closed_at) { opened_at + 45.days }
+        let(:petition) { FactoryGirl.create(:archived_petition, opened_at: opened_at, closed_at: closed_at, parliament: parliament) }
+
+        it "returns a fractional number of months assuming that 1 month == 30 days" do
+          expect(petition.duration).to eq(1.5)
+        end
+      end
+    end
+
+    context "when the parliament petition duration is not nil" do
+      let(:parliament) { FactoryGirl.create(:parliament, petition_duration: 6) }
+      let(:petition) { FactoryGirl.create(:archived_petition, parliament: parliament) }
+
+      it "returns the duration from the parliament" do
+        expect(petition.duration).to eq(6)
+      end
+    end
   end
 
   describe "#threshold_for_response" do

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Parliament, type: :model do
   describe "schema" do
     it { is_expected.to have_db_column(:government).of_type(:string).with_options(limit: 100, null: true) }
     it { is_expected.to have_db_column(:opening_at).of_type(:datetime).with_options(null: true) }
-    it { is_expected.to have_db_column(:petition_duration).of_type(:integer).with_options(null: false, default: 6) }
+    it { is_expected.to have_db_column(:petition_duration).of_type(:integer).with_options(default: 6) }
     it { is_expected.to have_db_column(:dissolution_at).of_type(:datetime).with_options(null: true) }
     it { is_expected.to have_db_column(:dissolution_heading).of_type(:string).with_options(limit: 100, null: true) }
     it { is_expected.to have_db_column(:dissolution_message).of_type(:text).with_options(null: true) }
@@ -49,7 +49,7 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.to validate_presence_of(:government) }
       it { is_expected.to validate_presence_of(:opening_at) }
-      it { is_expected.to validate_presence_of(:petition_duration) }
+      it { is_expected.not_to validate_presence_of(:petition_duration) }
       it { is_expected.not_to validate_presence_of(:dissolution_heading) }
       it { is_expected.not_to validate_presence_of(:dissolution_message) }
       it { is_expected.not_to validate_presence_of(:dissolved_heading) }
@@ -71,7 +71,7 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.to validate_presence_of(:government) }
       it { is_expected.to validate_presence_of(:opening_at) }
-      it { is_expected.to validate_presence_of(:petition_duration) }
+      it { is_expected.not_to validate_presence_of(:petition_duration) }
       it { is_expected.to validate_presence_of(:dissolution_heading) }
       it { is_expected.to validate_presence_of(:dissolution_message) }
       it { is_expected.not_to validate_presence_of(:dissolved_heading) }
@@ -93,7 +93,7 @@ RSpec.describe Parliament, type: :model do
 
       it { is_expected.to validate_presence_of(:government) }
       it { is_expected.to validate_presence_of(:opening_at) }
-      it { is_expected.to validate_presence_of(:petition_duration) }
+      it { is_expected.not_to validate_presence_of(:petition_duration) }
       it { is_expected.to validate_presence_of(:dissolution_heading) }
       it { is_expected.to validate_presence_of(:dissolution_message) }
       it { is_expected.to validate_presence_of(:dissolved_heading) }


### PR DESCRIPTION
Petitions from the coalition government ran for a period of time chosen by the petition creator so we need to cater for that.