### PR TITLE
Update petition id sequences for re-opening

### DIFF
--- a/db/migrate/20170903162156_adjust_petition_sequences_for_twenty_seventeen.rb
+++ b/db/migrate/20170903162156_adjust_petition_sequences_for_twenty_seventeen.rb
@@ -1,0 +1,11 @@
+class AdjustPetitionSequencesForTwentySeventeen < ActiveRecord::Migration
+  def up
+    execute "ALTER SEQUENCE archived_petitions_id_seq MAXVALUE 199999"
+    execute "ALTER SEQUENCE petitions_id_seq START WITH 200000 RESTART WITH 200000 MINVALUE 200000"
+  end
+
+  def down
+    execute "ALTER SEQUENCE archived_petitions_id_seq MAXVALUE 99999"
+    execute "ALTER SEQUENCE petitions_id_seq START WITH 100000 RESTART WITH 100000 MINVALUE 100000"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -276,7 +276,7 @@ CREATE SEQUENCE archived_petitions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
-    MAXVALUE 99999
+    MAXVALUE 199999
     CACHE 1;
 
 
@@ -891,9 +891,9 @@ CREATE TABLE petitions (
 --
 
 CREATE SEQUENCE petitions_id_seq
-    START WITH 100000
+    START WITH 200000
     INCREMENT BY 1
-    MINVALUE 100000
+    MINVALUE 200000
     NO MAXVALUE
     CACHE 1;
 
@@ -2634,6 +2634,8 @@ INSERT INTO schema_migrations (version) VALUES ('20170712070139');
 INSERT INTO schema_migrations (version) VALUES ('20170713193039');
 
 INSERT INTO schema_migrations (version) VALUES ('20170818110849');
+
+INSERT INTO schema_migrations (version) VALUES ('20170903162156');
 
 INSERT INTO schema_migrations (version) VALUES ('20170903181738');
 


### PR DESCRIPTION
When the site re-opened in July 2015 we restarted the ids from 100,000 so it seems like a good idea to bump them to 200,000 for when we next re-open to make it easy to recognise which parliament the petition came from.