### PR TITLE
Search from home page

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -38,6 +38,10 @@ module HomeHelper
     end
   end
 
+  def any_actioned_petitions?
+    !actioned_petitions_decorator.empty?
+  end
+
   def actioned_petitions(&block)
     actioned = actioned_petitions_decorator
     yield actioned unless actioned.empty?

--- a/app/views/pages/home/_dissolution_announced.html.erb
+++ b/app/views/pages/home/_dissolution_announced.html.erb
@@ -11,5 +11,15 @@
 <% end %>
 
 <%= render "pages/home/actioned_petitions" %>
+
+<section class="search-petitions">
+  <h1 class="page-title">Search petitions</h1>
+
+  <%= form_tag petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
+    <%= search_field_tag 'q', nil, class: 'form-control', id: 'search' %>
+    <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
+  <% end %>
+</section>
+
 <%= render "pages/home/explanation_petitions" %>
 <%= render "pages/home/local_petitions" %>

--- a/app/views/pages/home/_dissolved.html.erb
+++ b/app/views/pages/home/_dissolved.html.erb
@@ -10,6 +10,22 @@
   </a>
 <% end %>
 
+<% if any_actioned_petitions? %>
+  <div class="section-panel-borderless">
+    <p>During the last parliament</p>
+  </div>
+<% end %>
+
 <%= render "pages/home/actioned_petitions" %>
+
+<section class="search-petitions">
+  <h1 class="page-title">Search petitions</h1>
+
+  <%= form_tag petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
+    <%= search_field_tag 'q', nil, class: 'form-control', id: 'search' %>
+    <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
+  <% end %>
+</section>
+
 <%= render "pages/home/explanation_petitions" %>
 <%= render "pages/home/local_petitions" %>

--- a/app/views/pages/home/_opened.html.erb
+++ b/app/views/pages/home/_opened.html.erb
@@ -7,6 +7,15 @@
 
 <%= render "pages/home/actioned_petitions" %>
 
+<section class="search-petitions">
+  <h1 class="page-title">Search petitions</h1>
+
+  <%= form_tag petitions_path, class: 'search-inline', method: 'get', enforce_utf8: false do %>
+    <%= search_field_tag 'q', nil, class: 'form-control', id: 'search' %>
+    <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
+  <% end %>
+</section>
+
 <% unless no_petitions_yet? %>
   <%= render "pages/home/trending_petitions" %>
 <% end %>

--- a/app/views/pages/home/_pending.html.erb
+++ b/app/views/pages/home/_pending.html.erb
@@ -11,6 +11,15 @@
   Get involved with the UK Parliament
 </a>
 
+<section class="search-petitions">
+  <h1 class="page-title">Search petitions</h1>
+
+  <%= form_tag archived_petitions_path(state: 'published'), class: 'search-inline', method: 'get', enforce_utf8: false do %>
+    <%= search_field_tag 'q', nil, class: 'form-control', id: 'search' %>
+    <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
+  <% end %>
+</section>
+
 <h2 id="archived-petitions">View petitions from a previous government</h2>
 
 <ul>

