### PR TITLE
Prevent editing as soon as archiving has started

### DIFF
--- a/app/jobs/archive_petition_job.rb
+++ b/app/jobs/archive_petition_job.rb
@@ -103,6 +103,7 @@ class ArchivePetitionJob < ApplicationJob
         end
       end
 
+      petition.update_column(:archiving_started_at, Time.current)
       ArchiveSignaturesJob.perform_later(petition, archived_petition)
     end
   end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -606,8 +606,16 @@ class Petition < ActiveRecord::Base
     state.in?(PUBLISHED_STATES)
   end
 
+  def archiving?
+    archiving_started_at? && !archived_at?
+  end
+
   def archived?
     archived_at?
+  end
+
+  def editing_disabled?
+    archiving_started_at? || archived_at?
   end
 
   def can_have_debate_added?

--- a/app/views/admin/debate_outcomes/_petition_action_debate_outcome.html.erb
+++ b/app/views/admin/debate_outcomes/_petition_action_debate_outcome.html.erb
@@ -3,17 +3,17 @@
   <%= form_row for: [f.object, :overview] do %>
     <%= f.label :overview, class: 'form-label' %>
     <%= error_messages_for_field f.object, :overview %>
-    <%= f.text_area :overview, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.text_area :overview, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
   <% end %>
 
   <h3 class="petition-action-subheading">Was this petition debated?</h3>
 
   <%= form_row class: 'inline' do %>
     <%= f.label :debated_true, nil, class: 'block-label' do %>
-      <%= f.radio_button :debated, true, disabled: @petition.archived? %> Yes
+      <%= f.radio_button :debated, true, disabled: @petition.editing_disabled? %> Yes
     <% end %>
     <%= f.label :debated_false, nil, class: 'block-label' do %>
-      <%= f.radio_button :debated, false, disabled: @petition.archived? %> No
+      <%= f.radio_button :debated, false, disabled: @petition.editing_disabled? %> No
     <% end %>
     <%= error_messages_for_field petition, :debated %>
   <% end %>
@@ -22,31 +22,31 @@
     <%= form_row :for => [f.object, :debated_on] do %>
       <%= f.label :debated_on, class: 'form-label' %>
       <%= error_messages_for_field f.object, :debated_on %>
-      <%= f.date_field :debated_on, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+      <%= f.date_field :debated_on, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
     <% end %>
 
     <%= form_row for: [f.object, :transcript_url] do %>
       <%= f.label :transcript_url, 'Transcript URL', class: 'form-label' %>
       <%= error_messages_for_field f.object, :transcript_url %>
-      <%= f.url_field :transcript_url, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+      <%= f.url_field :transcript_url, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
     <% end %>
 
     <%= form_row for: [f.object, :video_url] do %>
       <%= f.label :video_url, 'Video URL', class: 'form-label' %>
       <%= error_messages_for_field f.object, :video_url %>
-      <%= f.url_field :video_url, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+      <%= f.url_field :video_url, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
     <% end %>
 
     <%= form_row for: [f.object, :commons_image] do %>
       <%= f.label :commons_image, 'Commons Image', class: 'form-label' %>
       <%= error_messages_for_field f.object, :commons_image %>
-      <%= f.file_field :commons_image, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+      <%= f.file_field :commons_image, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
     <% end %>
   </div>
 
-  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.archived?) %>
+  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.editing_disabled?) %>
 
-  <% if @petition.archived? %>
+  <% if @petition.editing_disabled? %>
     <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
   <% else %>
     <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>

--- a/app/views/admin/government_response/_petition_action_government_response.html.erb
+++ b/app/views/admin/government_response/_petition_action_government_response.html.erb
@@ -3,19 +3,19 @@
   <%= form_row :for => [f.object, :summary] do %>
     <%= f.label :summary, 'Summary quote', class: 'form-label' %>
     <%= error_messages_for_field f.object, :summary %>
-    <%= f.text_area :summary, rows: 3, cols: 70, tabindex: increment, data: { max_length: 200 }, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.text_area :summary, rows: 3, cols: 70, tabindex: increment, data: { max_length: 200 }, class: 'form-control', disabled: @petition.editing_disabled? %>
     <p class="character-count">200 characters max</p>
   <% end %>
 
   <%= form_row :for => [f.object, :details] do %>
     <%= f.label :details, 'Response in full', class: 'form-label' %>
     <%= error_messages_for_field f.object, :details %>
