### PR TITLE
Change black/white to neutral allow/block

### DIFF
--- a/app/controllers/admin/rate_limits_controller.rb
+++ b/app/controllers/admin/rate_limits_controller.rb
@@ -27,7 +27,7 @@ class Admin::RateLimitsController < Admin::AdminController
   def rate_limit_attributes
     %i[
       burst_rate burst_period sustained_rate sustained_period
-      domain_whitelist ip_whitelist domain_blacklist ip_blacklist
+      allowed_domains allowed_ips blocked_domains blocked_ips
       geoblocking_enabled countries
     ]
   end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -78,12 +78,12 @@ module AdminHelper
 
   def build_trending_domains(since, limit)
     all_domains = Signature.trending_domains(since: since, limit: limit + 30)
-    whitelist = rate_limit.whitelisted_domains
+    allowed_domains = rate_limit.allowed_domains_list
 
     all_domains.inject([]) do |domains, (domain, count)|
       return domains if domains.size == limit
 
-      unless whitelist.any?{ |d| d === domain }
+      unless allowed_domains.any?{ |d| d === domain }
         domains << [domain, count]
       end
 
@@ -93,12 +93,12 @@ module AdminHelper
 
   def build_trending_ips(since, limit)
     all_ips = Signature.trending_ips(since: since, limit: limit + 30)
-    whitelist = rate_limit.whitelisted_ips
+    allowed_ips = rate_limit.allowed_ips_list
 
     all_ips.inject([]) do |ips, (ip, count)|
       return ips if ips.size == limit
 
-      unless whitelist.any?{ |i| i.include?(ip) }
+      unless allowed_ips.any?{ |i| i.include?(ip) }
         ips << [ip, count]
       end
 

--- a/app/views/admin/rate_limits/edit.html.erb
+++ b/app/views/admin/rate_limits/edit.html.erb
@@ -3,86 +3,86 @@
 <div class="grid-row">
   <div class="column-two-thirds extra-gutter">
     <p>
-      <% if params[:tab] == "domain_whitelist" %>
+      <% if params[:tab] == "allowed_domains" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
-        Domain Whitelist |
-        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        Allowed Domains |
+        <%= link_to "Blocked Domains", edit_admin_rate_limits_path(tab: 'blocked_domains') %> |
+        <%= link_to "Allowed IPs", edit_admin_rate_limits_path(tab: 'allowed_ips') %> |
+        <%= link_to "Blocked IPs", edit_admin_rate_limits_path(tab: 'blocked_ips') %> |
         <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
-      <% elsif params[:tab] == "domain_blacklist" %>
+      <% elsif params[:tab] == "blocked_domains" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
-        Domain Blacklist |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Allowed Domains", edit_admin_rate_limits_path(tab: 'allowed_domains') %> |
+        Blocked Domains |
+        <%= link_to "Allowed IPs", edit_admin_rate_limits_path(tab: 'allowed_ips') %> |
+        <%= link_to "Blocked IPs", edit_admin_rate_limits_path(tab: 'blocked_ips') %> |
         <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
-      <% elsif params[:tab] == "ip_whitelist" %>
+      <% elsif params[:tab] == "allowed_ips" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
-        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
-        IP Whitelist |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Allowed Domains", edit_admin_rate_limits_path(tab: 'allowed_domains') %> |
+        <%= link_to "Blocked Domains", edit_admin_rate_limits_path(tab: 'blocked_domains') %> |
+        Allowed IPs |
+        <%= link_to "Blocked IPs", edit_admin_rate_limits_path(tab: 'blocked_ips') %> |
         <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
