### PR TITLE
Add archived petition email jobs

### DIFF
--- a/app/controllers/archived/signatures_controller.rb
+++ b/app/controllers/archived/signatures_controller.rb
@@ -1,0 +1,38 @@
+module Archived
+  class SignaturesController < ApplicationController
+    before_action :retrieve_signature
+    before_action :verify_unsubscribe_token
+    before_action :do_not_cache
+
+    respond_to :html
+
+    def unsubscribe
+      @signature.unsubscribe!(token_param)
+
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    private
+
+    def token_param
+      @token_param ||= params[:token].to_s
+    end
+
+    def verify_unsubscribe_token
+      unless @signature.unsubscribe_token == token_param
+        raise ActiveRecord::RecordNotFound, "Unable to find Signature with unsubscribe token: #{token_param.inspect}"
+      end
+    end
+
+    def retrieve_signature
+      @signature = Archived::Signature.find(params[:id])
+      @petition = @signature.petition
+
+      if @signature.invalidated? || @signature.fraudulent?
+        raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+      end
+    end
+  end
+end

--- a/app/jobs/archive_petition_job.rb
+++ b/app/jobs/archive_petition_job.rb
@@ -28,6 +28,13 @@ class ArchivePetitionJob < ApplicationJob
         p.created_at = petition.created_at
         p.updated_at = petition.updated_at
 
+        if receipt = petition.email_requested_receipt
+          p.email_requested_for_government_response_at = receipt.government_response
+          p.email_requested_for_debate_scheduled_at = receipt.debate_scheduled
+          p.email_requested_for_debate_outcome_at = receipt.debate_outcome
+          p.email_requested_for_petition_email_at = receipt.petition_email
+        end
+
         if note = petition.note
           p.build_note do |n|
             n.details = note.details

--- a/app/jobs/archived/deliver_debate_outcome_email_job.rb
+++ b/app/jobs/archived/deliver_debate_outcome_email_job.rb
@@ -1,0 +1,13 @@
+module Archived
+  class DeliverDebateOutcomeEmailJob < ApplicationJob
+    include EmailDelivery
+
+    def create_email
+      if signature.creator?
+        mailer.notify_creator_of_debate_outcome signature.petition, signature
+      else
+        mailer.notify_signer_of_debate_outcome signature.petition, signature
+      end
+    end
+  end
+end

--- a/app/jobs/archived/deliver_debate_scheduled_email_job.rb
+++ b/app/jobs/archived/deliver_debate_scheduled_email_job.rb
@@ -1,0 +1,13 @@
+module Archived
+  class DeliverDebateScheduledEmailJob < ApplicationJob
+    include EmailDelivery
+
+    def create_email
+      if signature.creator?
+        mailer.notify_creator_of_debate_scheduled signature.petition, signature
+      else
+        mailer.notify_signer_of_debate_scheduled signature.petition, signature
+      end
+    end
+  end
+end

--- a/app/jobs/archived/deliver_petition_email_job.rb
+++ b/app/jobs/archived/deliver_petition_email_job.rb
@@ -1,0 +1,20 @@
+module Archived
+  class DeliverPetitionEmailJob < ApplicationJob
+    include EmailDelivery
+
+    attr_reader :email
+
+    def perform(**args)
+      @email = args[:email]
+      super
+    end
+
+    def create_email
+      if signature.creator?
+        mailer.email_creator petition, signature, email
+      else
+        mailer.email_signer petition, signature, email
+      end
+    end
+  end
+end

--- a/app/jobs/archived/deliver_threshold_response_email_job.rb
+++ b/app/jobs/archived/deliver_threshold_response_email_job.rb
@@ -1,0 +1,13 @@
+module Archived
+  class DeliverThresholdResponseEmailJob < ApplicationJob
+    include EmailDelivery
+
+    def create_email
+      if signature.creator?
+        mailer.notify_creator_of_threshold_response signature.petition, signature
+      else
+        mailer.notify_signer_of_threshold_response signature.petition, signature
+      end
+    end
+  end
+end

--- a/app/jobs/archived/email_debate_outcomes_job.rb
+++ b/app/jobs/archived/email_debate_outcomes_job.rb
@@ -1,0 +1,8 @@
+module Archived
+  class EmailDebateOutcomesJob < ApplicationJob
+    include EmailAllPetitionSignatories
+
+    self.email_delivery_job_class = Archived::DeliverDebateOutcomeEmailJob
+    self.timestamp_name = 'debate_outcome'
+  end
+end

--- a/app/jobs/archived/email_debate_scheduled_job.rb
+++ b/app/jobs/archived/email_debate_scheduled_job.rb
@@ -1,0 +1,8 @@
+module Archived
+  class EmailDebateScheduledJob < ApplicationJob
+    include EmailAllPetitionSignatories
+
+    self.email_delivery_job_class = Archived::DeliverDebateScheduledEmailJob
+    self.timestamp_name = 'debate_scheduled'
+  end
+end

--- a/app/jobs/archived/email_petitioners_job.rb
+++ b/app/jobs/archived/email_petitioners_job.rb
@@ -1,0 +1,34 @@
+module Archived
+  class EmailPetitionersJob < ApplicationJob
+    include EmailAllPetitionSignatories
+
+    self.email_delivery_job_class = Archived::DeliverPetitionEmailJob
+    self.timestamp_name = 'petition_email'
+
+    attr_reader :email
+
+    # It's likely that the email got deleted so we just log the error and move on
+    rescue_from ActiveJob::DeserializationError do |exception|
+      log_exception(exception)
+    end
+
+    def perform(**args)
+      @email = args[:email]
+      super
+    end
+
+    private
+
+    def mailer_arguments(signature)
+      super.merge(email: email)
+    end
+
+    def log_exception(exception)
+      logger.info(log_message(exception))
+    end
+
+    def log_message(exception)
+      "#{exception.class.name} while running #{self.class.name}"
+    end
+  end
+end

--- a/app/jobs/archived/email_threshold_response_job.rb
+++ b/app/jobs/archived/email_threshold_response_job.rb
@@ -1,0 +1,8 @@
+module Archived
+  class EmailThresholdResponseJob < ApplicationJob
+    include EmailAllPetitionSignatories
+
+    self.email_delivery_job_class = Archived::DeliverThresholdResponseEmailJob
+    self.timestamp_name = 'government_response'
+  end
+end