--- a/features/arnold_searches_from_home_page.feature
+++ b/features/arnold_searches_from_home_page.feature
@@ -1,0 +1,78 @@
+@search
+Feature: Arnold searches from the home page
+  In order to reduce the likelihood of a duplicate petition being made
+  As a petition moderator
+  I want to prominently show a petition search for the current parliament from the home page
+
+Background:
+    Given a pending petition exists with action: "Wombles are great"
+    And a validated petition exists with action: "The Wombles of Wimbledon"
+    And an open petition exists with action: "Uncle Bulgaria", additional_details: "The Wombles are here", closed_at: "1 minute from now"
+    And an open petition exists with action: "Common People", background: "The Wombles belong to us all", closed_at: "11 days from now"
+    And an open petition exists with action: "Overthrow the Wombles", closed_at: "1 year from now"
+    And a closed petition exists with action: "The Wombles will rock Glasto", closed_at: "1 minute ago"
+    And a rejected petition exists with action: "Eavis vs the Wombles"
+    And a hidden petition exists with action: "The Wombles are profane"
+    And an open petition exists with action: "Wombles", closed_at: "10 days from now"
+    And the following archived petitions exist:
+      | action                   | state    | signature_count| opened_at  | closed_at  | created_at |
+      | Rivers are great         | closed   | 835            | 2012-01-01 | 2013-01-01 | 2012-01-01 |
+      | More rivers please       | closed   | 243            | 2011-04-01 | 2012-04-01 | 2011-04-01 |
+      | Cry me a river           | closed   | 639            | 2014-10-01 | 2015-03-31 | 2014-10-01 |
+      | Also Rivers              | rejected |                |            |            | 2011-01-01 |
+      | River Island             | hidden   |                |            |            | 2011-01-01 |
+
+Scenario: Arnold searches for petitions when parliament is opened
+  Given I am on the home page
+  When I search all petitions for "Wombles"
+  Then I should be on the all petitions page
+  And I should see my search term "Wombles" filled in the search field
+  And I should see "6 results"
+  And I should see the following search results:
+    | Wombles                            | 1 signature             |
+    | Overthrow the Wombles              | 1 signature             |
+    | Uncle Bulgaria                     | 1 signature             |
+    | Common People                      | 1 signature             |
+    | The Wombles will rock Glasto       | 1 signature, now closed |
+    | Eavis vs the Wombles               | Rejected                |
+
+Scenario: Arnold searches for petitions when parliament is dissolving
+  Given Parliament is dissolving
+  When I am on the home page
+  And I search all petitions for "Wombles"
+  Then I should be on the all petitions page
+  And I should see my search term "Wombles" filled in the search field
+  And I should see "6 results"
+  And I should see the following search results:
+    | Wombles                            | 1 signature             |
+    | Overthrow the Wombles              | 1 signature             |
+    | Uncle Bulgaria                     | 1 signature             |
+    | Common People                      | 1 signature             |
+    | The Wombles will rock Glasto       | 1 signature, now closed |
+    | Eavis vs the Wombles               | Rejected                |
+
+Scenario: Arnold searches for petitions when parliament is dissolved
+  Given Parliament is dissolved
+  When I am on the home page
+  And I search all petitions for "Wombles"
+  Then I should be on the all petitions page
+  And I should see my search term "Wombles" filled in the search field
+  And I should see the following search results:
+    | Wombles                            | 1 signature             |
+    | Overthrow the Wombles              | 1 signature             |
+    | Uncle Bulgaria                     | 1 signature             |
+    | Common People                      | 1 signature             |
+    | The Wombles will rock Glasto       | 1 signature, now closed |
+    | Eavis vs the Wombles               | Rejected                |
+
+Scenario: Arnold searches for petitions when parliament is pending
+  Given Parliament is pending
+  When I am on the home page
+  And I search all petitions for "Rivers"
+  Then I should be on the archived petitions page
+  And I should see my search term "Rivers" filled in the search field
+  And I should see "3 results"
+  And I should see the following search results:
+    | More rivers please       | 243 signatures   |
+    | Rivers are great         | 835 signatures   |
+    | Cry me a river           | 639 signatures   |

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -30,6 +30,10 @@ Given(/^Parliament is dissolved$/) do
     dissolution_faq_url: "https://parliament.example.com/parliament-is-closing"
 end
 
+Given(/^Parliament is pending$/) do
+  Parliament.instance.update!(opening_at: 1.month.from_now)
+end
+
 Given(/^the request is not local$/) do
   page.driver.options[:headers] = { "REMOTE_ADDR" => "192.168.1.128" }
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -466,3 +466,11 @@ Given(/^these archived petitions? exist?:?$/) do |table|
     FactoryGirl.create(:archived_petition, attributes)
   end
 end
+
+When (/^I search all petitions for "(.*?)"$/) do |search_term|
+  within :css, '.search-petitions' do
+    fill_in :search, with: search_term
+    step %{I press "Search"}
+  end
+end
+

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -28,6 +28,19 @@ Feature: Suzy Singer searches by free text
     Given a petition "Ban Badger Baiting" has been debated 2 days ago
     Given a petition "Leave EU" has been debated 18 days ago
 
+  Scenario: Search for all visible petitions
+    When I search for "All petitions" with "Wombles"
+    Then I should see my search term "Wombles" filled in the search field
+    And I should see "6 results"
+    And I should see the following search results:
+      | Wombles                            | 1 signature             |
+      | Overthrow the Wombles              | 1 signature             |
+      | Uncle Bulgaria                     | 1 signature             |
+      | Common People                      | 1 signature             |
+      | The Wombles will rock Glasto       | 1 signature, now closed |
+      | Eavis vs the Wombles               | Rejected                |
+    And the markup should be valid
+
   Scenario: Search for open petitions
     When I search for "Open petitions" with "Wombles"
     Then I should see my search term "Wombles" filled in the search field

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -88,4 +88,24 @@ RSpec.describe HomeHelper, type: :helper do
       end
     end
   end
+
+  describe "#any_actioned_petitions?" do
+    let!(:pending_petition) { FactoryGirl.create :pending_petition }
+    let!(:hidden_petition) { FactoryGirl.create :hidden_petition }
+    let!(:open_petition) { FactoryGirl.create :open_petition }
+
+    describe "when there is an actioned petition" do
+      let!(:responded_petition) { FactoryGirl.create :responded_petition }
+
+      it "returns true" do
+        expect(helper.any_actioned_petitions?).to eq true
+      end
+    end
+
+    describe "when there are no actioned petitions" do
+      it "returns false" do
+        expect(helper.any_actioned_petitions?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Make searches of petitions more prominent on the search page with the aim of reducing the number of duplicate petitions. 

[Pivotal tracker story](https://www.pivotaltracker.com/story/show/147678677)