-      <% elsif params[:tab] == "ip_blacklist" %>
+      <% elsif params[:tab] == "blocked_ips" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
-        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        IP Blacklist |
+        <%= link_to "Allowed Domains", edit_admin_rate_limits_path(tab: 'allowed_domains') %> |
+        <%= link_to "Blocked Domains", edit_admin_rate_limits_path(tab: 'blocked_domains') %> |
+        <%= link_to "Allowed IPs", edit_admin_rate_limits_path(tab: 'allowed_ips') %> |
+        Blocked IPs |
         <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
       <% elsif params[:tab] == "countries" %>
         <%= link_to "Rate Limits", edit_admin_rate_limits_path %> |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
-        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Allowed Domains", edit_admin_rate_limits_path(tab: 'allowed_domains') %> |
+        <%= link_to "Blocked Domains", edit_admin_rate_limits_path(tab: 'blocked_domains') %> |
+        <%= link_to "Allowed IPs", edit_admin_rate_limits_path(tab: 'allowed_ips') %> |
+        <%= link_to "Blocked IPs", edit_admin_rate_limits_path(tab: 'blocked_ips') %> |
         Countries
       <% else %>
         Rate Limits |
-        <%= link_to "Domain Whitelist", edit_admin_rate_limits_path(tab: 'domain_whitelist') %> |
-        <%= link_to "Domain Blacklist", edit_admin_rate_limits_path(tab: 'domain_blacklist') %> |
-        <%= link_to "IP Whitelist", edit_admin_rate_limits_path(tab: 'ip_whitelist') %> |
-        <%= link_to "IP Blacklist", edit_admin_rate_limits_path(tab: 'ip_blacklist') %> |
+        <%= link_to "Allowed Domains", edit_admin_rate_limits_path(tab: 'allowed_domains') %> |
+        <%= link_to "Blocked Domains", edit_admin_rate_limits_path(tab: 'blocked_domains') %> |
+        <%= link_to "Allowed IPs", edit_admin_rate_limits_path(tab: 'allowed_ips') %> |
+        <%= link_to "Blocked IPs", edit_admin_rate_limits_path(tab: 'blocked_ips') %> |
         <%= link_to "Countries", edit_admin_rate_limits_path(tab: 'countries') %>
       <% end %>
     </p>
 
     <%= form_for @rate_limit, url: admin_rate_limits_path do |form| %>
 
-      <% if params[:tab] == "domain_whitelist" %>
-        <%= hidden_field_tag :tab, "domain_whitelist" %>
+      <% if params[:tab] == "allowed_domains" %>
+        <%= hidden_field_tag :tab, "allowed_domains" %>
 
-        <%= form_row for: [form.object, :domain_whitelist] do %>
-          <%= error_messages_for_field @rate_limit, :domain_whitelist %>
-          <%= form.text_area :domain_whitelist, tabindex: increment, rows: 15, class: 'form-control' %>
+        <%= form_row for: [form.object, :allowed_domains] do %>
+          <%= error_messages_for_field @rate_limit, :allowed_domains %>
+          <%= form.text_area :allowed_domains, tabindex: increment, rows: 15, class: 'form-control' %>
           <p><small>use *.example.com to match one subdomain and **.example.com to match nested subdomains</small><p>
         <% end %>
 
-      <% elsif params[:tab] == "domain_blacklist" %>
-        <%= hidden_field_tag :tab, "domain_blacklist" %>
+      <% elsif params[:tab] == "blocked_domains" %>
+        <%= hidden_field_tag :tab, "blocked_domains" %>
 
-        <%= form_row for: [form.object, :domain_blacklist] do %>
-          <%= error_messages_for_field @rate_limit, :domain_blacklist %>
-          <%= form.text_area :domain_blacklist, tabindex: increment, rows: 15, class: 'form-control' %>
+        <%= form_row for: [form.object, :blocked_domains] do %>
+          <%= error_messages_for_field @rate_limit, :blocked_domains %>
+          <%= form.text_area :blocked_domains, tabindex: increment, rows: 15, class: 'form-control' %>
           <p><small>use *.example.com to match one subdomain and **.example.com to match nested subdomains</small><p>
         <% end %>
 