--- a/app/jobs/concerns/email_delivery.rb
+++ b/app/jobs/concerns/email_delivery.rb
@@ -67,7 +67,14 @@ module EmailDelivery
   end
 
   def mailer
-    PetitionMailer
+    case petition
+    when Archived::Petition
+      Archived::PetitionMailer
+    when Petition
+      PetitionMailer
+    else
+      raise ArgumentError, "Unknown petition type: #{petition.class}"
+    end
   end
 
   def create_email

--- a/app/mailers/archived/petition_mailer.rb
+++ b/app/mailers/archived/petition_mailer.rb
@@ -35,6 +35,30 @@ module Archived
         list_unsubscribe: unsubscribe_url
     end
 
+    def notify_signer_of_debate_outcome(petition, signature)
+      @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+      if @debate_outcome.debated?
+        subject = subject_for(:notify_signer_of_positive_debate_outcome)
+      else
+        subject = subject_for(:notify_signer_of_negative_debate_outcome)
+      end
+
+      mail to: @signature.email, subject: subject, list_unsubscribe: unsubscribe_url
+    end
+
+    def notify_creator_of_debate_outcome(petition, signature)
+      @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+      if @debate_outcome.debated?
+        subject = subject_for(:notify_creator_of_positive_debate_outcome)
+      else
+        subject = subject_for(:notify_creator_of_negative_debate_outcome)
+      end
+
+      mail to: @signature.email, subject: subject, list_unsubscribe: unsubscribe_url
+    end
+
     private
 
     def subject_for(key, options = {})

--- a/app/mailers/archived/petition_mailer.rb
+++ b/app/mailers/archived/petition_mailer.rb
@@ -2,6 +2,24 @@ module Archived
   class PetitionMailer < ApplicationMailer
     include ActiveSupport::NumberHelper
 
+    def notify_signer_of_threshold_response(petition, signature)
+      @petition, @signature = petition, signature
+      @government_response, @parliament = petition.government_response, petition.parliament
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_signer_of_threshold_response),
+        list_unsubscribe: unsubscribe_url
+    end
+
+    def notify_creator_of_threshold_response(petition, signature)
+      @petition, @signature = petition, signature
+      @government_response, @parliament = petition.government_response, petition.parliament
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_creator_of_threshold_response),
+        list_unsubscribe: unsubscribe_url
+    end
+
     def notify_signer_of_debate_scheduled(petition, signature)
       @petition, @signature = petition, signature
 

--- a/app/mailers/archived/petition_mailer.rb
+++ b/app/mailers/archived/petition_mailer.rb
@@ -2,6 +2,21 @@ module Archived
   class PetitionMailer < ApplicationMailer
     include ActiveSupport::NumberHelper
 
+    def email_signer(petition, signature, email)
+      @petition, @signature, @email = petition, signature, email
+
+      mail to: @signature.email,
+        subject: subject_for(:email_signer),
+        list_unsubscribe: unsubscribe_url
+    end
+
+    def email_creator(petition, signature, email)
+      @petition, @signature, @email = petition, signature, email
+      mail to: @signature.email,
+        subject: subject_for(:email_creator),
+        list_unsubscribe: unsubscribe_url
+    end
+
     def notify_signer_of_threshold_response(petition, signature)
       @petition, @signature = petition, signature
       @government_response, @parliament = petition.government_response, petition.parliament

--- a/app/mailers/archived/petition_mailer.rb
+++ b/app/mailers/archived/petition_mailer.rb
@@ -1,0 +1,50 @@
+module Archived
+  class PetitionMailer < ApplicationMailer
+    include ActiveSupport::NumberHelper
+
+    def notify_signer_of_debate_scheduled(petition, signature)
+      @petition, @signature = petition, signature
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_signer_of_debate_scheduled),
+        list_unsubscribe: unsubscribe_url
+    end
+
+    def notify_creator_of_debate_scheduled(petition, signature)
+      @petition, @signature = petition, signature
+      mail to: @signature.email,
+        subject: subject_for(:notify_creator_of_debate_scheduled),
+        list_unsubscribe: unsubscribe_url
+    end
+
+    private
+
+    def subject_for(key, options = {})
+      I18n.t key, i18n_options.merge(options)
+    end
+
+    def signature_belongs_to_creator?
+      @signature && @signature.creator?
+    end
+
+    def i18n_options
+      {}.tap do |options|
+        options[:scope] = :"petitions.emails.subjects"
+
+        if defined?(@petition)
+          options[:count] = @petition.signature_count
+          options[:formatted_count] = number_to_delimited(@petition.signature_count)
+          options[:action] = @petition.action
+        end
+
+        if defined?(@email)
+          options[:subject] = @email.subject
+        end
+      end
+    end
+
+    def unsubscribe_url
+      "<#{unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token)}>"
+    end
+  end
+end

--- a/app/models/archived/debate_outcome.rb
+++ b/app/models/archived/debate_outcome.rb
@@ -1,3 +1,5 @@
+require_dependency 'archived'
+
 module Archived
   class DebateOutcome < ActiveRecord::Base
     # By default we want the user to upload a '2x' style image, and we can then

--- a/app/models/archived/government_response.rb
+++ b/app/models/archived/government_response.rb
@@ -1,3 +1,5 @@
+require_dependency 'archived'
+
 module Archived
   class GovernmentResponse < ActiveRecord::Base
     belongs_to :petition, touch: true

--- a/app/models/archived/note.rb
+++ b/app/models/archived/note.rb
@@ -1,3 +1,5 @@
+require_dependency 'archived'
+
 module Archived
   class Note < ActiveRecord::Base
     belongs_to :petition, touch: true

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -1,4 +1,5 @@
 require 'textacular/searchable'
+require_dependency 'archived'
 
 module Archived
   class Petition < ActiveRecord::Base
@@ -75,6 +76,10 @@ module Archived
 
       def not_debated
         where(debate_state: 'not_debated')
+      end
+
+      def debate_scheduled
+        where.not(scheduled_debate_date: nil)
       end
 
       def visible

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -148,6 +148,22 @@ module Archived
       end
     end
 
+    def get_email_requested_at_for(name)
+      self["email_requested_for_#{name}_at"]
+    end
+
+    def set_email_requested_at_for(name, to: Time.current)
+      update_column("email_requested_for_#{name}_at", to)
+    end
+
+    def signatures_to_email_for(name)
+      if timestamp = get_email_requested_at_for(name)
+        signatures.need_emailing_for(name, since: timestamp)
+      else
+        raise ArgumentError, "The #{name} email has not been requested for petition #{id}"
+      end
+    end
+
     private
 
     def calculate_petition_duration