-    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
   <% end %>
 
-  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.archived?) %>
+  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.editing_disabled?) %>
 
-  <% if @petition.archived? %>
+  <% if @petition.editing_disabled? %>
     <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
   <% else %>
     <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>

--- a/app/views/admin/notes/_petition_action_notes.html.erb
+++ b/app/views/admin/notes/_petition_action_notes.html.erb
@@ -3,7 +3,7 @@
   <%= form_row :for => [f.object, :admin_notes] do %>
     <%= f.label :details, 'Notes', class: 'form-label petition-action-heading' %>
     <%= error_messages_for_field f.object, :admin_notes %>
-    <%= f.text_area :details, tabindex: increment, rows: 10, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.text_area :details, tabindex: increment, rows: 10, class: 'form-control', disabled: @petition.editing_disabled? %>
     <div class="form-group-help">
       <details>
         <summary class="summary">How to use tags</summary>
@@ -17,7 +17,7 @@
     </div>
   <% end %>
 
-  <%= f.submit 'Save notes', class: 'button', disabled: @petition.archived? %>
+  <%= f.submit 'Save notes', class: 'button', disabled: @petition.editing_disabled? %>
   <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
 
 <% end -%>

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -1,6 +1,8 @@
 <!-- Back to X list -->
 
-<% if @petition.archived? %>
+<% if @petition.archiving? %>
+  <p class="flash-alert">This petition is being archived and cannot be edited</p>
+<% elsif @petition.archived? %>
   <p class="flash-alert">This petition has been archived and cannot be edited</p>
 <% end %>
 
@@ -14,37 +16,37 @@
       <%= form_row for: [f.object, :action] do %>
         <%= f.label :action, class: 'form-label' %>
         <%= error_messages_for_field @petition, :action %>
-        <%= f.text_area :action, tabindex: increment, rows: 3, maxlength: 80, class: 'form-control', disabled: @petition.archived? %>
+        <%= f.text_area :action, tabindex: increment, rows: 3, maxlength: 80, class: 'form-control', disabled: @petition.editing_disabled? %>
       <% end %>
 
       <%= form_row for: [f.object, :background] do %>
         <%= f.label :background, class: 'form-label' %>
         <%= error_messages_for_field @petition, :background %>
-        <%= f.text_area :background, tabindex: increment, rows: 5, class: 'form-control', disabled: @petition.archived? %>
+        <%= f.text_area :background, tabindex: increment, rows: 5, class: 'form-control', disabled: @petition.editing_disabled? %>
       <% end %>
 
       <%= form_row for: [f.object, :additional_details] do %>
         <%= f.label :additional_details, class: 'form-label' %>
         <%= error_messages_for_field @petition, :additional_details %>
-        <%= f.text_area :additional_details, tabindex: increment, rows: 7, class: 'form-control', disabled: @petition.archived? %>
+        <%= f.text_area :additional_details, tabindex: increment, rows: 7, class: 'form-control', disabled: @petition.editing_disabled? %>
       <% end %>
 
       <%= form_row for: [f.object, :creator_signature_name] do %>
         <%= f.fields_for :creator_signature do |c| %>
           <%= c.label :name, "Creator", class: 'form-label' %>
           <%= error_messages_for_field @petition.creator_signature, :name %>
-          <%= c.text_field :name, tabindex: increment, rows: 8, class: 'form-control', disabled: @petition.archived? %>
+          <%= c.text_field :name, tabindex: increment, rows: 8, class: 'form-control', disabled: @petition.editing_disabled? %>
         <% end %>
       <% end %>
 
       <%= form_row for: [f.object, :special_consideration] do %>
         <%= f.label :special_consideration do %>
-          <%= f.check_box :special_consideration, tabindex: increment, disabled: @petition.archived? %> Special consideration when dealing with this petition
+          <%= f.check_box :special_consideration, tabindex: increment, disabled: @petition.editing_disabled? %> Special consideration when dealing with this petition
         <% end %>
         <%= error_messages_for_field @petition, :special_consideration %>
       <% end %>
 
-      <%= f.submit 'Save', class: 'button', disabled: @petition.archived? %>
+      <%= f.submit 'Save', class: 'button', disabled: @petition.editing_disabled? %>
 
       <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
 