-      <% elsif params[:tab] == "ip_whitelist" %>
-        <%= hidden_field_tag :tab, "ip_whitelist" %>
+      <% elsif params[:tab] == "allowed_ips" %>
+        <%= hidden_field_tag :tab, "allowed_ips" %>
 
-        <%= form_row for: [form.object, :ip_whitelist] do %>
-          <%= error_messages_for_field @rate_limit, :ip_whitelist %>
-          <%= form.text_area :ip_whitelist, tabindex: increment, rows: 15, class: 'form-control' %>
+        <%= form_row for: [form.object, :allowed_ips] do %>
+          <%= error_messages_for_field @rate_limit, :allowed_ips %>
+          <%= form.text_area :allowed_ips, tabindex: increment, rows: 15, class: 'form-control' %>
           <p><small>use CIDR addressing to match ranges, e.g. 192.168.0.0/24</small><p>
         <% end %>
 
-      <% elsif params[:tab] == "ip_blacklist" %>
-        <%= hidden_field_tag :tab, "ip_blacklist" %>
+      <% elsif params[:tab] == "blocked_ips" %>
+        <%= hidden_field_tag :tab, "blocked_ips" %>
 
-        <%= form_row for: [form.object, :ip_blacklist] do %>
-          <%= error_messages_for_field @rate_limit, :ip_blacklist %>
-          <%= form.text_area :ip_blacklist, tabindex: increment, rows: 15, class: 'form-control' %>
+        <%= form_row for: [form.object, :blocked_ips] do %>
+          <%= error_messages_for_field @rate_limit, :blocked_ips %>
+          <%= form.text_area :blocked_ips, tabindex: increment, rows: 15, class: 'form-control' %>
           <p><small>use CIDR addressing to match ranges, e.g. 192.168.0.0/24</small><p>
         <% end %>
 

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -66,10 +66,14 @@ en-GB:
 
         rate_limit:
           attributes:
-            ip_whitelist:
-              invalid: "IP whitelist is invalid"
-            ip_blacklist:
-              invalid: "IP blacklist is invalid"
+            allowed_domains:
+              invalid: "Allowed domains list is invalid"
+            blocked_domains:
+              invalid: "Blocked domains list is invalid"
+            allowed_ips:
+              invalid: "Allowed IPs list is invalid"
+            blocked_ips:
+              invalid: "Blocked IPs list is invalid"
 
         tag:
           attributes:

--- a/db/migrate/20170818110849_change_rate_limit_columns.rb
+++ b/db/migrate/20170818110849_change_rate_limit_columns.rb
@@ -1,0 +1,8 @@
+class ChangeRateLimitColumns < ActiveRecord::Migration
+  def change
+    rename_column(:rate_limits, :domain_whitelist, :allowed_domains)
+    rename_column(:rate_limits, :ip_whitelist, :allowed_ips)
+    rename_column(:rate_limits, :domain_blacklist, :blocked_domains)
+    rename_column(:rate_limits, :ip_blacklist, :blocked_ips)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -913,12 +913,12 @@ CREATE TABLE rate_limits (
     burst_period integer DEFAULT 60 NOT NULL,
     sustained_rate integer DEFAULT 5 NOT NULL,
     sustained_period integer DEFAULT 300 NOT NULL,
-    domain_whitelist character varying(10000) DEFAULT ''::character varying NOT NULL,
-    ip_whitelist character varying(10000) DEFAULT ''::character varying NOT NULL,
+    allowed_domains character varying(10000) DEFAULT ''::character varying NOT NULL,
+    allowed_ips character varying(10000) DEFAULT ''::character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    domain_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL,
-    ip_blacklist character varying(50000) DEFAULT ''::character varying NOT NULL,
+    blocked_domains character varying(50000) DEFAULT ''::character varying NOT NULL,
+    blocked_ips character varying(50000) DEFAULT ''::character varying NOT NULL,
     geoblocking_enabled boolean DEFAULT false NOT NULL,
     countries character varying(2000) DEFAULT ''::character varying NOT NULL
 );