--- a/app/models/archived/petition/email.rb
+++ b/app/models/archived/petition/email.rb
@@ -1,3 +1,5 @@
+require_dependency 'archived'
+
 module Archived
   class Petition < ActiveRecord::Base
     class Email < ActiveRecord::Base

--- a/app/models/archived/rejection.rb
+++ b/app/models/archived/rejection.rb
@@ -1,3 +1,5 @@
+require_dependency 'archived'
+
 module Archived
   class Rejection < ActiveRecord::Base
     CODES = %w[duplicate irrelevant no-action honours fake-name foi libellous offensive]

--- a/app/models/archived/signature.rb
+++ b/app/models/archived/signature.rb
@@ -1,3 +1,5 @@
+require_dependency 'archived'
+
 module Archived
   class Signature < ActiveRecord::Base
     PENDING_STATE = 'pending'

--- a/app/models/archived/signature.rb
+++ b/app/models/archived/signature.rb
@@ -27,8 +27,41 @@ module Archived
     validates :name, presence: true, length: { maximum: 255 }
     validates :state, presence: true, inclusion: { in: STATES }
 
-    def self.batch(id = 0, limit: 1000)
-      where(arel_table[:id].gteq(id)).order(id: :asc).limit(limit)
+    class << self
+      def batch(id = 0, limit: 1000)
+        where(arel_table[:id].gteq(id)).order(id: :asc).limit(limit)
+      end
+
+      def column_name_for(timestamp)
+        TIMESTAMPS.fetch(timestamp)
+      rescue
+        raise ArgumentError, "Unknown petition email timestamp: #{timestamp.inspect}"
+      end
+
+      def for_timestamp(timestamp, since:)
+        column = arel_table[column_name_for(timestamp)]
+        where(column.eq(nil).or(column.lt(since)))
+      end
+
+      def need_emailing_for(timestamp, since:)
+        validated.subscribed.for_timestamp(timestamp, since: since)
+      end
+
+      def subscribed
+        where(notify_by_email: true)
+      end
+
+      def validated
+        where(state: VALIDATED_STATE)
+      end
+    end
+
+    def get_email_sent_at_for(timestamp)
+      self[column_name_for(timestamp)]
+    end
+
+    def set_email_sent_at_for(timestamp, to: Time.current)
+      update_column(column_name_for(timestamp), to)
     end
 
     def pending?
@@ -67,6 +100,12 @@ module Archived
 
     def invalid_unsubscribe_token?
       errors[:base].include?("Invalid Unsubscribe Token")
+    end
+
+    private
+
+    def column_name_for(timestamp)
+      self.class.column_name_for(timestamp)
     end
   end
 end