--- a/app/views/admin/petition_emails/_petition_action_email_petitioners.html.erb
+++ b/app/views/admin/petition_emails/_petition_action_email_petitioners.html.erb
@@ -13,8 +13,8 @@
         <tr>
           <td><%= email.subject %></td>
           <td>
-            <%= button_to 'Edit', edit_admin_petition_email_path(petition, email), method: :get, class: 'button', disabled: @petition.archived? %>
-            <%= button_to 'Delete', admin_petition_email_path(petition, email), method: :delete, class: 'button-warning', disabled: @petition.archived?, data: { confirm: 'Delete other parliamentary business?' } %>
+            <%= button_to 'Edit', edit_admin_petition_email_path(petition, email), method: :get, class: 'button', disabled: @petition.editing_disabled? %>
+            <%= button_to 'Delete', admin_petition_email_path(petition, email), method: :delete, class: 'button-warning', disabled: @petition.editing_disabled?, data: { confirm: 'Delete other parliamentary business?' } %>
           </td>
         </tr>
       <% end %>
@@ -26,20 +26,20 @@
   <%= form_row :for => [f.object, :subject] do %>
     <%= f.label :subject, 'Subject', class: 'form-label' %>
     <%= error_messages_for_field f.object, :subject %>
-    <%= f.text_area :subject, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.text_area :subject, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: 'form-control', disabled: @petition.editing_disabled? %>
     <p class="character-count">100 characters max</p>
   <% end %>
 
   <%= form_row :for => [f.object, :body] do %>
     <%= f.label :body, 'Body', class: 'form-label' %>
     <%= error_messages_for_field f.object, :body %>
-    <%= f.text_area :body, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.text_area :body, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: 'form-control', disabled: @petition.editing_disabled? %>
     <p class="character-count">5000 characters max</p>
   <% end %>
 
-  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.archived?) %>
+  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.editing_disabled?) %>
 
-  <% if @petition.archived? %>
+  <% if @petition.editing_disabled? %>
     <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
   <% else %>
     <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>

--- a/app/views/admin/petition_emails/edit.html.erb
+++ b/app/views/admin/petition_emails/edit.html.erb
@@ -6,20 +6,20 @@
       <%= form_row :for => [f.object, :subject] do %>
         <%= f.label :subject, 'Subject', class: 'form-label' %>
         <%= error_messages_for_field f.object, :subject %>
-        <%= f.text_area :subject, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: 'form-control', disabled: @petition.archived? %>
+        <%= f.text_area :subject, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: 'form-control', disabled: @petition.editing_disabled? %>
         <p class="character-count">100 characters max</p>
       <% end %>
 
       <%= form_row :for => [f.object, :body] do %>
         <%= f.label :body, 'Body', class: 'form-label' %>
         <%= error_messages_for_field f.object, :body %>
-        <%= f.text_area :body, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: 'form-control', disabled: @petition.archived? %>
+        <%= f.text_area :body, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: 'form-control', disabled: @petition.editing_disabled? %>
         <p class="character-count">5000 characters max</p>
       <% end %>
 
-      <%= email_petitioners_with_count_submit_button(f, @petition, disabled: @petition.archived?) %>
+      <%= email_petitioners_with_count_submit_button(f, @petition, disabled: @petition.editing_disabled?) %>
 
-      <% if @petition.archived? %>
+      <% if @petition.editing_disabled? %>
         <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
       <% else %>
         <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>

--- a/app/views/admin/petitions/_petition_content.html.erb
+++ b/app/views/admin/petitions/_petition_content.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 <% end %>
 
-<% unless @petition.archived? %>
+<% unless @petition.editing_disabled? %>
   <p class="edit-petition-link">
     <%= link_to 'Edit petition', admin_petition_petition_details_path(@petition) %>
   </p>

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -1,5 +1,7 @@
 <!-- Back to X list -->
-<% if @petition.archived? %>
+<% if @petition.archiving? %>
+  <p class="flash-alert">This petition is being archived and cannot be edited</p>
+<% elsif @petition.archived? %>
   <p class="flash-alert">This petition has been archived and cannot be edited</p>
 <% end %>
 

--- a/app/views/admin/schedule_debate/_petition_action_debate_date.html.erb
+++ b/app/views/admin/schedule_debate/_petition_action_debate_date.html.erb
@@ -3,12 +3,12 @@
   <%= form_row :for => [f.object, :scheduled_debate_date] do %>
     <%= f.label :scheduled_debate_date, class: 'form-label petition-action-heading' %>
     <%= error_messages_for_field f.object, :debated_on %>