@@ -2623,4 +2623,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170711153945');
 INSERT INTO schema_migrations (version) VALUES ('20170712070139');
 
 INSERT INTO schema_migrations (version) VALUES ('20170713193039');
+
+INSERT INTO schema_migrations (version) VALUES ('20170818110849');
 

--- a/features/admin/updating_rate_limits.feature
+++ b/features/admin/updating_rate_limits.feature
@@ -17,59 +17,59 @@ Feature: Sysadmin updates the rate limits
     And I press "Save"
     Then I should see "Rate limits updated successfully"
 
-  Scenario: Sysadmin updates the domain whitelist
+  Scenario: Sysadmin updates the allowed domains list
     When I am logged in as a sysadmin
     And I am on the admin home page
     And I follow "Rate Limits"
     Then I should see "Edit Rate Limits"
-    When I follow "Domain Whitelist"
+    When I follow "Allowed Domains"
     Then I should see "use *.example.com to match one subdomain and **.example.com to match nested subdomains"
-    When I fill in "rate_limit_domain_whitelist" with "foo("
+    When I fill in "rate_limit_allowed_domains" with "foo("
     And I press "Save"
-    Then I should see "Domain whitelist is invalid"
-    When I fill in "rate_limit_domain_whitelist" with "example.com"
+    Then I should see "Allowed domains list is invalid"
+    When I fill in "rate_limit_allowed_domains" with "example.com"
     And I press "Save"
     Then I should see "Rate limits updated successfully"
 
-  Scenario: Sysadmin updates the domain blacklist
+  Scenario: Sysadmin updates the blocked domains list
     When I am logged in as a sysadmin
     And I am on the admin home page
     And I follow "Rate Limits"
     Then I should see "Edit Rate Limits"
-    When I follow "Domain Blacklist"
+    When I follow "Blocked Domains"
     Then I should see "use *.example.com to match one subdomain and **.example.com to match nested subdomains"
-    When I fill in "rate_limit_domain_blacklist" with "foo("
+    When I fill in "rate_limit_blocked_domains" with "foo("
     And I press "Save"
-    Then I should see "Domain blacklist is invalid"
-    When I fill in "rate_limit_domain_blacklist" with "example.com"
+    Then I should see "Blocked domains list is invalid"
+    When I fill in "rate_limit_blocked_domains" with "example.com"
     And I press "Save"
     Then I should see "Rate limits updated successfully"
 
-  Scenario: Sysadmin updates the IP whitelist
+  Scenario: Sysadmin updates the allowed IPs list
     When I am logged in as a sysadmin
     And I am on the admin home page
     And I follow "Rate Limits"
     Then I should see "Edit Rate Limits"
-    When I follow "IP Whitelist"
+    When I follow "Allowed IPs"
     Then I should see "use CIDR addressing to match ranges, e.g. 192.168.0.0/24"
-    When I fill in "rate_limit_ip_whitelist" with "127"
+    When I fill in "rate_limit_allowed_ips" with "127"
     And I press "Save"
-    Then I should see "IP whitelist is invalid"
-    When I fill in "rate_limit_ip_whitelist" with "127.0.0.1/32"
+    Then I should see "Allowed IPs list is invalid"
+    When I fill in "rate_limit_allowed_ips" with "127.0.0.1/32"
     And I press "Save"
     Then I should see "Rate limits updated successfully"
 
-  Scenario: Sysadmin updates the IP whitelist
+  Scenario: Sysadmin updates the blocked IPs list
     When I am logged in as a sysadmin
     And I am on the admin home page
     And I follow "Rate Limits"
     Then I should see "Edit Rate Limits"
-    When I follow "IP Blacklist"
+    When I follow "Blocked IPs"
     Then I should see "use CIDR addressing to match ranges, e.g. 192.168.0.0/24"