--- a/app/views/archived/petition_mailer/email_creator.html.erb
+++ b/app/views/archived/petition_mailer/email_creator.html.erb
@@ -1,0 +1,18 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently created the petition “<%= @petition.action %>”:<br />
+<%= link_to nil, archived_petition_url(@petition) %></p>
+
+<%= auto_link(simple_format(h(@email.body))) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/email_creator.text.erb
+++ b/app/views/archived/petition_mailer/email_creator.text.erb
@@ -1,0 +1,18 @@
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+You recently created the petition “<%= @petition.action %>”:
+<%= archived_petition_url(@petition) %>
+
+<%= @email.body %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/email_signer.html.erb
+++ b/app/views/archived/petition_mailer/email_signer.html.erb
@@ -1,0 +1,18 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently signed the petition “<%= @petition.action %>”:<br />
+<%= link_to nil, archived_petition_url(@petition) %></p>
+
+<%= auto_link(simple_format(h(@email.body))) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/email_signer.text.erb
+++ b/app/views/archived/petition_mailer/email_signer.text.erb
@@ -1,0 +1,18 @@
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+You recently signed the petition “<%= @petition.action %>”:
+<%= archived_petition_url(@petition) %>
+
+<%= @email.body %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -1,0 +1,41 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<% if @debate_outcome.debated? %>
+<p>Parliament debated your petition – “<%= @petition.action %>”</p>
+<% if @debate_outcome.overview? %>
+
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+<% end %>
+<% if @debate_outcome.video_url? %>
+
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+<% end %>
+
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+<% else %>
+<p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+<% if @debate_outcome.overview? %>
+
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+<% end %>
+
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+<% end %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -1,0 +1,42 @@
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+<% if @debate_outcome.debated? %>
+Parliament debated your petition – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+<% else %>
+The Petitions Committee decided not to debate your petition – "<%= @petition.action %>"
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<% end %>
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/notify_creator_of_debate_scheduled.html.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_debate_scheduled.html.erb
@@ -1,0 +1,21 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament is going to debate your petition – “<%= @petition.action %>”.</p>
+
+<p><%= link_to nil, archived_petition_url(@petition) %></p>
+
+<p>The debate is scheduled for <%= short_date_format(@petition.scheduled_debate_date) %>.</p>
+
+<p>Once the debate has happened, we’ll email you a video and transcript.</p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/notify_creator_of_debate_scheduled.text.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_debate_scheduled.text.erb
@@ -1,0 +1,21 @@
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+Parliament is going to debate your petition – “<%= @petition.action %>”.
+
+<%= archived_petition_url(@petition) %>
+
+The debate is scheduled for <%= short_date_format(@petition.scheduled_debate_date) %>.
+
+Once the debate has happened, we’ll email you a video and transcript.
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -1,0 +1,33 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Government has responded to your petition – “<%= link_to @petition.action, archived_petition_url(@petition) %>”.</p>
+
+<p>Government responded:</p>
+
+<blockquote><%= auto_link(simple_format(h(@government_response.summary))) %></blockquote>
+
+<blockquote><%= auto_link(simple_format(h(@government_response.details))) %></blockquote>
+
+<p>Click this link to view the response online:</p>
+
+<p><%= link_to nil, archived_petition_url(@petition, reveal_response: "yes") %></p>
+
+<% if @petition.signature_count < @parliament.threshold_for_debate %>
+<p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= @parliament.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<% else %>
+<p>This petition has over <%= @parliament.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>
+<% end %>
+
+<p>The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -1,0 +1,33 @@
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+The Government has responded to your petition – “<%= @petition.action %>”.
+
+Government responded:
+
+<%= h(@government_response.summary) %>
+
+<%= h(@government_response.details) %>
+
+Click this link to view the response online:
+
+<%= archived_petition_url(@petition, reveal_response: "yes") %>
+
+<% if @petition.signature_count < Site.threshold_for_debate %>
+The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+<% else %>
+This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.
+<% end %>
+
+The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= help_url(anchor: 'petitions-committee') %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -1,0 +1,41 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<% if @debate_outcome.debated? %>
+<p>Parliament debated the petition you signed – “<%= @petition.action %>”</p>
+<% if @debate_outcome.overview? %>
+
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+<% end %>
+<% if @debate_outcome.video_url? %>
+
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+<% end %>
+
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+<% else %>
+<p>The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”</p>
+<% if @debate_outcome.overview? %>
+
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+<% end %>
+
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+<% end %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -1,0 +1,42 @@
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+<% if @debate_outcome.debated? %>
+Parliament debated the petition you signed – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+<% else %>
+The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<% end %>
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -1,0 +1,21 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament is going to debate the petition you signed – “<%= @petition.action %>”.</p>
+
+<p><%= link_to nil, archived_petition_url(@petition) %></p>
+
+<p>The debate is scheduled for <%= short_date_format(@petition.scheduled_debate_date) %>.</p>
+
+<p>Once the debate has happened, we’ll email you a video and transcript.</p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -1,0 +1,21 @@
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+Parliament is going to debate the petition you signed – “<%= @petition.action %>”.
+
+<%= archived_petition_url(@petition) %>
+
+The debate is scheduled for <%= short_date_format(@petition.scheduled_debate_date) %>.
+
+Once the debate has happened, we’ll email you a video and transcript.
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -1,0 +1,33 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Government has responded to the petition you signed – “<%= link_to @petition.action, archived_petition_url(@petition) %>”.</p>
+
+<p>Government responded:</p>
+
+<blockquote><%= auto_link(simple_format(h(@government_response.summary))) %></blockquote>
+
+<blockquote><%= auto_link(simple_format(h(@government_response.details))) %></blockquote>
+
+<p>Click this link to view the response online:</p>
+
+<p><%= link_to nil, archived_petition_url(@petition, reveal_response: "yes") %></p>
+
+<% if @petition.signature_count < @parliament.threshold_for_debate %>
+<p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= @parliament.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<% else %>
+<p>This petition has over <%= @parliament.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>
+<% end %>
+
+<p>The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -1,0 +1,33 @@
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+The Government has responded to the petition you signed – “<%= @petition.action %>”.
+
+Government responded:
+
+<%= h(@government_response.summary) %>
+
+<%= h(@government_response.details) %>
+
+Click this link to view the response online:
+
+<%= archived_petition_url(@petition, reveal_response: "yes") %>
+
+<% if @petition.signature_count < @parliament.threshold_for_debate %>
+The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= @parliament.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+<% else %>
+This petition has over <%= @parliament.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.
+<% end %>
+
+The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= help_url(anchor: 'petitions-committee') %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/signatures/unsubscribe.html.erb
+++ b/app/views/archived/signatures/unsubscribe.html.erb
@@ -1,0 +1,12 @@
+<% if @signature.already_unsubscribed? %>
+  <h1>Already unsubscribed from this petition</h1>
+  <p>You have already unsubscribed from email updates about this petition.</p>
+<% elsif @signature.invalid_unsubscribe_token? %>
+  <h1>Failed to unsubscribe</h1>
+  <p>Your unsubscribe link is invalid.</p>
+<% else %>
+  <h1>Successfully unsubscribed from this petition</h1>
+  <p>You have unsubscribed from email updates about this petition.</p>
+<% end %>
+
+<%= link_to "Return to home page", home_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,10 @@ Rails.application.routes.draw do
 
     namespace :archived do
       resources :petitions, only: [:index, :show]
+
+      resources :signatures, only: [] do
+        get :unsubscribe, on: :member
+      end
     end
 
     # REDIRECTS OLD PAGES

--- a/db/migrate/20170629144129_add_email_requested_timestamps_to_archived_petitions.rb
+++ b/db/migrate/20170629144129_add_email_requested_timestamps_to_archived_petitions.rb
@@ -1,0 +1,8 @@
+class AddEmailRequestedTimestampsToArchivedPetitions < ActiveRecord::Migration
+  def change
+    add_column :archived_petitions, :email_requested_for_government_response_at, :datetime
+    add_column :archived_petitions, :email_requested_for_debate_scheduled_at, :datetime
+    add_column :archived_petitions, :email_requested_for_debate_outcome_at, :datetime
+    add_column :archived_petitions, :email_requested_for_petition_email_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -242,7 +242,11 @@ CREATE TABLE archived_petitions (
     stopped_at timestamp without time zone,
     special_consideration boolean,
     signatures_by_constituency jsonb,
-    signatures_by_country jsonb
+    signatures_by_country jsonb,
+    email_requested_for_government_response_at timestamp without time zone,
+    email_requested_for_debate_scheduled_at timestamp without time zone,
+    email_requested_for_debate_outcome_at timestamp without time zone,
+    email_requested_for_petition_email_at timestamp without time zone
 );
 
 
@@ -2481,4 +2485,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170626123257');
 INSERT INTO schema_migrations (version) VALUES ('20170626130418');
 
 INSERT INTO schema_migrations (version) VALUES ('20170627125046');
+
+INSERT INTO schema_migrations (version) VALUES ('20170629144129');
 

--- a/features/suzie_unsubscribes_from_petition_updates.feature
+++ b/features/suzie_unsubscribes_from_petition_updates.feature
@@ -10,7 +10,7 @@ Feature: Unsubscribing from petiton updates as Suzie
     And the threshold for a parliamentary debate is "5"
     And a moderator responds to the petition
 
-  Scenario: Suzie receives and email containing an unsubscription link
+  Scenario: Suzie receives an email containing an unsubscription link
     Then Suzie should have received a petition response email with an unsubscription link
     When Suzie follows the unsubscription link
     Then Suzie should see a confirmation page stating that her subscription was successful