-    <%= f.date_field :scheduled_debate_date, tabindex: increment, class: 'form-control', disabled: @petition.archived? %>
+    <%= f.date_field :scheduled_debate_date, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
   <% end %>
 
-  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.archived?) %>
+  <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.editing_disabled?) %>
 
-  <% if @petition.archived? %>
+  <% if @petition.editing_disabled? %>
     <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
   <% else %>
     <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>

--- a/db/migrate/20170703100952_add_archiving_started_at_to_petitions.rb
+++ b/db/migrate/20170703100952_add_archiving_started_at_to_petitions.rb
@@ -1,0 +1,5 @@
+class AddArchivingStartedAtToPetitions < ActiveRecord::Migration
+  def change
+    add_column :petitions, :archiving_started_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -859,7 +859,8 @@ CREATE TABLE petitions (
     debate_state character varying(30) DEFAULT 'pending'::character varying,
     stopped_at timestamp without time zone,
     special_consideration boolean,
-    archived_at timestamp without time zone
+    archived_at timestamp without time zone,
+    archiving_started_at timestamp without time zone
 );
 
 
@@ -2487,4 +2488,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170626130418');
 INSERT INTO schema_migrations (version) VALUES ('20170627125046');
 
 INSERT INTO schema_migrations (version) VALUES ('20170629144129');
+
+INSERT INTO schema_migrations (version) VALUES ('20170703100952');
 

--- a/spec/jobs/archive_petition_job_spec.rb
+++ b/spec/jobs/archive_petition_job_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe ArchivePetitionJob, type: :job do
     expect(enqueued_jobs).to include(archive_signatures_job)
   end
 
+  it "updates the archiving_started_at timestamp" do
+    expect(petition.archiving_started_at).not_to be_nil
+  end
+
   context "with a closed petition" do
     let(:petition) do
       FactoryGirl.create(

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2322,6 +2322,32 @@ RSpec.describe Petition, type: :model do
       end
     end
 
+    describe "#archiving?" do
+      context "when a petition has not started archiving" do
+        let(:petition) { FactoryGirl.create(:open_petition, archiving_started_at: nil, archived_at: nil) }
+
+        it "returns false" do
+          expect(petition.archiving?).to eq(false)
+        end
+      end
+
+      context "when a petition has started archiving, but not finished" do
+        let(:petition) { FactoryGirl.create(:open_petition, archiving_started_at: Time.current, archived_at: nil) }
+
+        it "returns true" do
+          expect(petition.archiving?).to eq(true)
+        end
+      end
+
+      context "when a petition has finished archiving" do
+        let(:petition) { FactoryGirl.create(:open_petition, archiving_started_at: 1.hour.ago, archived_at: Time.current) }
+
+        it "returns false" do
+          expect(petition.archiving?).to eq(false)
+        end
+      end
+    end
+
     describe "#archived?" do
       context "when a petition has not been copied to the archive" do
         let(:petition) { FactoryGirl.create(:open_petition, archived_at: nil) }
@@ -2336,6 +2362,32 @@ RSpec.describe Petition, type: :model do
 
         it "returns true" do
           expect(petition.archived?).to eq(true)
+        end
+      end
+    end
+
+    describe "#editing_disabled?" do
+      context "when a petition has not started archiving" do
+        let(:petition) { FactoryGirl.create(:open_petition, archiving_started_at: nil, archived_at: nil) }
+
+        it "returns false" do
+          expect(petition.editing_disabled?).to eq(false)
+        end
+      end
+
+      context "when a petition has started archiving, but not finished" do
+        let(:petition) { FactoryGirl.create(:open_petition, archiving_started_at: Time.current, archived_at: nil) }
+
+        it "returns true" do
+          expect(petition.editing_disabled?).to eq(true)
+        end
+      end
+
+      context "when a petition has finished archiving" do
+        let(:petition) { FactoryGirl.create(:open_petition, archiving_started_at: 1.hour.ago, archived_at: Time.current) }
+
+        it "returns true" do
+          expect(petition.editing_disabled?).to eq(true)
         end
       end
     end


### PR DESCRIPTION
It may take a number of hours for archiving a petition to complete so prevent editing as soon as it's started archiving.