-    When I fill in "rate_limit_ip_blacklist" with "127"
+    When I fill in "rate_limit_blocked_ips" with "127"
     And I press "Save"
-    Then I should see "IP blacklist is invalid"
-    When I fill in "rate_limit_ip_blacklist" with "127.0.0.1/32"
+    Then I should see "Blocked IPs list is invalid"
+    When I fill in "rate_limit_blocked_ips" with "127.0.0.1/32"
 
   Scenario: Sysadmin updates the countries
     When I am logged in as a sysadmin

--- a/features/step_definitions/rate_limit_steps.rb
+++ b/features/step_definitions/rate_limit_steps.rb
@@ -2,12 +2,12 @@ Given(/^the burst rate limit is (\d+) per minute$/) do |rate|
   RateLimit.first_or_create!.update!(burst_rate: rate, burst_period: 60)
 end
 
-Given(/^there is no IP whitelist$/) do
-  RateLimit.first_or_create!.update!(ip_whitelist: "")
+Given(/^there are no allowed IPs$/) do
+  RateLimit.first_or_create!.update!(allowed_ips: "")
 end
 
-Given(/^the domain "(.*?)" is whitelisted$/) do |domain|
-  RateLimit.first_or_create!.update!(domain_whitelist: domain)
+Given(/^the domain "(.*?)" is allowed$/) do |domain|
+  RateLimit.first_or_create!.update!(allowed_domains: domain)
 end
 
 Given(/^there is a signature already from this IP address$/) do

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -16,7 +16,7 @@ Before do
   RateLimit.create!(
     burst_rate: 10, burst_period: 60,
     sustained_rate: 20, sustained_period: 300,
-    domain_whitelist: "example.com", ip_whitelist: "127.0.0.1"
+    allowed_domains: "example.com", allowed_ips: "127.0.0.1"
   )
 end
 

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -150,7 +150,7 @@ Feature: Suzie signs a petition
 
   Scenario: Suzie cannot validate her signature when IP address is rate limited
     Given the burst rate limit is 1 per minute
-    And there is no IP whitelist
+    And there are no allowed IPs
     And there is a signature already from this IP address
     When I am on the new signature page
     And I fill in my details
@@ -160,10 +160,10 @@ Feature: Suzie signs a petition
     Then I am told to check my inbox to complete signing
     And "womboid@wimbledon.com" should have no emails
 
-  Scenario: Suzie can validate her signature when IP address is rate limited but the domain is whitelisted
+  Scenario: Suzie can validate her signature when IP address is rate limited but the domain is allowed
     Given the burst rate limit is 1 per minute
-    And there is no IP whitelist
-    And the domain "wimbledon.com" is whitelisted
+    And there are no allowed IPs
+    And the domain "wimbledon.com" is allowed
     And there is a signature already from this IP address
     When I am on the new signature page
     And I fill in my details

--- a/spec/controllers/admin/rate_limits_controller_spec.rb
+++ b/spec/controllers/admin/rate_limits_controller_spec.rb
@@ -85,9 +85,9 @@ RSpec.describe Admin::RateLimitsController, type: :controller, admin: true do
         end
       end
 
-      context "when submitting just the domain whitelist" do
+      context "when submitting just the allowed domains list" do
         let :params do
-          { domain_whitelist: "example.com" }
+          { allowed_domains: "example.com" }
         end
 
         it "redirects to the edit page" do
@@ -99,9 +99,9 @@ RSpec.describe Admin::RateLimitsController, type: :controller, admin: true do
         end
       end
 
-      context "when submitting just the domain blacklist" do
+      context "when submitting just the blocked domains list" do
         let :params do
-          { domain_blacklist: "example.com" }
+          { blocked_domains: "example.com" }
         end
 
         it "redirects to the edit page" do