--- a/spec/controllers/archived/signatures_controller_spec.rb
+++ b/spec/controllers/archived/signatures_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Archived::SignaturesController, type: :controller do
+  describe '#unsubscribe' do
+    let(:signature) { double(:signature, id: 1, unsubscribe_token: "token") }
+    let(:petition) { double(:petition) }
+
+    before do
+      expect(Archived::Signature).to receive(:find).with("1").and_return(signature)
+      expect(signature).to receive(:petition).and_return(petition)
+      allow(signature).to receive(:fraudulent?).and_return(false)
+      allow(signature).to receive(:invalidated?).and_return(false)
+    end
+
+    context "when the signature is validated" do
+      before do
+        expect(signature).to receive(:unsubscribe!).with("token")
+      end
+
+      it "renders the action template" do
+        get :unsubscribe, id: "1", token: "token"
+        expect(response).to render_template(:unsubscribe)
+      end
+    end
+
+    context "when the signature is fraudulent" do
+      before do
+        expect(signature).to receive(:fraudulent?).and_return(true)
+      end
+
+      it "raises an ActiveRecord::RecordNotFound error" do
+        expect {
+          get :unsubscribe, id: "1", token: "token"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when the signature is invalidated" do
+      before do
+        expect(signature).to receive(:invalidated?).and_return(true)
+      end
+
+      it "raises an ActiveRecord::RecordNotFound error" do
+        expect {
+          get :unsubscribe, id: "1", token: "token"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -80,6 +80,11 @@ FactoryGirl.define do
       end
     end
 
+    trait :scheduled_for_debate do
+      scheduled_debate_date { 1.week.from_now }
+      debate_state "scheduled"
+    end
+
     trait :debated do
       debate_outcome_at { 1.week.ago }
       debate_state "debated"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -207,6 +207,24 @@ FactoryGirl.define do
     trait :scheduled_for_debate do
       scheduled_debate_date { 10.days.from_now }
     end
+
+    trait :email_requested do
+      transient do
+        email_requested_for_government_response_at { nil }
+        email_requested_for_debate_scheduled_at { nil }
+        email_requested_for_debate_outcome_at { nil }
+        email_requested_for_petition_email_at { nil }
+      end
+
+      after(:build) do |petition, evaluator|
+        petition.build_email_requested_receipt do |r|
+          r.government_response = evaluator.email_requested_for_government_response_at
+          r.debate_scheduled = evaluator.email_requested_for_debate_scheduled_at
+          r.debate_outcome = evaluator.email_requested_for_debate_outcome_at
+          r.petition_email = evaluator.email_requested_for_petition_email_at
+        end
+      end
+    end
   end
 
   factory :pending_petition, :parent => :petition do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -99,6 +99,7 @@ FactoryGirl.define do
 
       after(:build) do |petition, evaluator|
         petition.build_debate_outcome do |o|
+          o.debated = true
           o.debated_on = evaluator.debated_on if evaluator.debated_on.present?
           o.overview = evaluator.overview if evaluator.overview.present?
           o.transcript_url = evaluator.transcript_url if evaluator.transcript_url.present?
@@ -109,8 +110,15 @@ FactoryGirl.define do
     end
 
     trait :not_debated do
+      transient do
+        overview { nil }
+      end
+
       after(:build) do |petition, evaluator|
-        petition.build_debate_outcome(debated: false)
+        petition.build_debate_outcome do |o|
+          o.debated = false
+          o.overview = evaluator.overview if evaluator.overview.present?
+        end
       end
     end
 

--- a/spec/jobs/archive_petition_job_spec.rb
+++ b/spec/jobs/archive_petition_job_spec.rb
@@ -4,6 +4,7 @@ require 'digest/sha2'
 RSpec.describe ArchivePetitionJob, type: :job do
   let(:petition) { FactoryGirl.create(:closed_petition) }
   let(:archived_petition) { Archived::Petition.first }
+  let(:email_request) { petition.email_requested_receipt }
 
   let(:archive_signatures_job) do
     {
@@ -225,6 +226,46 @@ RSpec.describe ArchivePetitionJob, type: :job do
 
       expect(File.exist?(path)).to eq(true)
       expect(Digest::SHA256.file(path)).to eq(commons_image_file_digest)
+    end
+  end
+
+  context "with a petition that has an government_response email scheduled" do
+    let(:petition) do
+      FactoryGirl.create(:closed_petition, :email_requested, email_requested_for_government_response_at: Time.current)
+    end
+
+    it "copies the receipt timestamp to the archived petition" do
+      expect(archived_petition.email_requested_for_government_response_at).to be_usec_precise_with(email_request.government_response)
+    end
+  end
+
+  context "with a petition that has an debate_scheduled email scheduled" do
+    let(:petition) do
+      FactoryGirl.create(:closed_petition, :email_requested, email_requested_for_debate_scheduled_at: Time.current)
+    end
+
+    it "copies the receipt timestamp to the archived petition" do
+      expect(archived_petition.email_requested_for_debate_scheduled_at).to be_usec_precise_with(email_request.debate_scheduled)
+    end
+  end
+
+  context "with a petition that has an debate_outcome email scheduled" do
+    let(:petition) do
+      FactoryGirl.create(:closed_petition, :email_requested, email_requested_for_debate_outcome_at: Time.current)
+    end
+
+    it "copies the receipt timestamp to the archived petition" do
+      expect(archived_petition.email_requested_for_debate_outcome_at).to be_usec_precise_with(email_request.debate_outcome)
+    end
+  end
+
+  context "with a petition that has an petition_email email scheduled" do
+    let(:petition) do
+      FactoryGirl.create(:closed_petition, :email_requested, email_requested_for_petition_email_at: Time.current)
+    end
+
+    it "copies the receipt timestamp to the archived petition" do
+      expect(archived_petition.email_requested_for_petition_email_at).to be_usec_precise_with(email_request.petition_email)
     end
   end
 end

--- a/spec/jobs/archived/deliver_debate_outcome_email_job_spec.rb
+++ b/spec/jobs/archived/deliver_debate_outcome_email_job_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::DeliverDebateOutcomeEmailJob, type: :job do
+  let(:requested_at) { Time.current.change(usec: 0) }
+  let(:requested_at_as_string) { requested_at.getutc.iso8601(6) }
+
+  let(:petition) { FactoryGirl.create(:archived_petition, :debated) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:timestamp_name) { 'debate_outcome' }
+
+  let :arguments do
+    {
+      signature: signature,
+      timestamp_name: timestamp_name,
+      petition: petition,
+      requested_at: requested_at_as_string
+    }
+  end
+
+  before do
+    petition.set_email_requested_at_for(timestamp_name, to: requested_at)
+  end
+
+  it_behaves_like "a job to send an signatory email"
+
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_outcome).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_outcome).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+end

--- a/spec/jobs/archived/deliver_debate_scheduled_email_job_spec.rb
+++ b/spec/jobs/archived/deliver_debate_scheduled_email_job_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::DeliverDebateScheduledEmailJob, type: :job do
+  let(:requested_at) { Time.current.change(usec: 0) }
+  let(:requested_at_as_string) { requested_at.getutc.iso8601(6) }
+
+  let(:petition) { FactoryGirl.create(:archived_petition, :scheduled_for_debate) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:timestamp_name) { 'debate_scheduled' }
+
+  let :arguments do
+    {
+      signature: signature,
+      timestamp_name: timestamp_name,
+      petition: petition,
+      requested_at: requested_at_as_string
+    }
+  end
+
+  before do
+    petition.set_email_requested_at_for(timestamp_name, to: requested_at)
+  end
+
+  it_behaves_like "a job to send an signatory email"
+
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_scheduled).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+end

