### PR TITLE
Reset column information in migration

### DIFF
--- a/db/migrate/20170611131130_add_parliament_id_to_archived_petitions.rb
+++ b/db/migrate/20170611131130_add_parliament_id_to_archived_petitions.rb
@@ -7,6 +7,9 @@ class AddParliamentIdToArchivedPetitions < ActiveRecord::Migration
     add_index :archived_petitions, :parliament_id
     add_foreign_key :archived_petitions, :parliaments
 
+    Parliament.reset_column_information
+    ArchivedPetition.reset_column_information
+
     parliament = Parliament.create!(
       government: "Conservative – Liberal Democrat coalition",
       opening_at: "2010-05-18T00:00:00".in_time_zone,


### PR DESCRIPTION
When running `rake db:migrate` from scratch Rails will load the column information for a table and cache it so when the model is used a second time the column information is stale and a previously added column is not found.

Fix this by resetting the column information before using the model(s).