@@ -113,9 +113,9 @@ RSpec.describe Admin::RateLimitsController, type: :controller, admin: true do
         end
       end
 
-      context "when submitting just the ip whitelist" do
+      context "when submitting just the allowed IPs list" do
         let :params do
-          { ip_whitelist: "127.0.0.1" }
+          { allowed_ips: "127.0.0.1" }
         end
 
         it "redirects to the edit page" do
@@ -127,9 +127,9 @@ RSpec.describe Admin::RateLimitsController, type: :controller, admin: true do
         end
       end
 
-      context "when submitting just the ip blacklist" do
+      context "when submitting just the blocked IPs list" do
         let :params do
-          { ip_blacklist: "127.0.0.1" }
+          { blocked_ips: "127.0.0.1" }
         end
 
         it "redirects to the edit page" do

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe AdminHelper, type: :helper do
 
   describe "#trending_domains" do
     let(:rate_limit) { double(:rate_limit) }
-    let(:whitelist) { [/\Afoo.com\z/] }
+    let(:allowed_domains_list) { [/\Afoo.com\z/] }
     let(:now) { Time.current.beginning_of_minute }
 
     let(:domains) do
@@ -158,7 +158,7 @@ RSpec.describe AdminHelper, type: :helper do
     before do
       expect(Signature).to receive(:trending_domains).with(args).and_return(domains)
       expect(RateLimit).to receive(:first_or_create!).and_return(rate_limit)
-      expect(rate_limit).to receive(:whitelisted_domains).and_return(whitelist)
+      expect(rate_limit).to receive(:allowed_domains_list).and_return(allowed_domains_list)
     end
 
     around do |example|
@@ -174,7 +174,7 @@ RSpec.describe AdminHelper, type: :helper do
         helper.trending_domains
       end
 
-      it "returns non-whitelisted trending domains" do
+      it "returns non-allowed trending domains" do
         expect(subject).to eq([["bar.com", 1]])
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe AdminHelper, type: :helper do
         helper.trending_domains(since: 2.hours.ago)
       end
 
-      it "returns non-whitelisted trending domains" do
+      it "returns non-allowed trending domains" do
         expect(subject).to eq([["bar.com", 1]])
       end
     end
@@ -202,7 +202,7 @@ RSpec.describe AdminHelper, type: :helper do
         helper.trending_domains(limit: 20)
       end
 
-      it "returns non-whitelisted trending domains" do
+      it "returns non-allowed trending domains" do
         expect(subject).to eq([["bar.com", 1]])
       end
     end
@@ -210,16 +210,16 @@ RSpec.describe AdminHelper, type: :helper do
 
   describe "#trending_domains?" do
     let(:rate_limit) { double(:rate_limit) }
-    let(:whitelist) { [/\Afoo.com\z/] }
+    let(:allowed_domains_list) { [/\Afoo.com\z/] }
 
     before do
-      expect(Signature).to receive(:trending_domains).and_return(ips)
+      expect(Signature).to receive(:trending_domains).and_return(domains)
       expect(RateLimit).to receive(:first_or_create!).and_return(rate_limit)
-      expect(rate_limit).to receive(:whitelisted_domains).and_return(whitelist)
+      expect(rate_limit).to receive(:allowed_domains_list).and_return(allowed_domains_list)
     end
 
-    context "when there are non-whitelisted trending domains" do
-      let(:ips) do
+    context "when there are non-allowed trending domains" do
+      let(:domains) do
         { "foo.com" => 2, "bar.com" => 1 }
       end
 
@@ -232,8 +232,8 @@ RSpec.describe AdminHelper, type: :helper do
       end
     end
 
-    context "when there aren't any non-whitelisted trending IP addresses" do
-      let(:ips) do
+    context "when there aren't any non-allowed trending domains" do
+      let(:domains) do
         { "foo.com" => 2 }
       end
 