--- a/spec/jobs/archived/deliver_petition_email_job_spec.rb
+++ b/spec/jobs/archived/deliver_petition_email_job_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::DeliverPetitionEmailJob, type: :job do
+  let(:requested_at) { Time.current.change(usec: 0) }
+  let(:requested_at_as_string) { requested_at.getutc.iso8601(6) }
+
+  let(:petition) { FactoryGirl.create(:archived_petition) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:email) { FactoryGirl.create(:archived_petition_email, petition: petition) }
+  let(:timestamp_name) { 'petition_email' }
+
+  let :arguments do
+    {
+      signature: signature,
+      timestamp_name: timestamp_name,
+      petition: petition,
+      requested_at: requested_at_as_string,
+      email: email
+    }
+  end
+
+  before do
+    petition.set_email_requested_at_for(timestamp_name, to: requested_at)
+  end
+
+  it_behaves_like "a job to send an signatory email"
+
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :email_creator).with(petition, signature, email).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :email_signer).with(petition, signature, email).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+end

--- a/spec/jobs/archived/deliver_threshold_response_email_job_spec.rb
+++ b/spec/jobs/archived/deliver_threshold_response_email_job_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::DeliverThresholdResponseEmailJob, type: :job do
+  let(:requested_at) { Time.current.change(usec: 0) }
+  let(:requested_at_as_string) { requested_at.getutc.iso8601(6) }
+
+  let(:petition) { FactoryGirl.create(:archived_petition, :response) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:timestamp_name) { 'government_response' }
+
+  let :arguments do
+    {
+      signature: signature,
+      timestamp_name: timestamp_name,
+      petition: petition,
+      requested_at: requested_at_as_string
+    }
+  end
+
+  before do
+    petition.set_email_requested_at_for(timestamp_name, to: requested_at)
+  end
+
+  it_behaves_like "a job to send an signatory email"
+
+  context "when the signature is the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(true)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_threshold_response).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+
+  context "when the signature is not the creator" do
+    before do
+      allow(signature).to receive(:creator?).and_return(false)
+    end
+
+    it "uses the correct mailer method to generate the email" do
+      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_threshold_response).with(petition, signature).and_return double.as_null_object
+      subject.perform(**arguments)
+    end
+  end
+end

--- a/spec/jobs/archived/email_debate_outcomes_job_spec.rb
+++ b/spec/jobs/archived/email_debate_outcomes_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::EmailDebateOutcomesJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:archived_petition, :debated) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:arguments) { { petition: petition } }
+
+  before do
+    petition.set_email_requested_at_for('debate_outcome', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+  end
+
+  it_behaves_like "job to enqueue signatory mailing jobs"
+end

--- a/spec/jobs/archived/email_debate_scheduled_job_spec.rb
+++ b/spec/jobs/archived/email_debate_scheduled_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::EmailDebateScheduledJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:archived_petition, :scheduled_for_debate) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:arguments) { { petition: petition } }
+
+  before do
+    petition.set_email_requested_at_for('debate_scheduled', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+  end
+
+  it_behaves_like "job to enqueue signatory mailing jobs"
+end

--- a/spec/jobs/archived/email_petitioners_job_spec.rb
+++ b/spec/jobs/archived/email_petitioners_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::EmailPetitionersJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:archived_petition) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:email) { FactoryGirl.create(:archived_petition_email, petition: petition) }
+  let(:arguments) { { petition: petition, email: email } }
+
+  before do
+    petition.set_email_requested_at_for('petition_email', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+  end
+
+  it_behaves_like "job to enqueue signatory mailing jobs"
+
+  context "when the petition email has been deleted" do
+    before do
+      email.destroy
+    end
+
+    it "enqueues a job" do
+      described_class.run_later_tonight(**arguments)
+      expect(enqueued_jobs.size).to eq(1)
+    end
+
+    it "doesn't raise an error" do
+      expect {
+        perform_enqueued_jobs {
+          described_class.run_later_tonight(**arguments)
+        }
+      }.not_to raise_error
+    end
+
+    it "doesn't send any email" do
+      expect {
+        perform_enqueued_jobs {
+          described_class.run_later_tonight(**arguments)
+        }
+      }.not_to change { deliveries.size }
+    end
+  end
+end

--- a/spec/jobs/archived/email_threshold_response_job_spec.rb
+++ b/spec/jobs/archived/email_threshold_response_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require_relative '../shared_examples'
+
+RSpec.describe Archived::EmailThresholdResponseJob, type: :job do
+  let(:email_requested_at) { Time.current }
+  let(:petition) { FactoryGirl.create(:archived_petition, :response) }
+  let(:signature) { FactoryGirl.create(:archived_signature, petition: petition) }
+  let(:arguments) { { petition: petition } }
+
+  before do
+    petition.set_email_requested_at_for('government_response', to: email_requested_at)
+    allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
+  end
+
+  it_behaves_like "job to enqueue signatory mailing jobs"
+end

--- a/spec/jobs/email_threshold_response_job_spec.rb
+++ b/spec/jobs/email_threshold_response_job_spec.rb
@@ -13,5 +13,4 @@ RSpec.describe EmailThresholdResponseJob, type: :job do
   end
 
   it_behaves_like "job to enqueue signatory mailing jobs"
-
 end

--- a/spec/jobs/shared_examples.rb
+++ b/spec/jobs/shared_examples.rb
@@ -7,7 +7,6 @@ RSpec.shared_examples_for "job to enqueue signatory mailing jobs" do
   end
 
   describe '.run_later_tonight' do
-    let(:petition) { FactoryGirl.create(:open_petition) }
     let(:petition_gid) { { "_aj_globalid" => petition.to_global_id.to_s } }
 
     let(:queue_size) { enqueued_jobs.size }

--- a/spec/mailers/archived/petition_mailer_spec.rb
+++ b/spec/mailers/archived/petition_mailer_spec.rb
@@ -17,6 +17,117 @@ RSpec.describe Archived::PetitionMailer, type: :mailer do
     )
   end
 
+  describe "notifying signature of a government response" do
+    let :petition do
+      FactoryGirl.create(:archived_petition, :response,
+        action: "Allow organic vegetable vans to use red diesel",
+        background: "Add vans to permitted users of red diesel",
+        additional_details: "To promote organic vegetables",
+        response_summary: "Sounds like a good idea",
+        response_details: "We’ll get right on that",
+        signature_count: signature_count
+      )
+    end
+
+    let(:signature_count) { 15000 }
+
+    shared_examples_for "a government response email" do
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+      end
+
+      it "includes the petition action" do
+        expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+      end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+      end
+
+      it "has the correct subject" do
+        expect(mail).to have_subject("Government responded to “Allow organic vegetable vans to use red diesel”")
+      end
+
+      it "has response summary in the body" do
+        expect(mail).to have_body_text("Sounds like a good idea")
+      end
+
+      it "has response details in the body" do
+        expect(mail).to have_body_text("We’ll get right on that")
+      end
+
+      it "includes a link to read the response online" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}\?reveal_response=yes])
+      end
+
+      context "when the signature count is less than the debate threshold" do
+        let(:signature_count) { 12345 }
+
+        it "includes a message about the committee's response" do
+          expect(mail).to have_body_text("The Petitions Committee will take a look at this petition and its response.")
+          expect(mail).to have_body_text("They can press the government for action and gather evidence.")
+          expect(mail).to have_body_text("If this petition reaches 100,000 signatures, the Committee will consider it for a debate.")
+        end
+      end
+
+      context "when the signature count is more than the debate threshold" do
+        let(:signature_count) { 123456 }
+
+        it "includes a message about the committee's response" do
+          expect(mail).to have_body_text("This petition has over 100,000 signatures.")
+          expect(mail).to have_body_text("The Petitions Committee will consider it for a debate.")
+          expect(mail).to have_body_text("They can also gather further evidence and press the government for action.")
+        end
+      end
+    end
+
+    context "when the signature is the creator" do
+      let(:signature) { creator }
+      subject(:mail) { described_class.notify_creator_of_threshold_response(petition, signature) }
+
+      it_behaves_like "a government response email"
+
+      it "sends it only to the creator" do
+        expect(mail.to).to eq(%w[bazbutler@gmail.com])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear Barry Butler,")
+      end
+
+      it "has the message in the body" do
+        expect(mail).to have_body_text("The Government has responded to your petition")
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { signer }
+      subject(:mail) { described_class.notify_signer_of_threshold_response(petition, signature) }
+
+      it_behaves_like "a government response email"
+
+      it "sends it only to the signer" do
+        expect(mail.to).to eq(%w[laurapalmer@hotmail.com])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear Laura Palmer,")
+      end
+
+      it "has the message in the body" do
+        expect(mail).to have_body_text("The Government has responded to the petition you signed")
+      end
+    end
+  end
+
   describe "notifying signature of a debate being scheduled" do
     let :petition do
       FactoryGirl.create(:archived_petition, :scheduled_for_debate,

--- a/spec/mailers/archived/petition_mailer_spec.rb
+++ b/spec/mailers/archived/petition_mailer_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe Archived::PetitionMailer, type: :mailer do
+  let :creator do
+    FactoryGirl.create(:archived_signature,
+      name: "Barry Butler",
+      email: "bazbutler@gmail.com",
+      creator: true
+    )
+  end
+
+  let(:signer) do
+    FactoryGirl.create(:archived_signature,
+      name: "Laura Palmer",
+      email: "laurapalmer@hotmail.com",
+      petition: petition
+    )
+  end
+
+  describe "notifying signature of a debate being scheduled" do
+    let :petition do
+      FactoryGirl.create(:archived_petition, :scheduled_for_debate,
+        action: "Allow organic vegetable vans to use red diesel",
+        background: "Add vans to permitted users of red diesel",
+        additional_details: "To promote organic vegetables",
+        scheduled_debate_date: "2017-09-12"
+      )
+    end
+
+    shared_examples_for "a debate scheduled email" do
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+      end
+
+      it "includes the petition action" do
+        expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+      end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+      end
+
+      it "has the correct subject" do
+        expect(mail).to have_subject("Parliament will debate “Allow organic vegetable vans to use red diesel”")
+      end
+
+      it "has the scheduled debate date in the body" do
+        expect(mail).to have_body_text("12 September 2017")
+      end
+    end
+
+    context "when the signature is the creator" do
+      let(:signature) { creator }
+      subject(:mail) { described_class.notify_creator_of_debate_scheduled(petition, signature) }
+
+      it_behaves_like "a debate scheduled email"
+
+      it "sends it only to the creator" do
+        expect(mail.to).to eq(%w[bazbutler@gmail.com])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear Barry Butler,")
+      end
+
+      it "has the message in the body" do
+        expect(mail).to have_body_text("Parliament is going to debate your petition")
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { signer }
+      subject(:mail) { described_class.notify_signer_of_debate_scheduled(petition, signature) }
+
+      it_behaves_like "a debate scheduled email"
+
+      it "sends it only to the signer" do
+        expect(mail.to).to eq(%w[laurapalmer@hotmail.com])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear Laura Palmer,")
+      end
+
+      it "has the message in the body" do
+        expect(mail).to have_body_text("Parliament is going to debate the petition you signed")
+      end
+    end
+  end
+end

--- a/spec/mailers/archived/petition_mailer_spec.rb
+++ b/spec/mailers/archived/petition_mailer_spec.rb
@@ -468,4 +468,76 @@ RSpec.describe Archived::PetitionMailer, type: :mailer do
       end
     end
   end
+
+  describe "emailing a signature" do
+    let :petition do
+      FactoryGirl.create(:archived_petition,
+        action: "Allow organic vegetable vans to use red diesel",
+        background: "Add vans to permitted users of red diesel",
+        additional_details: "To promote organic vegetables"
+      )
+    end
+
+    let(:email) do
+      FactoryGirl.create(:archived_petition_email,
+        subject: "This is a message from the committee",
+        body: "Message body from the petition committee",
+        petition: petition
+      )
+    end
+
+    shared_examples_for "a petition email" do
+      it "has the correct subject" do
+        expect(mail).to have_subject("This is a message from the committee")
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear #{signature.name},")
+      end
+
+      it "sends it only to the signatory" do
+        expect(mail.to).to eq([signature.email])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+      end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+      end
+
+      it "includes the message body" do
+        expect(mail).to have_body_text(%r[Message body from the petition committee])
+      end
+    end
+
+    context "when the signature is the creator" do
+      let(:signature) { creator }
+      subject(:mail) { described_class.email_creator(petition, signature, email) }
+
+      it_behaves_like "a petition email"
+
+      it "identifies them as the creator" do
+        expect(mail).to have_body_text(%[You recently created the petition])
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { signer }
+      subject(:mail) { described_class.email_signer(petition, signature, email) }
+
+      it_behaves_like "a petition email"
+
+      it "identifies them as a ordinary signature" do
+        expect(mail).to have_body_text(%[You recently signed the petition])
+      end
+    end
+  end
 end

--- a/spec/mailers/previews/archived/petition_mailer_preview.rb
+++ b/spec/mailers/previews/archived/petition_mailer_preview.rb
@@ -29,5 +29,33 @@ module Archived
 
       Archived::PetitionMailer.notify_creator_of_debate_scheduled(petition, signature)
     end
+
+    def notify_signer_of_positive_debate_outcome
+      petition = Archived::Petition.debated.last
+      signature = petition.signatures.validated.last
+
+      Archived::PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+    end
+
+    def notify_creator_of_positive_debate_outcome
+      petition = Archived::Petition.debated.last
+      signature = petition.creator
+
+      Archived::PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+    end
+
+    def notify_signer_of_negative_debate_outcome
+      petition = Archived::Petition.not_debated.last
+      signature = petition.signatures.validated.last
+
+      Archived::PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+    end
+
+    def notify_creator_of_negative_debate_outcome
+      petition = Archived::Petition.not_debated.last
+      signature = petition.creator
+
+      Archived::PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+    end
   end
 end

--- a/spec/mailers/previews/archived/petition_mailer_preview.rb
+++ b/spec/mailers/previews/archived/petition_mailer_preview.rb
@@ -1,0 +1,19 @@
+# Preview all emails at http://localhost:3000/rails/mailers/archived/petition_mailer
+
+module Archived
+  class PetitionMailerPreview < ActionMailer::Preview
+    def notify_signer_of_debate_scheduled
+      petition = Archived::Petition.debated.last
+      signature = petition.signatures.validated.last
+
+      Archived::PetitionMailer.notify_signer_of_debate_scheduled(petition, signature)
+    end
+
+    def notify_creator_of_debate_scheduled
+      petition = Archived::Petition.debated.last
+      signature = petition.creator
+
+      Archived::PetitionMailer.notify_creator_of_debate_scheduled(petition, signature)
+    end
+  end
+end

--- a/spec/mailers/previews/archived/petition_mailer_preview.rb
+++ b/spec/mailers/previews/archived/petition_mailer_preview.rb
@@ -2,6 +2,22 @@
 
 module Archived
   class PetitionMailerPreview < ActionMailer::Preview
+    def email_signer
+      email = Archived::Petition::Email.last
+      petition = email.petition
+      signature = petition.signatures.validated.last
+
+      PetitionMailer.email_signer(petition, signature, email)
+    end
+
+    def email_creator
+      email = Archived::Petition::Email.last
+      petition = email.petition
+      signature = petition.creator
+
+      PetitionMailer.email_creator(petition, signature, email)
+    end
+
     def notify_signer_of_threshold_response
       petition = Archived::Petition.with_response.last
       signature = petition.signatures.validated.last

--- a/spec/mailers/previews/archived/petition_mailer_preview.rb
+++ b/spec/mailers/previews/archived/petition_mailer_preview.rb
@@ -2,6 +2,20 @@
 
 module Archived
   class PetitionMailerPreview < ActionMailer::Preview
+    def notify_signer_of_threshold_response
+      petition = Archived::Petition.with_response.last
+      signature = petition.signatures.validated.last
+
+      Archived::PetitionMailer.notify_signer_of_threshold_response(petition, signature)
+    end
+
+    def notify_creator_of_threshold_response
+      petition = Archived::Petition.with_response.last
+      signature = petition.creator
+
+      Archived::PetitionMailer.notify_creator_of_threshold_response(petition, signature)
+    end
+
     def notify_signer_of_debate_scheduled
       petition = Archived::Petition.debated.last
       signature = petition.signatures.validated.last

--- a/spec/support/time_comparison_helpers.rb
+++ b/spec/support/time_comparison_helpers.rb
@@ -4,15 +4,15 @@ RSpec::Matchers.define :be_usec_precise_with do |expected|
   end
 
   failure_message do |actual|
-    "\nexpected #{expected_formatted} to #{description}\n\n\n"
+    "\nexpected #{formatted(actual)} to #{description}\n\n\n"
   end
 
   failure_message_when_negated do |actual|
-    "\nexpected #{expected_formatted} not to #{description}\n\n\n"
+    "\nexpected #{formatted(actual)} not to #{description}\n\n\n"
   end
 
   description do
-    "be within 1 microsecond of #{expected_formatted}"
+    "be within 1 microsecond of #{formatted(expected)}"
   end
 
   private
@@ -20,12 +20,7 @@ RSpec::Matchers.define :be_usec_precise_with do |expected|
   def usec_precision
     @_usec ||= 0.000001.seconds
   end
-  def expected_formatted
-    formatted(expected)
-  end
-  def actual_formatted
-    formatted(actual)
-  end
+
   def formatted(object)
     RSpec::Support::ObjectFormatter.format(object)
   end


### PR DESCRIPTION
This PR adds the email jobs that we need for the archived petition admin. It also adds the ability to unsubscribe from updates about archived petitions.

Based off #604 so that needs to be merged first