@@ -249,7 +249,7 @@ RSpec.describe AdminHelper, type: :helper do
 
   describe "#trending_ips" do
     let(:rate_limit) { double(:rate_limit) }
-    let(:whitelist) { [IPAddr.new("192.168.1.1")] }
+    let(:allowed_ips_list) { [IPAddr.new("192.168.1.1")] }
     let(:now) { Time.current.beginning_of_minute }
 
     let(:ips) do
@@ -259,7 +259,7 @@ RSpec.describe AdminHelper, type: :helper do
     before do
       expect(Signature).to receive(:trending_ips).with(args).and_return(ips)
       expect(RateLimit).to receive(:first_or_create!).and_return(rate_limit)
-      expect(rate_limit).to receive(:whitelisted_ips).and_return(whitelist)
+      expect(rate_limit).to receive(:allowed_ips_list).and_return(allowed_ips_list)
     end
 
     around do |example|
@@ -275,7 +275,7 @@ RSpec.describe AdminHelper, type: :helper do
         helper.trending_ips
       end
 
-      it "returns non-whitelisted trending IP addresses" do
+      it "returns non-allowed trending IP addresses" do
         expect(subject).to eq([["10.0.1.1", 1]])
       end
     end
@@ -289,7 +289,7 @@ RSpec.describe AdminHelper, type: :helper do
         helper.trending_ips(since: 2.hours.ago)
       end
 
-      it "returns non-whitelisted trending IP addresses" do
+      it "returns non-allowed trending IP addresses" do
         expect(subject).to eq([["10.0.1.1", 1]])
       end
     end
@@ -303,7 +303,7 @@ RSpec.describe AdminHelper, type: :helper do
         helper.trending_ips(limit: 20)
       end
 
-      it "returns non-whitelisted trending IP addresses" do
+      it "returns non-allowed trending IP addresses" do
         expect(subject).to eq([["10.0.1.1", 1]])
       end
     end
@@ -311,15 +311,15 @@ RSpec.describe AdminHelper, type: :helper do
 
   describe "#trending_ips?" do
     let(:rate_limit) { double(:rate_limit) }
-    let(:whitelist) { [IPAddr.new("192.168.1.1")] }
+    let(:allowed_ips_list) { [IPAddr.new("192.168.1.1")] }
 
     before do
       expect(Signature).to receive(:trending_ips).and_return(ips)
       expect(RateLimit).to receive(:first_or_create!).and_return(rate_limit)
-      expect(rate_limit).to receive(:whitelisted_ips).and_return(whitelist)
+      expect(rate_limit).to receive(:allowed_ips_list).and_return(allowed_ips_list)
     end
 
-    context "when there are non-whitelisted trending IP addresses" do
+    context "when there are non-allowed trending IP addresses" do
       let(:ips) do
         { "192.168.1.1" => 2, "10.0.1.1" => 1 }
       end
@@ -333,7 +333,7 @@ RSpec.describe AdminHelper, type: :helper do
       end
     end
 
-    context "when there aren't any non-whitelisted trending IP addresses" do
+    context "when there aren't any non-allowed trending IP addresses" do
       let(:ips) do
         { "192.168.1.1" => 2 }
       end

--- a/spec/support/rate_limiting.rb
+++ b/spec/support/rate_limiting.rb
@@ -3,7 +3,7 @@ RSpec.configure do |config|
     RateLimit.create!(
       burst_rate: 10, burst_period: 60,
       sustained_rate: 20, sustained_period: 300,
-      domain_whitelist: "example.com", ip_whitelist: "127.0.0.1"
+      allowed_domains: "example.com", allowed_ips: "127.0.0.1"
     )
   end
 end


### PR DESCRIPTION
Whilst the etymology of black/white listing isn't racially based, it does reinforce the stereotypes of white=good and black=bad so change them to the neutral terms allow/block.

H/T to https://twitter.com/secnerdette/status/898314208097427457 for the inspiration.