### PR TITLE
Add archived petition admin pages

### DIFF
--- a/app/assets/javascripts/edit_lock.js
+++ b/app/assets/javascripts/edit_lock.js
@@ -1,7 +1,7 @@
 (function ($) {
   'use strict';
 
-  $.fn.editLock = function(id, user_id) {
+  $.fn.editLock = function(id, user_id, path) {
     var $html = this;
     var $message = $html.find('.edit-lock-message');
     var $override = $html.find('#edit-lock-override');
@@ -9,8 +9,9 @@
 
     var ID = id;
     var USER_ID = user_id;
+    var PATH = path;
     var INTERVAL = 10000;
-    var LOCK_URL = '/admin/petitions/' + ID + '/lock.json';
+    var LOCK_URL = PATH + '/' + ID + '/lock.json';
 
     var EditLock = {
       processStatus: function(data) {
@@ -58,7 +59,7 @@
       },
 
       cancelClicked: function(e) {
-        window.location = '/admin/petitions/' + ID;
+        window.location = PATH + '/' + ID;
       }
     };
 

--- a/app/assets/stylesheets/petitions/admin/views/_hub.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_hub.scss
@@ -34,12 +34,6 @@
     }
   }
 
-  .all-petitions-link {
-    float: right;
-    margin-right: $gutter-half;
-    text-decoration: underline;
-  }
-
   .moderation {
     overflow: hidden;
     margin-left: $gutter-half;
@@ -113,4 +107,8 @@
       }
     }
   }
+}
+
+.hub-links {
+  text-align: right;
 }

--- a/app/controllers/admin/archived/debate_outcomes_controller.rb
+++ b/app/controllers/admin/archived/debate_outcomes_controller.rb
@@ -1,0 +1,49 @@
+class Admin::Archived::DebateOutcomesController < Admin::AdminController
+  before_action :fetch_petition
+  before_action :fetch_debate_outcome
+
+  rescue_from ActiveRecord::RecordNotUnique do
+    @debate_outcome = @petition.debate_outcome(true) and update
+  end
+
+  def show
+    render 'admin/archived/petitions/show'
+  end
+
+  def update
+    if @debate_outcome.update(debate_outcome_params)
+      if send_email_to_petitioners?
+        ::Archived::EmailDebateOutcomesJob.run_later_tonight(petition: @petition)
+        message = :email_sent_overnight
+      else
+        message = :debate_outcome_updated
+      end
+
+      redirect_to admin_archived_petition_url(@petition), notice: message
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.debateable.find(params[:petition_id])
+  end
+
+  def fetch_debate_outcome
+    @debate_outcome = @petition.debate_outcome || @petition.build_debate_outcome
+  end
+
+  def debate_outcome_params
+    params.require(:archived_debate_outcome).permit(*debate_outcome_attributes)
+  end
+
+  def debate_outcome_attributes
+    %i[debated_on overview transcript_url video_url debate_pack_url debated commons_image]
+  end
+
+  def send_email_to_petitioners?
+    params.key?(:save_and_email)
+  end
+end

--- a/app/controllers/admin/archived/government_response_controller.rb
+++ b/app/controllers/admin/archived/government_response_controller.rb
@@ -1,0 +1,45 @@
+class Admin::Archived::GovernmentResponseController < Admin::AdminController
+  before_action :fetch_petition
+  before_action :fetch_government_response
+
+  rescue_from ActiveRecord::RecordNotUnique do
+    @government_response = @petition.government_response(true) and update
+  end
+
+  def show
+    render 'admin/archived/petitions/show'
+  end
+
+  def update
+    if @government_response.update(government_response_params)
+      if send_email_to_petitioners?
+        ::Archived::EmailThresholdResponseJob.run_later_tonight(petition: @petition)
+        message = :email_sent_overnight
+      else
+        message = :government_response_updated
+      end
+
+      redirect_to admin_archived_petition_url(@petition), notice: message
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.moderated.find(params[:petition_id])
+  end
+
+  def fetch_government_response
+    @government_response = @petition.government_response || @petition.build_government_response
+  end
+
+  def government_response_params
+    params.require(:archived_government_response).permit(:summary, :details)
+  end
+
+  def send_email_to_petitioners?
+    params.key?(:save_and_email)
+  end
+end

--- a/app/controllers/admin/archived/locks_controller.rb
+++ b/app/controllers/admin/archived/locks_controller.rb
@@ -1,0 +1,45 @@
+class Admin::Archived::LocksController < Admin::AdminController
+  before_action :fetch_petition
+
+  def show
+    @petition.update_lock!(current_user)
+
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  def create
+    @petition.checkout!(current_user)
+
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  def update
+    @petition.force_checkout!(current_user)
+
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  def destroy
+    @petition.release!(current_user)
+
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  def last_request_update_allowed?
+    false
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:petition_id])
+  end
+end

--- a/app/controllers/admin/archived/notes_controller.rb
+++ b/app/controllers/admin/archived/notes_controller.rb
@@ -1,0 +1,34 @@
+class Admin::Archived::NotesController < Admin::AdminController
+  before_action :fetch_petition
+  before_action :fetch_note
+
+  rescue_from ActiveRecord::RecordNotUnique do
+    @note = @petition.note(true) and update
+  end
+
+  def show
+    render 'admin/archived/petitions/show'
+  end
+
+  def update
+    if @note.update(note_params)
+      redirect_to admin_archived_petition_url(@petition)
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  private
+
+  def fetch_note
+    @note = @petition.note || @petition.build_note
+  end
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:petition_id])
+  end
+
+  def note_params
+    params.require(:archived_note).permit(:details)
+  end
+end

--- a/app/controllers/admin/archived/petition_details_controller.rb
+++ b/app/controllers/admin/archived/petition_details_controller.rb
@@ -1,0 +1,28 @@
+class Admin::Archived::PetitionDetailsController < Admin::AdminController
+  before_action :fetch_petition
+
+  def show
+  end
+
+  def update
+    if @petition.update_attributes(petition_params)
+      redirect_to admin_archived_petition_url(@petition), notice: :petition_updated
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:petition_id])
+  end
+
+  def petition_attributes
+    %i[action background additional_details special_consideration]
+  end
+
+  def petition_params
+    params.require(:archived_petition).permit(*petition_attributes)
+  end
+end

--- a/app/controllers/admin/archived/petition_emails_controller.rb
+++ b/app/controllers/admin/archived/petition_emails_controller.rb
@@ -1,0 +1,83 @@
+class Admin::Archived::PetitionEmailsController < Admin::AdminController
+  before_action :fetch_petition
+  before_action :build_email, only: [:new, :create]
+  before_action :fetch_email, only: [:edit, :update, :destroy]
+
+  def new
+    render 'admin/archived/petitions/show'
+  end
+
+  def create
+    if @email.update(email_params)
+      if send_email_to_petitioners?
+        schedule_email_petitioners_job
+        message = :email_sent_overnight
+      else
+        message = :petition_email_created
+      end
+
+      redirect_to admin_archived_petition_url(@petition), notice: message
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @email.update(email_params)
+      if send_email_to_petitioners?
+        schedule_email_petitioners_job
+        message = :email_sent_overnight
+      else
+        message = :petition_email_updated
+      end
+
+      redirect_to admin_archived_petition_url(@petition), notice: message
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  def destroy
+    if @email.destroy
+      message = :petition_email_deleted
+    else
+      message = :petition_email_not_deleted
+    end
+
+    redirect_to admin_archived_petition_url(@petition), notice: message
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.published.find(params[:petition_id])
+  end
+
+  def build_email
+    @email = @petition.emails.build
+  end
+
+  def fetch_email
+    @email = @petition.emails.find(params[:id])
+  end
+
+  def email_params
+    params.require(:archived_petition_email).permit(:subject, :body).merge(sent_by: current_user.pretty_name)
+  end
+
+  def feedback_signature
+    FeedbackSignature.new(@petition)
+  end
+
+  def send_email_to_petitioners?
+    params.key?(:save_and_email)
+  end
+
+  def schedule_email_petitioners_job
+    ::Archived::EmailPetitionersJob.run_later_tonight(petition: @petition, email: @email)
+    ::Archived::PetitionMailer.email_signer(@petition, feedback_signature, @email).deliver_now
+  end
+end

--- a/app/controllers/admin/archived/petition_tags_controller.rb
+++ b/app/controllers/admin/archived/petition_tags_controller.rb
@@ -1,0 +1,25 @@
+class Admin::Archived::PetitionTagsController < Admin::AdminController
+  before_action :fetch_petition
+
+  def show
+    render 'admin/archived/petitions/show'
+  end
+
+  def update
+    if @petition.update(petition_params)
+      redirect_to admin_archived_petition_url(@petition), notice: :petition_updated
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:petition_id])
+  end
+
+  def petition_params
+    params.require(:petition).permit(tags: [])
+  end
+end

--- a/app/controllers/admin/archived/petitions_controller.rb
+++ b/app/controllers/admin/archived/petitions_controller.rb
@@ -1,0 +1,89 @@
+class Admin::Archived::PetitionsController < Admin::AdminController
+  before_action :redirect_to_show_page, only: [:index], if: :petition_id?
+  before_action :fetch_parliament, only: [:index]
+  before_action :fetch_petitions, only: [:index]
+  before_action :fetch_petition, only: [:show]
+
+  rescue_from ActiveRecord::RecordNotFound do
+    redirect_to admin_root_url, alert: "Sorry, we couldn't find petition #{params[:id]}"
+  end
+
+  def index
+    respond_to do |format|
+      format.html
+      format.csv { render_csv }
+    end
+  end
+
+  def show
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  protected
+
+  def petition_id?
+    /^\d+$/ =~ params[:q].to_s
+  end
+
+  def redirect_to_show_page
+    redirect_to admin_archived_petition_url(params[:q].to_i)
+  end
+
+  def scope
+    if params[:tags].present?
+      if params[:match] == "all"
+        @parliament.petitions.tagged_with_all(params[:tags])
+      else
+        @parliament.petitions.tagged_with_any(params[:tags])
+      end
+    else
+      @parliament.petitions.all
+    end
+  end
+
+  def parliament_id
+    params[:parliament].to_i
+  end
+
+  def fetch_parliament
+    if params.key?(:parliament)
+      @parliament = Parliament.archived.find(parliament_id)
+    else
+      @parliament = Parliament.archived.first
+    end
+  end
+
+  def fetch_petitions
+    @petitions = scope.search(params)
+  end
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:id])
+  end
+
+  def render_csv
+    set_file_headers
+    set_streaming_headers
+
+    #setting the body to an enumerator, rails will iterate this enumerator
+    self.response_body = PetitionsCSVPresenter.new(@petitions).render
+  end
+
+  def set_file_headers
+    headers["Content-Type"] = "text/csv"
+    headers["Content-Disposition"] = "attachment; filename=#{csv_filename}"
+  end
+
+  def set_streaming_headers
+    #nginx doc: Setting this to "no" will allow unbuffered responses suitable for Comet and HTTP streaming applications
+    headers['X-Accel-Buffering'] = 'no'
+    headers["Cache-Control"] ||= "no-cache"
+    headers.delete("Content-Length")
+  end
+
+  def csv_filename
+    "#{@petitions.scope.to_s.dasherize}-petitions-#{Time.current.to_s(:number)}.csv"
+  end
+end

--- a/app/controllers/admin/archived/schedule_debate_controller.rb
+++ b/app/controllers/admin/archived/schedule_debate_controller.rb
@@ -1,0 +1,36 @@
+class Admin::Archived::ScheduleDebateController < Admin::AdminController
+  before_action :fetch_petition
+
+  def show
+    render 'admin/archived/petitions/show'
+  end
+
+  def update
+    if @petition.update_attributes(params_for_update)
+      if send_email_to_petitioners?
+        ::Archived::EmailDebateScheduledJob.run_later_tonight(petition: @petition)
+        message = :email_sent_overnight
+      else
+        message = :debate_date_updated
+      end
+
+      redirect_to admin_archived_petition_url(@petition), notice: message
+    else
+      render 'admin/archived/petitions/show'
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:petition_id])
+  end
+
+  def params_for_update
+    params.require(:archived_petition).permit(:scheduled_debate_date)
+  end
+
+  def send_email_to_petitioners?
+    params.key?(:save_and_email)
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -24,12 +24,24 @@ module AdminHelper
     options_for_select(options, selected)
   end
 
+  def admin_archived_petition_facets_for_select(facets, selected)
+    options = admin_archived_petition_facets.map do |facet|
+      [I18n.t(facet,  scope: :"petitions.facets.names.admin_archived", quantity: facets[facet]), facet]
+    end
+
+    options_for_select(options, selected)
+  end
+
   def admin_invalidation_facets_for_select(facets, selected)
     options = admin_invalidation_facets.map do |facet|
       [I18n.t(facet,  scope: :"admin.invalidations.facets.labels", quantity: facets[facet]), facet]
     end
 
     options_for_select(options, selected)
+  end
+
+  def admin_parliaments_for_select(selected)
+    options_from_collection_for_select(archived_parliaments, :id, :name, selected)
   end
 
   def email_petitioners_with_count_submit_button(form, petition, options = {})
@@ -66,6 +78,10 @@ module AdminHelper
 
   def admin_petition_facets
     I18n.t(:admin, scope: :"petitions.facets")
+  end
+
+  def admin_archived_petition_facets
+    I18n.t(:admin_archived, scope: :"petitions.facets")
   end
 
   def admin_invalidation_facets

--- a/app/helpers/admin_hub_helper.rb
+++ b/app/helpers/admin_hub_helper.rb
@@ -3,6 +3,10 @@ module AdminHubHelper
     @petition_total_count ||= Petition.all.count
   end
 
+  def archived_petition_total_count
+    @archived_petition_total_count ||= Archived::Petition.all.count
+  end
+
   def in_moderation_count
     @in_moderation_count ||= Petition.in_moderation.count
   end

--- a/app/models/archived/government_response.rb
+++ b/app/models/archived/government_response.rb
@@ -5,7 +5,7 @@ module Archived
     belongs_to :petition, touch: true
 
     validates :petition, presence: true
-    validates :summary, length: { maximum: 200 }, allow_blank: true
+    validates :summary, presence: true, length: { maximum: 500 }
     validates :details, length: { maximum: 10000 }, allow_blank: true
 
     after_create do

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -10,8 +10,11 @@ module Archived
     STATES = [STOPPED_STATE, CLOSED_STATE, HIDDEN_STATE, REJECTED_STATE]
     PUBLISHED_STATES = [CLOSED_STATE]
     VISIBLE_STATES = [CLOSED_STATE, REJECTED_STATE]
+    MODERATED_STATES = [CLOSED_STATE, HIDDEN_STATE, REJECTED_STATE]
+    DEBATABLE_STATES = [CLOSED_STATE]
 
     belongs_to :parliament, inverse_of: :petitions, required: true
+    belongs_to :locked_by, class_name: 'AdminUser'
 
     has_one :creator, -> { where(creator: true) }, class_name: "Signature"
     has_one :debate_outcome, dependent: :destroy
@@ -37,19 +40,35 @@ module Archived
     filter :parliament
 
     facet :all, -> { visible.by_most_signatures }
-    facet :published, -> { for_state(PUBLISHED_STATES).by_most_signatures }
-    facet :stopped, -> { for_state(STOPPED_STATE).by_most_signatures }
-    facet :closed, -> { for_state(CLOSED_STATE).by_most_signatures }
-    facet :rejected, -> { for_state(REJECTED_STATE).by_most_signatures }
+    facet :awaiting_response, -> { awaiting_response.by_waiting_for_response_longest }
+    facet :awaiting_debate_date, -> { awaiting_debate_date.by_waiting_for_debate_longest }
+    facet :with_debate_outcome, -> { with_debate_outcome.by_most_recent_debate_outcome }
+    facet :with_debated_outcome, -> { with_debated_outcome.by_most_recent_debate_outcome }
+    facet :published, -> { published.by_most_signatures }
+    facet :stopped, -> { stopped.by_most_signatures }
+    facet :closed, -> { closed.by_most_signatures }
+    facet :rejected, -> { rejected.by_most_signatures }
+    facet :hidden, -> { hidden.by_most_recent }
     facet :with_response, -> { with_response.by_most_signatures }
     facet :debated, -> { debated.by_most_recent_debate_outcome }
     facet :not_debated, -> { not_debated.by_most_recent_debate_outcome }
     facet :by_most_signatures, -> { by_most_signatures }
     facet :by_created_at, -> { by_created_at }
+    facet :in_debate_queue, -> { in_debate_queue.by_waiting_for_debate_longest }
 
     default_scope { preload(:parliament) }
 
     delegate :threshold_for_response, :threshold_for_debate, to: :parliament
+
+    with_options allow_nil: true, prefix: true do
+      delegate :name, :email, to: :creator
+      delegate :code, :details, to: :rejection
+      delegate :summary, :details, :created_at, :updated_at, to: :government_response
+      delegate :date, :transcript_url, :video_url, :overview, to: :debate_outcome, prefix: :debate
+      delegate :debate_pack_url, to: :debate_outcome, prefix: false
+    end
+
+    alias_attribute :open_at, :opened_at
 
     class << self
       def for_state(state)
@@ -64,12 +83,68 @@ module Archived
         reorder(debate_outcome_at: :desc, created_at: :desc)
       end
 
+      def by_waiting_for_debate_longest
+        reorder(debate_threshold_reached_at: :asc, created_at: :desc)
+      end
+
+      def by_most_recent
+        reorder(created_at: :desc)
+      end
+
       def by_most_signatures
         reorder(signature_count: :desc)
       end
 
+      def by_waiting_for_response_longest
+        reorder(response_threshold_reached_at: :asc, created_at: :desc)
+      end
+
+      def awaiting_debate_date
+        debate_threshold_reached.not_scheduled
+      end
+
+      def awaiting_response
+        response_threshold_reached.not_responded
+      end
+
+      def not_responded
+        where(government_response_at: nil)
+      end
+
       def with_response
         where.not(government_response_at: nil)
+      end
+
+      def response_threshold_reached
+        where.not(response_threshold_reached_at: nil)
+      end
+
+      def published
+        where(state: PUBLISHED_STATES)
+      end
+
+      def moderated
+        where(state: MODERATED_STATES)
+      end
+
+      def stopped
+        where(state: STOPPED_STATE)
+      end
+
+      def closed
+        where(state: CLOSED_STATE)
+      end
+
+      def rejected
+        where(state: REJECTED_STATE)
+      end
+
+      def hidden
+        where(state: HIDDEN_STATE)
+      end
+
+      def debateable
+        where(state: DEBATABLE_STATES)
       end
 
       def debated
@@ -80,8 +155,24 @@ module Archived
         where(debate_state: 'not_debated')
       end
 
+      def debate_threshold_reached
+        where.not(debate_threshold_reached_at: nil)
+      end
+
       def debate_scheduled
         where.not(scheduled_debate_date: nil)
+      end
+
+      def not_scheduled
+        where(scheduled_debate_date: nil)
+      end
+
+      def with_debate_outcome
+        where.not(debate_outcome_at: nil)
+      end
+
+      def with_debated_outcome
+        debated.where.not(debate_outcome_at: nil)
       end
 
       def visible
@@ -96,6 +187,10 @@ module Archived
         in_need_of_marking_as_debated(date).update_all(debate_state: 'debated')
       end
 
+      def in_debate_queue
+        where(threshold_for_debate_reached.or(scheduled_for_debate))
+      end
+
       private
 
       def debate_date_in_the_past(date)
@@ -105,6 +200,22 @@ module Archived
       def scheduled_debate_state
         arel_table[:debate_state].eq('scheduled')
       end
+
+      def threshold_for_debate_reached
+        arel_table[:debate_threshold_reached_at].not_eq(nil)
+      end
+
+      def scheduled_for_debate
+        arel_table[:scheduled_debate_date].not_eq(nil)
+      end
+    end
+
+    def moderated?
+      state.in?(MODERATED_STATES)
+    end
+
+    def can_have_debate_added?
+      state.in?(DEBATABLE_STATES)
     end
 
     def stopped?
@@ -192,6 +303,37 @@ module Archived
     def update_debate_state
       self.debate_state = evaluate_debate_state
     end
+
+    def update_lock!(user, now = Time.current)
+      if locked_by == user
+        update!(locked_at: now)
+      end
+    end
+
+    def checkout!(user, now = Time.current)
+      with_lock do
+        if locked_by.present? && locked_by != user
+          raise RuntimeError, "Petition already being edited by #{locked_by.pretty_name}"
+        else
+          update!(locked_by: user, locked_at: now)
+        end
+      end
+    end
+
+    def force_checkout!(user, now = Time.current)
+      update!(locked_by: user, locked_at: now)
+    end
+
+    def release!(user)
+      with_lock do
+        if locked_by.present? && locked_by != user
+          raise RuntimeError, "Petition already being edited by #{locked_by.pretty_name}"
+        else
+          update!(locked_by: nil, locked_at: nil)
+        end
+      end
+    end
+
 
     private
 

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -100,6 +100,10 @@ class Parliament < ActiveRecord::Base
 
   after_save { Site.touch }
 
+  def name
+    "#{period} #{government} government"
+  end
+
   def opened?(now = Time.current)
     opening_at? && opening_at <= now
   end

--- a/app/views/admin/admin/_edit_lock.html.erb
+++ b/app/views/admin/admin/_edit_lock.html.erb
@@ -12,6 +12,10 @@
 
 <script>
   $(document).ready(function() {
-    $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>);
+    <% if @petition.is_a?(::Archived::Petition) %>
+      $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/archived/petitions');
+    <% else %>
+      $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/petitions');
+    <% end %>
   });
 </script>

--- a/app/views/admin/admin/_petition_action_debate_date.html.erb
+++ b/app/views/admin/admin/_petition_action_debate_date.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Scheduled debate date', admin_petition_schedule_debate_path(@petition), class: 'petition-action-heading' %>
+<% if @petition.is_a?(::Archived::Petition) %>
+  <%= link_to 'Scheduled debate date', admin_archived_petition_schedule_debate_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Scheduled debate date', admin_petition_schedule_debate_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/admin/_petition_action_debate_outcome.html.erb
+++ b/app/views/admin/admin/_petition_action_debate_outcome.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Debate outcome', admin_petition_debate_outcome_path(@petition), class: 'petition-action-heading' %>
+<% if @petition.is_a?(::Archived::Petition) %>
+  <%= link_to 'Debate outcome', admin_archived_petition_debate_outcome_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Debate outcome', admin_petition_debate_outcome_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/admin/_petition_action_email_petitioners.html.erb
+++ b/app/views/admin/admin/_petition_action_email_petitioners.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Other parliamentary business', new_admin_petition_email_path(@petition), class: 'petition-action-heading' %>
+<% if @petition.is_a?(::Archived::Petition) %>
+  <%= link_to 'Other parliamentary business', new_admin_archived_petition_email_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Other parliamentary business', new_admin_petition_email_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/admin/_petition_action_government_response.html.erb
+++ b/app/views/admin/admin/_petition_action_government_response.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Government response', admin_petition_government_response_path(@petition), class: 'petition-action-heading' %>
+<% if @petition.is_a?(::Archived::Petition) %>
+  <%= link_to 'Government response', admin_archived_petition_government_response_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Government response', admin_petition_government_response_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/admin/_petition_action_notes.html.erb
+++ b/app/views/admin/admin/_petition_action_notes.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Notes', admin_petition_notes_path(@petition), class: 'petition-action-heading' %>
+<% if @petition.is_a?(::Archived::Petition) %>
+  <%= link_to 'Notes', admin_archived_petition_notes_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Notes', admin_petition_notes_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/admin/_petition_action_tags.html.erb
+++ b/app/views/admin/admin/_petition_action_tags.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Tags', admin_petition_tags_path(@petition), class: 'petition-action-heading' %>
+<% if @petition.is_a?(::Archived::Petition) %>
+  <%= link_to 'Tags', admin_archived_petition_tags_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Tags', admin_petition_tags_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -106,7 +106,11 @@
         <% end %>
       </ul>
 
-      <%= link_to "All Petitions (#{petition_total_count})", admin_petitions_url(state: :all), class: 'all-petitions-link' %>
+    </div>
+
+    <div class="hub-links">
+      <%= link_to "All Petitions (#{petition_total_count})", admin_petitions_url(state: :all) %> |
+      <%= link_to "Archived Petitions (#{archived_petition_total_count})", admin_archived_root_url %>
     </div>
   </div>
 

--- a/app/views/admin/archived/debate_outcomes/_petition_action_debate_outcome.html.erb
+++ b/app/views/admin/archived/debate_outcomes/_petition_action_debate_outcome.html.erb
@@ -1,0 +1,85 @@
+<h2 class="petition-action-heading">Debate Outcome</h2>
+<%= form_for petition.debate_outcome, url: admin_archived_petition_debate_outcome_path(petition), method: :patch do |f| -%>
+  <%= form_row for: [f.object, :overview] do %>
+    <%= f.label :overview, class: 'form-label' %>
+    <%= error_messages_for_field f.object, :overview %>
+    <%= f.text_area :overview, tabindex: increment, class: 'form-control' %>
+  <% end %>
+
+  <h3 class="petition-action-subheading">Was this petition debated?</h3>
+
+  <%= form_row class: 'inline' do %>
+    <%= f.label :debated_true, nil, class: 'block-label' do %>
+      <%= f.radio_button :debated, true %> Yes
+    <% end %>
+    <%= f.label :debated_false, nil, class: 'block-label' do %>
+      <%= f.radio_button :debated, false %> No
+    <% end %>
+    <%= error_messages_for_field petition, :debated %>
+  <% end %>
+
+  <div class="debate-outcome-controls" style="overflow: hidden; clear: left;">
+    <%= form_row :for => [f.object, :debated_on] do %>
+      <%= f.label :debated_on, class: 'form-label' %>
+      <%= error_messages_for_field f.object, :debated_on %>
+      <%= f.date_field :debated_on, tabindex: increment, class: 'form-control' %>
+    <% end %>
+
+    <%= form_row for: [f.object, :transcript_url] do %>
+      <%= f.label :transcript_url, 'Transcript URL', class: 'form-label' %>
+      <%= error_messages_for_field f.object, :transcript_url %>
+      <%= f.url_field :transcript_url, tabindex: increment, class: 'form-control' %>
+    <% end %>
+
+    <%= form_row for: [f.object, :video_url] do %>
+      <%= f.label :video_url, 'Video URL', class: 'form-label' %>
+      <%= error_messages_for_field f.object, :video_url %>
+      <%= f.url_field :video_url, tabindex: increment, class: 'form-control' %>
+    <% end %>
+
+    <%= form_row for: [f.object, :debate_pack_url] do %>
+      <%= f.label :debate_pack_url, 'Debate Pack URL', class: 'form-label' %>
+      <%= error_messages_for_field f.object, :debate_pack_url %>
+      <%= f.url_field :debate_pack_url, tabindex: increment, class: 'form-control' %>
+    <% end %>
+
+    <%= form_row for: [f.object, :commons_image] do %>
+      <%= f.label :commons_image, 'Commons Image', class: 'form-label' %>
+      <%= error_messages_for_field f.object, :commons_image %>
+      <%= f.file_field :commons_image, tabindex: increment, class: 'form-control' %>
+    <% end %>
+  </div>
+
+  <%= email_petitioners_with_count_submit_button(f, petition) %>
+  <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+
+<% end -%>
+
+<%= javascript_tag do %>
+  $().ready(function() {
+    var $debate_outcome_controls = $('.debate-outcome-controls'),
+        $debated_true_control = $('#debate_outcome_debated_true'),
+        $debated_false_control = $('#debate_outcome_debated_false'),
+        $all_controls = $('input[name="debate_outcome[debated]"][type=radio]');
+
+    // Hide if the false control is already checked
+    if ($debated_false_control.is(':checked')) {
+      $debate_outcome_controls.hide();
+    }
+
+    // Ensure that we get the onchange event when the users uses the keyboard
+    // Details: http://bit.ly/iZx9nh
+    $all_controls.keyup(function() {
+      this.blur();
+      this.focus();
+    }).change(function() {
+      if ($debated_true_control.is(':checked')) {
+        $debate_outcome_controls.slideDown();
+      } else {
+        $debate_outcome_controls.slideUp();
+      }
+    });
+  });
+<% end -%>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/government_response/_petition_action_government_response.html.erb
+++ b/app/views/admin/archived/government_response/_petition_action_government_response.html.erb
@@ -1,0 +1,23 @@
+<h2 class="petition-action-heading">Government response</h2>
+<%= form_for @government_response, :url => admin_archived_petition_government_response_path(petition), method: :put do |f| -%>
+  <%= form_row :for => [f.object, :summary] do %>
+    <%= f.label :summary, 'Summary quote', class: 'form-label' %>
+    <%= error_messages_for_field f.object, :summary %>
+    <%= f.text_area :summary, rows: 3, cols: 70, tabindex: increment, data: { max_length: 200 }, class: 'form-control' %>
+    <p class="character-count">200 characters max</p>
+  <% end %>
+
+  <%= form_row :for => [f.object, :details] do %>
+    <%= f.label :details, 'Response in full', class: 'form-label' %>
+    <%= error_messages_for_field f.object, :details %>
+    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, class: 'form-control' %>
+  <% end %>
+
+  <%= email_petitioners_with_count_submit_button(f, petition) %>
+  <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+
+<% end -%>
+
+<%= javascript_include_tag 'character-counter' %>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/locks/_lock.json.jbuilder
+++ b/app/views/admin/archived/locks/_lock.json.jbuilder
@@ -1,0 +1,10 @@
+if user = @petition.locked_by
+  json.locked true
+  json.locked_at @petition.locked_at
+  json.locked_by do
+    json.id user.id
+    json.name user.pretty_name
+  end
+else
+  json.locked false
+end

--- a/app/views/admin/archived/locks/create.json.jbuilder
+++ b/app/views/admin/archived/locks/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'lock'

--- a/app/views/admin/archived/locks/destroy.json.jbuilder
+++ b/app/views/admin/archived/locks/destroy.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'lock'

--- a/app/views/admin/archived/locks/show.json.jbuilder
+++ b/app/views/admin/archived/locks/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'lock'

--- a/app/views/admin/archived/locks/update.json.jbuilder
+++ b/app/views/admin/archived/locks/update.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'lock'

--- a/app/views/admin/archived/notes/_petition_action_notes.html.erb
+++ b/app/views/admin/archived/notes/_petition_action_notes.html.erb
@@ -1,0 +1,14 @@
+<%= form_for @note, url: admin_archived_petition_notes_path(petition), method: :patch do |f| -%>
+
+  <%= form_row :for => [f.object, :admin_notes] do %>
+    <%= f.label :details, 'Notes', class: 'form-label petition-action-heading' %>
+    <%= error_messages_for_field f.object, :admin_notes %>
+    <%= f.text_area :details, tabindex: increment, rows: 10, class: 'form-control' %>
+  <% end %>
+
+  <%= f.submit 'Save notes', class: 'button' %>
+  <%= link_to 'Cancel', admin_archived_petition_path(@petition), class: 'button-secondary' %>
+
+<% end -%>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/petition_details/show.html.erb
+++ b/app/views/admin/archived/petition_details/show.html.erb
@@ -1,0 +1,48 @@
+<!-- Back to X list -->
+
+<div class="grid-row">
+
+  <div class="column-two-thirds extra-gutter">
+    <h2 class="petition-action-heading">Edit petition</h2>
+
+    <%= form_for @petition, url: admin_archived_petition_details_path(@petition), method: :patch do |f| %>
+
+      <%= form_row for: [f.object, :action] do %>
+        <%= f.label :action, class: 'form-label' %>
+        <%= error_messages_for_field @petition, :action %>
+        <%= f.text_area :action, tabindex: increment, rows: 3, maxlength: 80, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [f.object, :background] do %>
+        <%= f.label :background, class: 'form-label' %>
+        <%= error_messages_for_field @petition, :background %>
+        <%= f.text_area :background, tabindex: increment, rows: 5, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [f.object, :additional_details] do %>
+        <%= f.label :additional_details, class: 'form-label' %>
+        <%= error_messages_for_field @petition, :additional_details %>
+        <%= f.text_area :additional_details, tabindex: increment, rows: 7, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [f.object, :special_consideration] do %>
+        <%= f.label :special_consideration do %>
+          <%= f.check_box :special_consideration, tabindex: increment %> Special consideration when dealing with this petition
+        <% end %>
+        <%= error_messages_for_field @petition, :special_consideration %>
+      <% end %>
+
+      <%= f.submit 'Save', class: 'button' %>
+
+      <%= link_to 'Cancel', admin_archived_petition_path(@petition), class: 'button-secondary' %>
+
+    <% end %>
+  </div>
+
+  <div class="petition-meta column-third">
+    <%= render 'admin/archived/petitions/petition_details' %>
+  </div>
+
+</div>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/petition_emails/_petition_action_email_petitioners.html.erb
+++ b/app/views/admin/archived/petition_emails/_petition_action_email_petitioners.html.erb
@@ -1,0 +1,47 @@
+<h2 class="petition-action-heading">Other parliamentary business</h2>
+
+<% if petition.emails.any?(&:persisted?) %>
+  <table class="petition-list petition-emails">
+    <thead>
+      <tr>
+        <th>Subject</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% petition.emails.select(&:persisted?).each do |email| %>
+        <tr>
+          <td><%= email.subject %></td>
+          <td>
+            <%= button_to 'Edit', edit_admin_archived_petition_email_path(petition, email), method: :get, class: 'button' %>
+            <%= button_to 'Delete', admin_archived_petition_email_path(petition, email), method: :delete, class: 'button-warning', data: { confirm: 'Delete other parliamentary business?' } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= form_for @email, url: admin_archived_petition_emails_path(petition), method: :post do |f| -%>
+  <%= form_row :for => [f.object, :subject] do %>
+    <%= f.label :subject, 'Subject', class: 'form-label' %>
+    <%= error_messages_for_field f.object, :subject %>
+    <%= f.text_area :subject, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: 'form-control' %>
+    <p class="character-count">100 characters max</p>
+  <% end %>
+
+  <%= form_row :for => [f.object, :body] do %>
+    <%= f.label :body, 'Body', class: 'form-label' %>
+    <%= error_messages_for_field f.object, :body %>
+    <%= f.text_area :body, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: 'form-control' %>
+    <p class="character-count">5000 characters max</p>
+  <% end %>
+
+  <%= email_petitioners_with_count_submit_button(f, petition) %>
+  <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+
+<% end -%>
+
+<%= javascript_include_tag 'character-counter' %>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/petition_emails/edit.html.erb
+++ b/app/views/admin/archived/petition_emails/edit.html.erb
@@ -1,0 +1,32 @@
+<div class="grid-row">
+  <div class="column-two-thirds extra-gutter">
+    <h1>Edit other parliamentary business</h1>
+
+    <%= form_for @email, url: admin_archived_petition_email_path(@petition, @email), method: :patch do |f| -%>
+      <%= form_row :for => [f.object, :subject] do %>
+        <%= f.label :subject, 'Subject', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :subject %>
+        <%= f.text_area :subject, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: 'form-control' %>
+        <p class="character-count">100 characters max</p>
+      <% end %>
+
+      <%= form_row :for => [f.object, :body] do %>
+        <%= f.label :body, 'Body', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :body %>
+        <%= f.text_area :body, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: 'form-control' %>
+        <p class="character-count">5000 characters max</p>
+      <% end %>
+
+      <%= email_petitioners_with_count_submit_button(f, @petition) %>
+      <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+
+    <% end -%>
+  </div>
+  <div class="petition-meta column-third">
+    <%= render 'admin/archived/petitions/petition_details' %>
+  </div>
+</div>
+
+<%= javascript_include_tag 'character-counter' %>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/petition_tags/_petition_action_tags.html.erb
+++ b/app/views/admin/archived/petition_tags/_petition_action_tags.html.erb
@@ -1,0 +1,25 @@
+<h2 class="petition-action-heading">Tags</h2>
+<%= form_for petition, url: admin_archived_petition_tags_path(petition), method: :patch do |f| %>
+  <%= form_row for: [f.object, :tags], class: 'inline tag-list' do %>
+    <%= error_messages_for_field f.object, :tags %>
+    <% if Tag.any? %>
+      <%= collection_check_boxes(:petition, :tags, Tag.by_name, :id, :name) do |b| %>
+        <%= b.label class: 'block-label' do %>
+          <%= b.check_box %> <%= content_tag :span, b.text, title: b.object.description %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= hidden_field_tag "petition[tags][]", "" %>
+      <p>
+        No tags have been defined
+        <% if current_user.is_a_sysadmin? %>
+          — <%= link_to 'create some tags', admin_tags_path %>
+        <% end %>
+      </p>
+    <% end %>
+  <% end %>
+  <%= f.submit 'Save tags', class: 'button' %>
+  <%= link_to 'Cancel', admin_archived_petition_path(petition), class: 'button-secondary' %>
+<% end %>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/archived/petitions/_petition_actions.html.erb
+++ b/app/views/admin/archived/petitions/_petition_actions.html.erb
@@ -1,0 +1,33 @@
+<nav class="petition-actions" role="navigation">
+  <ul>
+    <li class="petition-action">
+      <%= render 'petition_action_tags', petition: @petition %>
+    </li>
+
+    <li class="petition-action">
+      <%= render 'petition_action_notes', petition: @petition %>
+    </li>
+
+    <% if @petition.moderated? %>
+      <li class="petition-action">
+        <%= render 'petition_action_government_response', petition: @petition %>
+      </li>
+    <% end %>
+
+    <% if @petition.can_have_debate_added? %>
+      <li class="petition-action">
+        <%= render 'petition_action_debate_date', petition: @petition %>
+      </li>
+
+      <li class="petition-action">
+        <%= render 'petition_action_debate_outcome', petition: @petition %>
+      </li>
+    <% end %>
+
+    <% if @petition.moderated? %>
+      <li class="petition-action">
+        <%= render 'petition_action_email_petitioners', petition: @petition %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/admin/archived/petitions/_petition_content.html.erb
+++ b/app/views/admin/archived/petitions/_petition_content.html.erb
@@ -1,0 +1,20 @@
+<h1><%= @petition.action %></h1>
+
+<%= auto_link(simple_format(h(@petition.background)), html: { rel: 'nofollow' }) %>
+
+<% unless @petition.additional_details.blank? %>
+  <details>
+    <summary><span>More details</span></summary>
+    <div><%= auto_link(simple_format(h(@petition.additional_details)), html: { rel: 'nofollow' }) %></div>
+  </details>
+<% end %>
+
+<p class="edit-petition-link">
+  <%= link_to 'Edit petition', admin_archived_petition_details_path(@petition) %>
+</p>
+
+<% if @petition.rejected? or @petition.hidden? -%>
+  <h2>This petition was rejected</h2>
+  <p><%= rejection_reason(@petition.rejection.code) %></p>
+  <%= auto_link(simple_format(@petition.rejection.details)) %>
+<% end -%>

--- a/app/views/admin/archived/petitions/_petition_details.html.erb
+++ b/app/views/admin/archived/petitions/_petition_details.html.erb
@@ -1,0 +1,35 @@
+<dl>
+  <dt>Status</dt>
+  <dd class="petition-meta-state"><%= @petition.state.capitalize %></dd>
+
+  <dt>Signatures</dt>
+  <dd class="petition-meta-signature-count"><%= number_with_delimiter(@petition.signature_count) %> </dd>
+
+  <% if @petition.creator %>
+    <dt>Creator</dt>
+    <dd>
+      <%=  @petition.creator.name %><br />
+      <%= auto_link(@petition.creator.email) %>
+    </dd>
+  <% end %>
+
+
+  <% if @petition.closed? %>
+    <dt>Closed</dt>
+    <dd><%= date_format_admin(@petition.closed_at) %></dd>
+  <% elsif @petition.rejected? || @petition.hidden? %>
+    <dt>Rejected</dt>
+    <dd><%= date_format_admin(@petition.rejected_at) %></dd>
+  <% end %>
+
+  <dt>Link to petition</dt>
+  <dd><%= link_to archived_petition_path(@petition), archived_petition_url(@petition), target: "_blank" %></dd>
+
+  <dt>ID</dt>
+  <dd><%= @petition.id %></dd>
+
+  <% if @petition.tags? %>
+    <dt>Tags</dt>
+    <dd><%= @petition.tag_names.join(", ") %></dd>
+  <% end %>
+</dl>

--- a/app/views/admin/archived/petitions/index.html.erb
+++ b/app/views/admin/archived/petitions/index.html.erb
@@ -1,0 +1,78 @@
+<h1>Archived Petitions</h1>
+
+<%= form_tag admin_archived_petitions_path, enforce_utf8: false, method: :get, class: "search-inline search-petitions" do %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= label_tag :parliament, "Filter by parliament", class: "visuallyhidden" %>
+      <%= select_tag :parliament, admin_parliaments_for_select(params[:parliament]), class: "form-control", data: { autosubmit: true } %>
+    </div>
+    <div class="column-two-thirds">
+      <%= label_tag :state, "Filter by status", class: "visuallyhidden" %>
+      <%= select_tag :state, admin_archived_petition_facets_for_select(@petitions.facets, params[:state]), class: "form-control", data: { autosubmit: true } %>
+    </div>
+    <div class="column-two-thirds">
+      <%= label_tag :q, "Search petitions", class: "visuallyhidden" %>
+      <%= search_field_tag :q, params[:q], class: "form-control", placeholder:"Enter a search query" %>
+      <%= submit_tag 'Search', name: nil, class: 'inline-submit' %>
+    </div>
+    <div class="column-third actions-right">
+      <%= link_to "Download CSV", url_for(params.merge(format: 'csv')) %>
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= content_tag(:details, class: "tag-selector", open: selected_tags.present?) do %>
+        <summary><span>Tags</span></summary>
+        <p>
+          <small>
+            Match <label><%= radio_button_tag :match, "any", params[:match] != "all" %> any selected tags</label>
+            or <label><%= radio_button_tag :match, "all", params[:match] == "all" %> all selected tags</label>
+          </small>
+        </p>
+        <div class="inline tag-list">
+          <% Tag.by_name.each do |tag| %>
+            <%= label_tag nil, title: tag.description, class: "block-label" do %>
+              <%= check_box_tag :"tags[]", tag.id, selected_tags.include?(tag.id) %> <%= tag.name %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<%= will_paginate(@petitions) %>
+
+<table class="petition-list">
+  <thead>
+    <tr>
+      <th class="petition-list-petition-action">Action</th>
+      <th class="petition-list-petition-creator">Creator</th>
+      <th class="petition-list-petition-id">Id</th>
+      <th>State</th>
+      <th class="date">Closed At</th>
+      <th class="numeric last">Signatures</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @petitions.each do |petition| -%>
+      <tr class="petition-list-petition petition-list-petition-state-<%= petition.state.dasherize %>">
+        <td class="petition-list-petition-action"><%= link_to petition.action, admin_archived_petition_path(petition) %></td>
+        <td class="petition-list-petition-creator">
+          <% if petition.creator.present? %>
+            <%= mail_to petition.creator.email, petition.creator.name %>
+          <% else %>
+            –
+          <% end %>
+        </td>
+        <td class="petition-list-petition-id"><%= petition.id %></td>
+        <td><%= petition.state.humanize %></td>
+        <td class="date"><%= date_format(petition.closed_at) %></td>
+        <td class="numeric last"><%= number_with_delimiter(petition.signature_count) %></td>
+      </tr>
+    <% end -%>
+  </tbody>
+</table>
+
+<%= will_paginate(@petitions) %>

--- a/app/views/admin/archived/petitions/show.html.erb
+++ b/app/views/admin/archived/petitions/show.html.erb
@@ -1,0 +1,12 @@
+<div class="grid-row">
+
+  <div class="column-two-thirds extra-gutter">
+    <%= render 'admin/archived/petitions/petition_content' %>
+    <%= render 'admin/archived/petitions/petition_actions' %>
+  </div>
+
+  <div class="petition-meta column-third">
+    <%= render 'admin/archived/petitions/petition_details' %>
+  </div>
+
+</div>

--- a/app/views/admin/archived/schedule_debate/_petition_action_debate_date.html.erb
+++ b/app/views/admin/archived/schedule_debate/_petition_action_debate_date.html.erb
@@ -1,0 +1,14 @@
+<%= form_for petition, url: admin_archived_petition_schedule_debate_path(petition), method: :patch do |f| %>
+
+  <%= form_row :for => [f.object, :scheduled_debate_date] do %>
+    <%= f.label :scheduled_debate_date, class: 'form-label petition-action-heading' %>
+    <%= error_messages_for_field f.object, :debated_on %>
+    <%= f.date_field :scheduled_debate_date, tabindex: increment, class: 'form-control' %>
+  <% end %>
+
+  <%= email_petitioners_with_count_submit_button(f, petition) %>
+  <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+
+<% end %>
+
+<%= render 'edit_lock' %>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -22,7 +22,7 @@
   <dd><%= date_format_admin(@petition.deadline) %></dd>
 
   <dt>Link to petition</dt>
-  <dd><%= link_to nil, petition_url(@petition), target: "_blank" %></dd>
+  <dd><%= link_to petition_path(@petition), petition_url(@petition), target: "_blank" %></dd>
 
   <dt>ID</dt>
   <dd><%= @petition.id %></dd>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -84,6 +84,17 @@ en-GB:
         - :awaiting_debate_date
         - :with_debate_outcome
         - :in_debate_queue
+      admin_archived:
+        - :all
+        - :published
+        - :rejected
+        - :hidden
+        - :stopped
+        - :awaiting_response
+        - :with_response
+        - :awaiting_debate_date
+        - :with_debate_outcome
+        - :in_debate_queue
       names:
         admin:
           all: "All petitions (%{quantity})"
@@ -95,6 +106,17 @@ en-GB:
           tagged_in_moderation: "Awaiting moderation - tagged (%{quantity})"
           open: "Open (%{quantity})"
           closed: "Closed (%{quantity})"
+          rejected: "Rejected (%{quantity})"
+          hidden: "Hidden (%{quantity})"
+          stopped: "Stopped (%{quantity})"
+          awaiting_response: "Awaiting a government response (%{quantity})"
+          with_response: "With a government response (%{quantity})"
+          awaiting_debate_date: "Awaiting a debate in parliament (%{quantity})"
+          with_debate_outcome: "Has been debated in parliament (%{quantity})"
+          in_debate_queue: "In debate queue (%{quantity})"
+        admin_archived:
+          all: "All petitions (%{quantity})"
+          published: "Published (%{quantity})"
           rejected: "Rejected (%{quantity})"
           hidden: "Hidden (%{quantity})"
           stopped: "Stopped (%{quantity})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,24 @@ Rails.application.routes.draw do
 
       resources :tags, except: %i[show]
 
+      namespace :archived do
+        root to: redirect('/admin/archived/petitions')
+
+        resources :petitions, only: %i[show index] do
+          resources :emails, controller: 'petition_emails', except: %i[index show]
+          resource  :lock, only: %i[show create update destroy]
+
+          scope only: %i[show update] do
+            resource :debate_outcome, path: 'debate-outcome'
+            resource :government_response, path: 'government-response', controller: 'government_response'
+            resource :notes
+            resource :details, controller: 'petition_details'
+            resource :schedule_debate, path: 'schedule-debate', controller: 'schedule_debate'
+            resource :tags, controller: 'petition_tags'
+          end
+        end
+      end
+
       controller 'user_sessions' do
         get '/logout',   action: 'destroy'
         get '/login',    action: 'new'

--- a/db/migrate/20170903181738_add_locking_columns_to_archived_petitions.rb
+++ b/db/migrate/20170903181738_add_locking_columns_to_archived_petitions.rb
@@ -1,0 +1,8 @@
+class AddLockingColumnsToArchivedPetitions < ActiveRecord::Migration
+  def change
+    add_column :archived_petitions, :locked_at, :datetime
+    add_column :archived_petitions, :locked_by_id, :integer
+
+    add_index :archived_petitions, :locked_by_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -262,7 +262,9 @@ CREATE TABLE archived_petitions (
     email_requested_for_debate_scheduled_at timestamp without time zone,
     email_requested_for_debate_outcome_at timestamp without time zone,
     email_requested_for_petition_email_at timestamp without time zone,
-    tags integer[] DEFAULT '{}'::integer[] NOT NULL
+    tags integer[] DEFAULT '{}'::integer[] NOT NULL,
+    locked_at timestamp without time zone,
+    locked_by_id integer
 );
 
 
@@ -1735,6 +1737,13 @@ CREATE INDEX index_archived_petitions_on_background ON archived_petitions USING 
 
 
 --
+-- Name: index_archived_petitions_on_locked_by_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_archived_petitions_on_locked_by_id ON archived_petitions USING btree (locked_by_id);
+
+
+--
 -- Name: index_archived_petitions_on_parliament_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2625,4 +2634,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170712070139');
 INSERT INTO schema_migrations (version) VALUES ('20170713193039');
 
 INSERT INTO schema_migrations (version) VALUES ('20170818110849');
+
+INSERT INTO schema_migrations (version) VALUES ('20170903181738');
 

--- a/spec/controllers/admin/archived/debate_outcomes_controller_spec.rb
+++ b/spec/controllers/admin/archived/debate_outcomes_controller_spec.rb
@@ -1,0 +1,480 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::DebateOutcomesController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+
+  describe 'not logged in' do
+    describe 'GET /show' do
+      it 'redirects to the login page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      it 'redirects to edit profile page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to edit profile page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe "logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      describe 'for an open petition' do
+        it 'fetches the requested petition' do
+          get :show, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        context 'that does not already have a debate outcome' do
+          it 'exposes an new unsaved debate_outcome for the requested petition' do
+            get :show, petition_id: petition.id
+            expect(assigns(:debate_outcome)).to be_present
+            expect(assigns(:debate_outcome)).not_to be_persisted
+            expect(assigns(:debate_outcome).petition).to eq petition
+          end
+        end
+
+        context 'that already has a debate outcome' do
+          let!(:debate_outcome) { FactoryGirl.create(:archived_debate_outcome, petition: petition) }
+          it 'exposes the existing debate_outcome on the requested petition' do
+            get :show, petition_id: petition.id
+            expect(assigns(:debate_outcome)).to be_present
+            expect(assigns(:debate_outcome)).to eq debate_outcome
+          end
+        end
+
+        it 'responds successfully and renders the petitions/show template' do
+          get :show, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petitions/show')
+        end
+      end
+
+      shared_examples_for 'trying to view a debate outcome for a petition in the wrong state' do
+        it 'raises a 404 error' do
+          expect {
+            get :show, petition_id: petition.id
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'trying to view a debate outcome for a petition in the wrong state'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'trying to view a debate outcome for a petition in the wrong state'
+      end
+    end
+
+    describe 'PATCH /update' do
+      let(:debate_outcome_attributes) do
+        {
+          debated_on: '2014-12-01',
+          overview: 'Discussion of the 2014 Christmas Adjournment - has the house considered everything it needs to before it closes for the festive period?',
+          transcript_url: 'http://www.publications.parliament.uk/pa/cm201415/cmhansrd/cm141218/debtext/141218-0003.htm#14121849000001',
+          video_url: 'http://parliamentlive.tv/event/index/f9eb68af-6a5c-4a94-95d3-6108aa87e9d7?in=13:57:00',
+          debate_pack_url: "http://researchbriefings.parliament.uk/ResearchBriefing/Summary/CDP-2014-1234"
+        }
+      end
+
+      context 'when clicking the Email button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            archived_debate_outcome: debate_outcome_attributes,
+            save_and_email: "Email"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'for a published petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their email will be sent overnight' do
+              do_patch
+              expect(flash[:notice]).to eq 'Email will be sent overnight'
+            end
+
+            it 'stores the supplied debate outcome details in the db' do
+              do_patch
+              petition.reload
+              expect(petition.debate_outcome).to be_present
+              expect(petition.debate_outcome.debated_on).to eq debate_outcome_attributes[:debated_on].to_date
+              expect(petition.debate_outcome.overview).to eq debate_outcome_attributes[:overview]
+              expect(petition.debate_outcome.transcript_url).to eq debate_outcome_attributes[:transcript_url]
+              expect(petition.debate_outcome.video_url).to eq debate_outcome_attributes[:video_url]
+              expect(petition.debate_outcome.debate_pack_url).to eq debate_outcome_attributes[:debate_pack_url]
+            end
+
+            describe "emails out a debate outcome response" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "queues a job to process the emails" do
+                assert_enqueued_jobs 1 do
+                  do_patch
+                end
+              end
+
+              it "stamps the 'debate_outcome' email sent timestamp on each signature when the job runs" do
+                perform_enqueued_jobs do
+                  do_patch
+                  petition.reload
+                  petition_timestamp = petition.get_email_requested_at_for('debate_outcome')
+                  expect(petition_timestamp).not_to be_nil
+                  petition.signatures.validated.subscribed.each do |signature|
+                    expect(signature.get_email_sent_at_for('debate_outcome')).to eq(petition_timestamp)
+                  end
+                end
+              end
+
+              it "should email out to the validated signees who have opted in when the delayed job runs" do
+                ActionMailer::Base.deliveries.clear
+                perform_enqueued_jobs do
+                  do_patch
+                  expect(ActionMailer::Base.deliveries.length).to eq 4
+                  expect(ActionMailer::Base.deliveries.map(&:to)).to eq([
+                    [petition.creator.email],
+                    ['laura_0@example.com'],
+                    ['laura_1@example.com'],
+                    ['laura_2@example.com']
+                  ])
+                end
+              end
+            end
+          end
+
+          shared_examples_for 'a debate_outcome with invalid parameters' do
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:petition).debate_outcome).to be_present
+              expect(assigns(:petition).debate_outcome.errors).not_to be_empty
+            end
+
+            it 'does not stores the supplied debate outcome details in the db' do
+              do_patch
+              petition.reload
+              expect(petition.debate_outcome).to be_nil
+            end
+          end
+
+          describe 'with invalid params' do
+            before { debate_outcome_attributes.delete(:debated_on) }
+            it_behaves_like 'a debate_outcome with invalid parameters'
+          end
+
+          describe 'image handling' do
+            def patch_and_reload
+              do_patch
+              petition.reload
+            end
+
+            describe 'with no supplied image' do
+              before { patch_and_reload }
+              it 'returns the default image url' do
+                expect(petition.debate_outcome.commons_image.url).to eq commons_default_image_url
+              end
+            end
+
+            describe 'a valid image' do
+
+              before { debate_outcome_attributes[:commons_image] = Rack::Test::UploadedFile.new(commons_image_file, 'image/jpeg') }
+              before { patch_and_reload }
+
+              it 'does not return the default image url' do
+                expect(petition.debate_outcome.commons_image.url).to_not eq commons_default_image_url
+              end
+            end
+
+            describe 'a small image' do
+              before { debate_outcome_attributes[:commons_image] = Rack::Test::UploadedFile.new(commons_image_file_too_small, 'image/jpeg') }
+              it_behaves_like 'a debate_outcome with invalid parameters'
+            end
+
+            describe 'an image in the wrong ratio' do
+              before { debate_outcome_attributes[:commons_image] = Rack::Test::UploadedFile.new(commons_image_file_wrong_ratio, 'image/jpeg') }
+              it_behaves_like 'a debate_outcome with invalid parameters'
+            end
+          end
+        end
+
+        shared_examples_for 'trying to add debate outcome details to a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not stores the supplied debate outcome details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            petition.reload
+            expect(petition.debate_outcome).to be_nil
+          end
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'trying to add debate outcome details to a petition in the wrong state'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'trying to add debate outcome details to a petition in the wrong state'
+        end
+      end
+
+      context 'when clicking the Save button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            archived_debate_outcome: debate_outcome_attributes,
+            save: "Save"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their changes were saved' do
+              do_patch
+              expect(flash[:notice]).to eq 'Updated debate outcome successfully'
+            end
+
+            it 'stores the supplied debate outcome details in the db' do
+              do_patch
+              petition.reload
+              expect(petition.debate_outcome).to be_present
+              expect(petition.debate_outcome.debated_on).to eq debate_outcome_attributes[:debated_on].to_date
+              expect(petition.debate_outcome.overview).to eq debate_outcome_attributes[:overview]
+              expect(petition.debate_outcome.transcript_url).to eq debate_outcome_attributes[:transcript_url]
+              expect(petition.debate_outcome.video_url).to eq debate_outcome_attributes[:video_url]
+              expect(petition.debate_outcome.debate_pack_url).to eq debate_outcome_attributes[:debate_pack_url]
+            end
+
+            describe "does not email out debate outcome response" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "does not queue a job to process the emails" do
+                assert_enqueued_jobs 0 do
+                  do_patch
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            before { debate_outcome_attributes.delete(:debated_on) }
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:petition).debate_outcome).to be_present
+              expect(assigns(:petition).debate_outcome.errors).not_to be_empty
+            end
+
+            it 'does not stores the supplied debate outcome details in the db' do
+              do_patch
+              petition.reload
+              expect(petition.debate_outcome).to be_nil
+            end
+          end
+        end
+
+        shared_examples_for 'trying to add debate outcome details to a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not stores the supplied debate outcome details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            petition.reload
+            expect(petition.debate_outcome).to be_nil
+          end
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'trying to add debate outcome details to a petition in the wrong state'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'trying to add debate outcome details to a petition in the wrong state'
+        end
+      end
+
+      context "when two moderators update the debate outcome for the first time simultaneously" do
+        let(:debate_outcome) do
+          FactoryGirl.build(:archived_debate_outcome, overview: "", debated: false, petition: petition)
+        end
+
+        before do
+          debateable = double(:scope)
+          allow(Archived::Petition).to receive(:debateable).and_return(debateable)
+          allow(debateable).to receive(:find).with(petition.id.to_s).and_return(petition)
+        end
+
+        it "doesn't raise an ActiveRecord::RecordNotUnique error" do
+          expect {
+            expect(petition.debate_outcome).to be_nil
+
+            outcome_attributes = {
+              overview: "overview 1",
+              debated: false
+            }
+
+            patch :update, petition_id: petition.id, archived_debate_outcome: outcome_attributes, save: "Save"
+            expect(petition.debate_outcome.overview).to eq("overview 1")
+
+            allow(petition).to receive(:debate_outcome).and_return(nil, petition.debate_outcome)
+            allow(petition).to receive(:build_debate_outcome).and_return(debate_outcome)
+
+            outcome_attributes = {
+              overview: "overview 2",
+              debated: false
+            }
+
+            patch :update, petition_id: petition.id, archived_debate_outcome: outcome_attributes, save: "Save"
+            expect(petition.debate_outcome(true).overview).to eq("overview 2")
+          }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/government_response_controller_spec.rb
+++ b/spec/controllers/admin/archived/government_response_controller_spec.rb
@@ -1,0 +1,584 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+  let(:government_response) { petition.government_response }
+
+  describe 'not logged in' do
+    describe 'GET /show' do
+      it 'redirects to the login page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      it 'redirects to edit profile page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to edit profile page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe "logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      shared_examples_for 'viewing government response for a petition' do
+        it 'fetches the requested petition' do
+          get :show, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'responds successfully and renders the petitions/show template' do
+          get :show, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petitions/show')
+        end
+      end
+
+      shared_examples_for 'viewing government response for a petition in the wrong state' do
+        it 'throws a 404' do
+          expect {
+            get :show, petition_id: petition.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      describe 'for a published petition' do
+        it_behaves_like 'viewing government response for a petition'
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'viewing government response for a petition'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'viewing government response for a petition'
+      end
+    end
+
+    describe 'PATCH /update' do
+      let(:government_response_attributes) do
+        {
+          summary: 'The government agrees',
+          details: 'Your petition is brilliant and we will do our utmost to make it law.'
+        }
+      end
+
+      context 'when clicking the Email button' do
+        def do_patch(overrides = {})
+          login_as(user)
+
+          params = {
+            petition_id: petition.id,
+            archived_government_response: government_response_attributes,
+            save_and_email: "Email"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'using valid params to add a government response' do
+          it 'redirects to the show page' do
+            do_patch
+            expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+          end
+
+          it 'tells the moderator that their email will be sent overnight' do
+            do_patch
+            expect(flash[:notice]).to eq 'Email will be sent overnight'
+          end
+
+          it 'stores the supplied government response in the db' do
+            do_patch
+            petition.reload
+            expect(government_response.summary).to eq government_response_attributes[:summary]
+            expect(government_response.details).to eq government_response_attributes[:details]
+          end
+
+          it 'stamps the current time on the government_response_at timestamp in the db' do
+            time = 6.days.from_now
+            travel_to time do
+              do_patch
+              petition.reload
+              expect(petition.government_response_at).to be_within(1.second).of time
+            end
+          end
+
+          it "sets the 'government_response' email requested receipt timestamp" do
+            time = 5.days.from_now
+            travel_to time do
+              do_patch
+              petition.reload
+              expect(petition.get_email_requested_at_for('government_response')).to be_within(1.second).of time
+            end
+          end
+
+          describe "emails out debate outcomes response" do
+            before do
+              3.times do |i|
+                attributes = {
+                  name: "Laura #{i}",
+                  email: "laura_#{i}@example.com",
+                  notify_by_email: true,
+                  petition: petition
+                }
+
+                FactoryGirl.create(:archived_signature, :validated, attributes)
+              end
+
+              2.times do |i|
+                attributes = {
+                  name: "Sarah #{i}",
+                  email: "sarah_#{i}@example.com",
+                  notify_by_email: false,
+                  petition: petition
+                }
+
+                FactoryGirl.create(:archived_signature, :validated, attributes)
+              end
+
+              2.times do |i|
+                attributes = {
+                  name: "Brian #{i}",
+                  email: "brian_#{i}@example.com",
+                  notify_by_email: true,
+                  petition: petition
+                }
+
+                FactoryGirl.create(:archived_signature, :pending, attributes)
+              end
+
+              petition.reload
+            end
+
+            it "queues a job to process the emails" do
+              assert_enqueued_jobs 1 do
+                do_patch
+              end
+            end
+
+            it "stamps the 'government_response' email sent timestamp on each signature when the job runs" do
+              perform_enqueued_jobs do
+                do_patch
+                petition.reload
+                petition_timestamp = petition.get_email_requested_at_for('government_response')
+                expect(petition_timestamp).not_to be_nil
+                petition.signatures.validated.subscribed.each do |signature|
+                  expect(signature.get_email_sent_at_for('government_response')).to eq(petition_timestamp)
+                end
+              end
+            end
+
+            it "should email out to the validated signees who have opted in when the delayed job runs" do
+              ActionMailer::Base.deliveries.clear
+              perform_enqueued_jobs do
+                do_patch
+                expect(ActionMailer::Base.deliveries.length).to eq 4
+                expect(ActionMailer::Base.deliveries.map(&:to)).to eq([
+                  [petition.creator.email],
+                  ['laura_0@example.com'],
+                  ['laura_1@example.com'],
+                  ['laura_2@example.com']
+                ])
+                expect(ActionMailer::Base.deliveries[0].subject).to match(/Government responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[1].subject).to match(/Government responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[2].subject).to match(/Government responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[3].subject).to match(/Government responded to “#{petition.action}”/)
+              end
+            end
+          end
+        end
+
+        describe 'using no params to add a government response' do
+          before do
+            government_response_attributes[:summary] = nil
+            government_response_attributes[:details] = nil
+          end
+
+          it 'does not tell the moderator that their email will be sent overnight' do
+            do_patch
+            expect(flash[:notice]).to be_blank
+          end
+
+          it "does not set the 'government_response' email requested receipt timestamp" do
+            time = 5.days.from_now
+            travel_to time do
+              do_patch
+              petition.reload
+              expect(petition.get_email_requested_at_for('government_response')).to be_nil
+            end
+          end
+
+          it "does not queue a job to process the emails" do
+            assert_enqueued_jobs 0 do
+              do_patch
+            end
+          end
+
+          it 're-renders the admin/archived/petitions/show template' do
+            do_patch
+            expect(response).to be_success
+            expect(response).to render_template('admin/archived/petitions/show')
+          end
+        end
+
+        describe 'using invalid params to add a government response' do
+          before { government_response_attributes[:summary] = 'a' * 501 }
+
+          it 're-renders the petitions/show template' do
+            do_patch
+            expect(response).to be_success
+            expect(response).to render_template('petitions/show')
+          end
+
+          it 'leaves the in-memory instance with errors' do
+            do_patch
+            expect(assigns(:government_response).errors).not_to be_empty
+          end
+
+          it 'does not store the supplied government response in the db' do
+            do_patch
+            petition.reload
+            expect(government_response).to be_nil
+          end
+
+          it 'does not stamp the government_response_at timestamp in the db' do
+            do_patch
+            petition.reload
+            expect(petition.government_response_at).to be_nil
+          end
+
+          it "does not stamp the 'government_response' email requested receipt timestamp" do
+            do_patch
+            petition.reload
+            expect(petition.get_email_requested_at_for('government_response')).to be_nil
+          end
+
+          it "doest not queue up a job to send the 'government_response' emails" do
+            do_patch
+            assert_enqueued_jobs 0
+          end
+        end
+
+        shared_examples_for 'adding a government response to a petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'stores the supplied response on the petition in the db' do
+            do_patch
+            petition.reload
+            expect(government_response.summary).to eq government_response_attributes[:summary]
+            expect(government_response.details).to eq government_response_attributes[:details]
+          end
+        end
+
+        shared_examples_for 'adding a government response to a petition in the wrong state' do
+          it 'throws a 404' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not store the supplied response on the petition in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            petition.reload
+            expect(government_response).to be_nil
+          end
+        end
+
+        describe 'for a published petition' do
+          it_behaves_like 'adding a government response to a petition'
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'adding a government response to a petition'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'adding a government response to a petition'
+        end
+      end
+
+      context 'when clicking the Save button' do
+        def do_patch(overrides = {})
+          login_as(user)
+
+          params = {
+            petition_id: petition.id,
+            archived_government_response: government_response_attributes,
+            save: "Save"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'using valid params to add a government response' do
+          it 'redirects to the show page' do
+            do_patch
+            expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+          end
+
+          it 'tells the moderator that their changes were saved' do
+            do_patch
+            expect(flash[:notice]).to eq 'Updated government response successfully'
+          end
+
+          it 'stores the supplied government response in the db' do
+            do_patch
+            petition.reload
+            expect(government_response.summary).to eq government_response_attributes[:summary]
+            expect(government_response.details).to eq government_response_attributes[:details]
+          end
+
+          it 'stamps the current time on the government_response_at timestamp in the db' do
+            time = 6.days.from_now
+            travel_to time do
+              do_patch
+              petition.reload
+              expect(petition.government_response_at).to be_within(1.second).of time
+            end
+          end
+
+          it "does not set the 'government_response' email requested receipt timestamp" do
+            time = 5.days.from_now
+            travel_to time do
+              do_patch
+              petition.reload
+              expect(petition.get_email_requested_at_for('government_response')).to be_nil
+            end
+          end
+
+          describe "does not email out debate outcomes response" do
+            before do
+              3.times do |i|
+                attributes = {
+                  name: "Laura #{i}",
+                  email: "laura_#{i}@example.com",
+                  notify_by_email: true,
+                  petition: petition
+                }
+
+                FactoryGirl.create(:archived_signature, :validated, attributes)
+              end
+
+              2.times do |i|
+                attributes = {
+                  name: "Sarah #{i}",
+                  email: "sarah_#{i}@example.com",
+                  notify_by_email: false,
+                  petition: petition
+                }
+
+                FactoryGirl.create(:archived_signature, :validated, attributes)
+              end
+
+              2.times do |i|
+                attributes = {
+                  name: "Brian #{i}",
+                  email: "brian_#{i}@example.com",
+                  notify_by_email: true,
+                  petition: petition
+                }
+
+                FactoryGirl.create(:archived_signature, :pending, attributes)
+              end
+
+              petition.reload
+            end
+
+            it "does not queue a job to process the emails" do
+              assert_enqueued_jobs 0 do
+                do_patch
+              end
+            end
+          end
+        end
+
+        describe 'using no params to add a government response' do
+          before do
+            government_response_attributes[:summary] = nil
+            government_response_attributes[:details] = nil
+          end
+
+          it 'does not tell the moderator that their changes were saved' do
+            do_patch
+            expect(flash[:notice]).to be_blank
+          end
+
+          it "does not set the 'government_response' email requested receipt timestamp" do
+            time = 5.days.from_now
+            travel_to time do
+              do_patch
+              petition.reload
+              expect(petition.get_email_requested_at_for('government_response')).to be_nil
+            end
+          end
+
+          it "does not queue a job to process the emails" do
+            assert_enqueued_jobs 0 do
+              do_patch
+            end
+          end
+
+          it 're-renders the admin/archived/petitions/show template' do
+            do_patch
+            expect(response).to be_success
+            expect(response).to render_template('admin/archived/petitions/show')
+          end
+        end
+
+        describe 'using invalid params to add a government response' do
+          before { government_response_attributes[:summary] = 'a' * 501 }
+
+          it 're-renders the petitions/show template' do
+            do_patch
+            expect(response).to be_success
+            expect(response).to render_template('petitions/show')
+          end
+
+          it 'leaves the in-memory instance with errors' do
+            do_patch
+            expect(assigns(:government_response).errors).not_to be_empty
+          end
+
+          it 'does not store the supplied government response in the db' do
+            do_patch
+            petition.reload
+            expect(government_response).to be_nil
+          end
+
+          it 'does not stamp the government_response_at timestamp in the db' do
+            do_patch
+            petition.reload
+            expect(petition.government_response_at).to be_nil
+          end
+
+          it "does not stamp the 'government_response' email requested receipt timestamp" do
+            do_patch
+            petition.reload
+            expect(petition.get_email_requested_at_for('government_response')).to be_nil
+          end
+
+          it "doest not queue up a job to send the 'government_response' emails" do
+            do_patch
+            assert_enqueued_jobs 0
+          end
+        end
+
+        shared_examples_for 'adding a government response to a petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'stores the supplied response on the petition in the db' do
+            do_patch
+            petition.reload
+            expect(government_response.summary).to eq government_response_attributes[:summary]
+            expect(government_response.details).to eq government_response_attributes[:details]
+          end
+        end
+
+        shared_examples_for 'adding a government response to a petition in the wrong state' do
+          it 'throws a 404' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not store the supplied response on the petition in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            petition.reload
+            expect(government_response).to be_nil
+          end
+        end
+
+        describe 'for a published petition' do
+          it_behaves_like 'adding a government response to a petition'
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'adding a government response to a petition'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'adding a government response to a petition'
+        end
+      end
+
+      context "when two moderators update the response for the first time simultaneously" do
+        let(:government_response) do
+          FactoryGirl.build(:archived_government_response, summary: "", details: "", petition: petition)
+        end
+
+        before do
+          moderated = double(:scope)
+          allow(Archived::Petition).to receive(:moderated).and_return(moderated)
+          allow(moderated).to receive(:find).with(petition.id.to_s).and_return(petition)
+        end
+
+        it "doesn't raise an ActiveRecord::RecordNotUnique error" do
+          expect {
+            expect(petition.government_response).to be_nil
+
+            response_attributes = {
+              summary: "summmary 1",
+              details: "details 1"
+            }
+
+            patch :update, petition_id: petition.id, archived_government_response: response_attributes, save: "Save"
+            expect(petition.government_response.summary).to eq("summmary 1")
+
+            allow(petition).to receive(:government_response).and_return(nil, petition.government_response)
+            allow(petition).to receive(:build_government_response).and_return(government_response)
+
+            response_attributes = {
+              summary: "summmary 2",
+              details: "details 2"
+            }
+
+            patch :update, petition_id: petition.id, archived_government_response: response_attributes, save: "Save"
+            expect(petition.government_response(true).summary).to eq("summmary 2")
+          }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/notes_controller_spec.rb
+++ b/spec/controllers/admin/archived/notes_controller_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::NotesController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+
+  describe 'not logged in' do
+    describe 'GET /show' do
+      it 'redirects to the login page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      it 'redirects to edit profile page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to edit profile page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe "logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      shared_examples_for 'viewing notes for a petition' do
+        it 'fetches the requested petition' do
+          get :show, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'responds successfully and renders the petitions/show template' do
+          get :show, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petitions/show')
+        end
+      end
+
+      describe 'for an open petition' do
+        it_behaves_like 'viewing notes for a petition'
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'viewing notes for a petition'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'viewing notes for a petition'
+      end
+    end
+
+    describe 'PATCH /update' do
+      let(:notes_attributes) do
+        {
+          details: 'This seems fine, just need to get legal to give it the once over before letting it through.'
+        }
+      end
+
+      def do_patch(overrides = {})
+        params = { petition_id: petition.id, archived_note: notes_attributes }
+        patch :update, params.merge(overrides)
+      end
+
+      shared_examples_for 'updating notes for a petition' do
+        it 'fetches the requested petition' do
+          do_patch
+          expect(assigns(:petition)).to eq petition
+        end
+
+        context 'with valid params' do
+          it 'redirects to the petition show page' do
+            do_patch
+            expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+          end
+
+          it 'stores the supplied notes in the db' do
+            do_patch
+            petition.reload
+            expect(petition.note.details).to eq notes_attributes[:details]
+          end
+        end
+      end
+
+      describe 'for a published petition' do
+        it_behaves_like 'updating notes for a petition'
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'updating notes for a petition'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'updating notes for a petition'
+      end
+
+      context "when two moderators update the notes for the first time simultaneously" do
+        let(:note) { FactoryGirl.build(:archived_note, details: "", petition: petition) }
+
+        before do
+          allow(Archived::Petition).to receive(:find).with(petition.id.to_s).and_return(petition)
+        end
+
+        it "doesn't raise an ActiveRecord::RecordNotUnique error" do
+          expect {
+            expect(petition.note).to be_nil
+
+            patch :update, petition_id: petition.id, archived_note: { details: "update 1" }
+            expect(petition.note.details).to eq("update 1")
+
+            allow(petition).to receive(:note).and_return(nil, petition.note)
+            allow(petition).to receive(:build_note).and_return(note)
+
+            patch :update, petition_id: petition.id, archived_note: { details: "update 2" }
+            expect(petition.note(true).details).to eq("update 2")
+          }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/petition_details_controller_spec.rb
+++ b/spec/controllers/admin/archived/petition_details_controller_spec.rb
@@ -1,0 +1,157 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::PetitionDetailsController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+
+  describe 'not logged in' do
+    describe 'GET #show' do
+      it 'redirects to the login page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe 'GET #show' do
+      it 'redirects to edit profile page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'redirects to edit profile page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe 'logged in as moderator user' do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET #show' do
+      shared_examples_for 'viewing a petition in the correct state' do
+        it 'fetches the requested petition' do
+          get :show, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'responds successfully and renders the petition_details/show template' do
+          get :show, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petition_details/show')
+        end
+      end
+
+      describe 'for a published petition' do
+        it_behaves_like 'viewing a petition in the correct state'
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'viewing a petition in the correct state'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'viewing a petition in the correct state'
+      end
+    end
+
+    describe 'PATCH #update' do
+      let(:petition) { FactoryGirl.create(:archived_petition, action: 'Old action', background: 'Old background', additional_details: 'Old additional details') }
+
+      def do_update
+        patch :update,
+              petition_id: petition.id,
+              archived_petition: petition_attributes
+      end
+
+      describe 'allowed params' do
+        let(:params) do
+          {
+            petition_id: petition.id,
+            archived_petition: {
+              action: 'New action',
+              background: 'New background',
+              additional_details: 'New additional_details'
+            }
+          }
+        end
+
+        it "are limited to action, background, additional_details and creator name" do
+          is_expected.to permit(:action, :background, :additional_details).for(:update, params: params).on(:archived_petition)
+        end
+      end
+
+      describe 'with valid params' do
+        let(:petition_attributes) do
+          {
+              action: 'New action',
+              background: 'New background',
+              additional_details: 'New additional_details'
+          }
+        end
+
+        shared_examples_for 'updating a petition in the correct state' do
+          it 'redirects to the edit petition page' do
+            do_update
+            petition.reload
+            expect(response).to redirect_to"https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+          end
+
+          it 'updates the petition' do
+            do_update
+            petition.reload
+            expect(petition).to be_present
+            expect(petition.action).to eq('New action')
+            expect(petition.background).to eq('New background')
+            expect(petition.additional_details).to eq('New additional_details')
+          end
+        end
+
+        describe 'for a published petition' do
+          it_behaves_like 'updating a petition in the correct state'
+        end
+      end
+
+      describe 'with invalid params' do
+        let(:petition_attributes) do
+          {
+              action: '',
+              background: '',
+              additional_details: 'Blah'
+          }
+        end
+
+        shared_examples_for 'updating a petition in the correct state' do
+          it 'renders the petition_details/show template again' do
+            do_update
+            expect(response).to be_success
+            expect(response).to render_template('petition_details/show')
+          end
+        end
+
+        describe 'for a published petition' do
+          it_behaves_like 'updating a petition in the correct state'
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/petition_emails_controller_spec.rb
+++ b/spec/controllers/admin/archived/petition_emails_controller_spec.rb
@@ -1,0 +1,889 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::PetitionEmailsController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+
+  describe 'not logged in' do
+    let(:email) { FactoryGirl.create(:archived_petition_email, petition: petition) }
+
+    describe 'GET /new' do
+      it 'redirects to the login page' do
+        get :new, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'POST /' do
+      it 'redirects to the login page' do
+        post :create, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'GET /:id/edit' do
+      it 'redirects to the login page' do
+        get :edit, petition_id: petition.id, id: email.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'PATCH /:id' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id, id: email.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'DELETE /:id' do
+      it 'redirects to the login page' do
+        patch :destroy, petition_id: petition.id, id: email.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:email) { FactoryGirl.create(:archived_petition_email, petition: petition) }
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+
+    before { login_as(user) }
+
+    describe 'GET /new' do
+      it 'redirects to edit profile page' do
+        get :new, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'POST /' do
+      it 'redirects to edit profile page' do
+        post :create, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'GET /:id/edit' do
+      it 'redirects to the login page' do
+        get :edit, petition_id: petition.id, id: email.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'PATCH /:id' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id, id: email.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'DELETE /:id' do
+      it 'redirects to the login page' do
+        patch :destroy, petition_id: petition.id, id: email.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe "logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET /new' do
+      describe 'for an open petition' do
+        it 'fetches the requested petition' do
+          get :new, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'responds successfully and renders the petitions/show template' do
+          get :new, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petitions/show')
+        end
+      end
+
+      shared_examples_for 'trying to view the email petitioners form of a petition in the wrong state' do
+        it 'raises a 404 error' do
+          expect {
+            get :new, petition_id: petition.id
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'trying to view the email petitioners form of a petition in the wrong state'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'trying to view the email petitioners form of a petition in the wrong state'
+      end
+    end
+
+    describe 'POST /' do
+      let(:petition_email_attributes) do
+        {
+          subject: "Petition email subject",
+          body: "Petition email body"
+        }
+      end
+
+      context 'when clicking the Email button' do
+        def do_post(overrides = {})
+          params = {
+            petition_id: petition.id,
+            archived_petition_email: petition_email_attributes,
+            save_and_email: "Email"
+          }
+
+          post :create, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_post
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_post
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their email will be sent overnight' do
+              do_post
+              expect(flash[:notice]).to eq 'Email will be sent overnight'
+            end
+
+            it 'stores the supplied email details in the db' do
+              do_post
+              petition.reload
+              email = petition.emails.last
+              expect(email).to be_present
+              expect(email.subject).to eq "Petition email subject"
+              expect(email.body).to eq "Petition email body"
+              expect(email.sent_by).to eq user.pretty_name
+            end
+
+            context "emails out the petition email" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "queues a job to process the emails" do
+                assert_enqueued_jobs 1 do
+                  do_post
+                end
+              end
+
+              it "stamps the 'petition_email' email sent timestamp on each signature when the job runs" do
+                perform_enqueued_jobs do
+                  do_post
+                  petition.reload
+                  petition_timestamp = petition.get_email_requested_at_for('petition_email')
+                  expect(petition_timestamp).not_to be_nil
+                  petition.signatures.validated.subscribed.each do |signature|
+                    expect(signature.get_email_sent_at_for('petition_email')).to eq(petition_timestamp)
+                  end
+                end
+              end
+
+              it "should email out to the validated signees who have opted in when the delayed job runs" do
+                perform_enqueued_jobs do
+                  do_post
+                  expect(deliveries.length).to eq 5
+                  expect(deliveries.map(&:to)).to eq([
+                    [petition.creator.email],
+                    ['laura_0@example.com'],
+                    ['laura_1@example.com'],
+                    ['laura_2@example.com'],
+                    ['petitionscommittee@parliament.uk']
+                  ])
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            let(:petition_email_attributes) do
+              { subject: "", body: "" }
+            end
+
+            it 're-renders the petitions/show template' do
+              do_post
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_post
+              expect(assigns(:email)).to be_present
+              expect(assigns(:email).errors).not_to be_empty
+            end
+
+            it 'does not stores the email details in the db' do
+              do_post
+              petition.reload
+              expect(petition.emails).to be_empty
+            end
+          end
+        end
+
+        shared_examples_for 'trying to email supporters of a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_post
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not stores the supplied email details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_post }
+            petition.reload
+            expect(petition.emails).to be_empty
+          end
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+      end
+
+      context 'when clicking the Save button' do
+        def do_post(overrides = {})
+          params = {
+            petition_id: petition.id,
+            archived_petition_email: petition_email_attributes,
+            save: "Save"
+          }
+
+          post :create, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_post
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_post
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their changes were saved' do
+              do_post
+              expect(flash[:notice]).to eq 'Created other parliamentary business successfully'
+            end
+
+            it 'stores the supplied email details in the db' do
+              do_post
+              petition.reload
+              email = petition.emails.last
+              expect(email).to be_present
+              expect(email.subject).to eq "Petition email subject"
+              expect(email.body).to eq "Petition email body"
+              expect(email.sent_by).to eq user.pretty_name
+            end
+
+            context "does not email out the petition email" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "does not queue a job to process the emails" do
+                assert_enqueued_jobs 0 do
+                  do_post
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            let(:petition_email_attributes) do
+              { subject: "", body: "" }
+            end
+
+            it 're-renders the petitions/show template' do
+              do_post
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_post
+              expect(assigns(:email)).to be_present
+              expect(assigns(:email).errors).not_to be_empty
+            end
+
+            it 'does not stores the email details in the db' do
+              do_post
+              petition.reload
+              expect(petition.emails).to be_empty
+            end
+          end
+        end
+
+        shared_examples_for 'trying to email supporters of a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_post
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not store the supplied email details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_post }
+            petition.reload
+            expect(petition.emails).to be_empty
+          end
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+      end
+    end
+
+    describe 'GET /:id/edit' do
+      let(:email) do
+        FactoryGirl.create(
+          :archived_petition_email,
+          petition: petition,
+          subject: "Petition email subject",
+          body: "Petition email body"
+        )
+      end
+
+      describe 'for an open petition' do
+        it 'fetches the requested petition' do
+          get :edit, petition_id: petition.id, id: email.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'fetches the requested email' do
+          get :edit, petition_id: petition.id, id: email.id
+          expect(assigns(:email)).to eq email
+        end
+
+        it 'responds successfully and renders the petition_emails/edit template' do
+          get :edit, petition_id: petition.id, id: email.id
+          expect(response).to be_success
+          expect(response).to render_template('petition_emails/edit')
+        end
+      end
+
+      shared_examples_for 'trying to view the email petitioners form of a petition in the wrong state' do
+        it 'raises a 404 error' do
+          expect {
+            get :new, petition_id: petition.id, id: email.id
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'trying to view the email petitioners form of a petition in the wrong state'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'trying to view the email petitioners form of a petition in the wrong state'
+      end
+    end
+
+    describe 'PATCH /:id' do
+      let(:email) do
+        FactoryGirl.create(
+          :archived_petition_email,
+          petition: petition,
+          subject: "Petition email subject",
+          body: "Petition email body"
+        )
+      end
+
+      let(:petition_email_attributes) do
+        {
+          subject: "New petition email subject",
+          body: "New petition email body"
+        }
+      end
+
+      context 'when clicking the Email button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            id: email.id,
+            archived_petition_email: petition_email_attributes,
+            save_and_email: "Email"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'fetches the requested email' do
+            do_patch
+            expect(assigns(:email)).to eq email
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their email will be sent overnight' do
+              do_patch
+              expect(flash[:notice]).to eq 'Email will be sent overnight'
+            end
+
+            it 'stores the supplied email details in the db' do
+              do_patch
+              petition.reload
+              email = petition.emails.last
+              expect(email).to be_present
+              expect(email.subject).to eq "New petition email subject"
+              expect(email.body).to eq "New petition email body"
+              expect(email.sent_by).to eq user.pretty_name
+            end
+
+            context "emails out the petition email" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "queues a job to process the emails" do
+                assert_enqueued_jobs 1 do
+                  do_patch
+                end
+              end
+
+              it "stamps the 'petition_email' email sent timestamp on each signature when the job runs" do
+                perform_enqueued_jobs do
+                  do_patch
+                  petition.reload
+                  petition_timestamp = petition.get_email_requested_at_for('petition_email')
+                  expect(petition_timestamp).not_to be_nil
+                  petition.signatures.validated.subscribed.each do |signature|
+                    expect(signature.get_email_sent_at_for('petition_email')).to eq(petition_timestamp)
+                  end
+                end
+              end
+
+              it "should email out to the validated signees who have opted in when the delayed job runs" do
+                perform_enqueued_jobs do
+                  do_patch
+                  expect(deliveries.length).to eq 5
+                  expect(deliveries.map(&:to)).to eq([
+                    [petition.creator.email],
+                    ['laura_0@example.com'],
+                    ['laura_1@example.com'],
+                    ['laura_2@example.com'],
+                    ['petitionscommittee@parliament.uk']
+                  ])
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            let(:petition_email_attributes) do
+              { subject: "", body: "" }
+            end
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:email)).to be_present
+              expect(assigns(:email).errors).not_to be_empty
+            end
+
+            it 'does not stores the email details in the db' do
+              do_patch
+              email.reload
+              expect(email).to be_present
+              expect(email.subject).to eq "Petition email subject"
+              expect(email.body).to eq "Petition email body"
+            end
+          end
+        end
+
+        shared_examples_for 'trying to email supporters of a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not stores the supplied email details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            email.reload
+            expect(email).to be_present
+            expect(email.subject).to eq "Petition email subject"
+            expect(email.body).to eq "Petition email body"
+          end
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+      end
+
+      context 'when clicking the Save button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            id: email.id,
+            archived_petition_email: petition_email_attributes,
+            save: "Save"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'fetches the requested email' do
+            do_patch
+            expect(assigns(:email)).to eq email
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their changes were saved' do
+              do_patch
+              expect(flash[:notice]).to eq 'Updated other parliamentary business successfully'
+            end
+
+            it 'stores the supplied email details in the db' do
+              do_patch
+              email.reload
+              expect(email).to be_present
+              expect(email.subject).to eq "New petition email subject"
+              expect(email.body).to eq "New petition email body"
+              expect(email.sent_by).to eq user.pretty_name
+            end
+
+            context "does not email out the petition email" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "does not queue a job to process the emails" do
+                assert_enqueued_jobs 0 do
+                  do_patch
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            let(:petition_email_attributes) do
+              { subject: "", body: "" }
+            end
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:email)).to be_present
+              expect(assigns(:email).errors).not_to be_empty
+            end
+
+            it 'does not stores the email details in the db' do
+              do_patch
+              email.reload
+              expect(email.subject).to eq("Petition email subject")
+              expect(email.body).to eq("Petition email body")
+            end
+          end
+        end
+
+        shared_examples_for 'trying to email supporters of a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not store the supplied email details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            email.reload
+            expect(email.subject).to eq("Petition email subject")
+            expect(email.body).to eq("Petition email body")
+          end
+        end
+
+        describe 'for a pending petition' do
+          before { petition.update_column(:state, Petition::PENDING_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a validated petition' do
+          before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a sponsored petition' do
+          before { petition.update_column(:state, Petition::SPONSORED_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+      end
+    end
+
+    describe 'DELETE /:id' do
+      let(:email) do
+        FactoryGirl.create(
+          :archived_petition_email,
+          petition: petition,
+          subject: "Petition email subject",
+          body: "Petition email body"
+        )
+      end
+
+      def do_delete(overrides = {})
+        params = { petition_id: petition.id, id: email.id }
+        delete :destroy, params.merge(overrides)
+      end
+
+      describe 'for a published petition' do
+        let(:published) { double(:published) }
+        let(:emails) { double(:emails) }
+
+        before do
+          expect(Archived::Petition).to receive(:published).and_return(published)
+          expect(published).to receive(:find).with("#{petition.id}").and_return(petition)
+          expect(petition).to receive(:emails).and_return(emails)
+          expect(emails).to receive(:find).with("#{email.id}").and_return(email)
+        end
+
+        it 'fetches the requested petition' do
+          do_delete
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'fetches the requested email' do
+          do_delete
+          expect(assigns(:email)).to eq email
+        end
+
+        context "when the delete is successful" do
+          before do
+            expect(email).to receive(:destroy).and_return(true)
+          end
+
+          it 'redirects to the petition show page' do
+            do_delete
+            expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+          end
+
+          it 'tells the moderator that the record was deleted' do
+            do_delete
+            expect(flash[:notice]).to eq 'Deleted other parliamentary business successfully'
+          end
+        end
+
+        context "when the delete is unsuccessful" do
+          before do
+            expect(email).to receive(:destroy).and_return(false)
+          end
+
+          it 'redirects to the petition show page' do
+            do_delete
+            expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+          end
+
+          it 'tells the moderator to contact support' do
+            do_delete
+            expect(flash[:notice]).to eq 'Unable to delete other parliamentary business - please contact support'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/petition_tags_controller_spec.rb
+++ b/spec/controllers/admin/archived/petition_tags_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::PetitionTagsController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+
+  context "when not logged in" do
+    describe "GET /admin/archived/petitions/:petition_id/tags" do
+      it "redirects to the login page" do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+      end
+    end
+
+    describe "PATCH /admin/archived/petitions/:petition_id/tags" do
+      it "redirects to the login page" do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+      end
+    end
+  end
+
+  context "when logged in as moderator user but need to reset password" do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe "GET /admin/archived/petitions/:petition_id/tags" do
+      it "redirects to the edit profile page" do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe "PATCH /admin/archived/petitions/:petition_id/tags" do
+      it "redirects to the edit profile page" do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  context "when logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe "GET /admin/archived/petitions/:petition_id/tags" do
+      before { get :show, petition_id: petition.id }
+
+      it "returns 200 OK" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the :show template" do
+        expect(response).to render_template("admin/archived/petitions/show")
+      end
+    end
+
+    describe "PATCH /admin/archived/petitions/:petition_id/tags" do
+      before { patch :update, petition_id: petition.id, petition: params }
+
+      context "and the params are invalid" do
+        let :params do
+          { tags: ["999"] }
+        end
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :show template" do
+          expect(response).to render_template("admin/archived/petitions/show")
+        end
+      end
+
+      context "and the params are valid" do
+        let :params do
+          { tags: [""] }
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Petition has been successfully updated")
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/petitions_controller_spec.rb
+++ b/spec/controllers/admin/archived/petitions_controller_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::PetitionsController, type: :controller, admin: true do
+  before do
+    FactoryGirl.create(:parliament, :archived)
+  end
+
+  context "when not logged in" do
+    describe "GET /admin/archived/petitions" do
+      it "redirects to the login page" do
+        get :index
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+      end
+    end
+
+    describe "GET /admin/archived/petitions/:id" do
+      it "redirects to the login page" do
+        get :show, id: "100000"
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+      end
+    end
+  end
+
+  context "when logged in as a moderator but need to reset password" do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe "GET /admin/archived/petitions" do
+      it "redirects to the edit profile page" do
+        get :index
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe "GET /admin/archived/petitions/:id" do
+      it "redirects to the edit profile page" do
+        get :show, id: "100000"
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  context "when logged in as a moderator" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe "GET /admin/archived/petitions" do
+      context "when making a HTML request" do
+        before { get :index }
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :index template" do
+          expect(response).to render_template("admin/archived/petitions/index")
+        end
+      end
+
+      context "when making a CSV request" do
+        before { get :index, format: "csv" }
+
+        it "returns a CSV file" do
+          expect(response.content_type).to eq("text/csv")
+        end
+
+        it "doesn't set the content length" do
+          expect(response.content_length).to be_nil
+        end
+
+        it "sets the streaming headers" do
+          expect(response["Cache-Control"]).to match(/no-cache/)
+          expect(response["X-Accel-Buffering"]).to eq("no")
+        end
+
+        it "sets the content disposition" do
+          expect(response['Content-Disposition']).to match(/attachment; filename=all-petitions-\d{14}\.csv/)
+        end
+      end
+
+      context "when searching by id" do
+        before { get :index, q: "100000" }
+
+        it "redirects to the admin petition page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/archived/petitions/100000")
+        end
+      end
+    end
+
+    describe "GET /admin/archived/petitions/:id" do
+      context "when the petition doesn't exist" do
+        before { get :show, id: "999999" }
+
+        it "redirects to the admin dashboard page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Sorry, we couldn't find petition 999999")
+        end
+      end
+
+      context "when the petition exists" do
+        let!(:petition) { FactoryGirl.create(:archived_petition) }
+
+        before { get :show, id: petition.to_param }
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :show template" do
+          expect(response).to render_template("admin/archived/petitions/show")
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/archived/schedule_debate_controller_spec.rb
+++ b/spec/controllers/admin/archived/schedule_debate_controller_spec.rb
@@ -1,0 +1,387 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::ScheduleDebateController, type: :controller, admin: true do
+  let!(:petition) { FactoryGirl.create(:archived_petition) }
+  let!(:creator) { FactoryGirl.create(:archived_signature, :validated, creator: true, petition: petition) }
+
+  describe 'not logged in' do
+    describe 'GET /show' do
+      it 'redirects to the login page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to the login page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to('https://moderate.petition.parliament.uk/admin/login')
+      end
+    end
+  end
+
+  context 'logged in as moderator user but need to reset password' do
+    let(:user) { FactoryGirl.create(:moderator_user, force_password_reset: true) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      it 'redirects to edit profile page' do
+        get :show, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+
+    describe 'PATCH /update' do
+      it 'redirects to edit profile page' do
+        patch :update, petition_id: petition.id
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/profile/#{user.id}/edit")
+      end
+    end
+  end
+
+  describe "logged in as moderator user" do
+    let(:user) { FactoryGirl.create(:moderator_user) }
+    before { login_as(user) }
+
+    describe 'GET /show' do
+      shared_examples_for 'viewing scheduled debate date' do
+        it 'fetches the requested petition' do
+          get :show, petition_id: petition.id
+          expect(assigns(:petition)).to eq petition
+        end
+
+        it 'responds successfully and renders the petitions/show template' do
+          get :show, petition_id: petition.id
+          expect(response).to be_success
+          expect(response).to render_template('petitions/show')
+        end
+      end
+
+      describe 'for an open petition' do
+        it_behaves_like 'viewing scheduled debate date'
+      end
+
+      describe 'for a rejected petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+        it_behaves_like 'viewing scheduled debate date'
+      end
+
+      describe 'for a hidden petition' do
+        let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+        it_behaves_like 'viewing scheduled debate date'
+      end
+    end
+
+    describe 'PATCH /update' do
+      let(:scheduled_debate_date_attributes) do
+        {
+          scheduled_debate_date: '2014-12-01',
+        }
+      end
+
+      context 'when clicking the Email button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            archived_petition: scheduled_debate_date_attributes,
+            save_and_email: "Email"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'scheduling a debate date for a petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their email will be sent overnight' do
+              do_patch
+              expect(flash[:notice]).to eq 'Email will be sent overnight'
+            end
+
+            it 'stores the supplied scheduled debate date against the petition in the db' do
+              do_patch
+              petition.reload
+              expect(petition.scheduled_debate_date).to eq Date.parse('2014-12-01')
+            end
+
+            describe "emails out debate scheduled response" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "queues a job to process the emails" do
+                assert_enqueued_jobs 1 do
+                  do_patch
+                end
+              end
+
+              it "stamps the 'debate_scheduled' email sent timestamp on each signature when the job runs" do
+                perform_enqueued_jobs do
+                  do_patch
+                  petition.reload
+                  petition_timestamp = petition.get_email_requested_at_for('debate_scheduled')
+                  expect(petition_timestamp).not_to be_nil
+                  petition.signatures.validated.subscribed.each do |signature|
+                    expect(signature.get_email_sent_at_for('debate_scheduled')).to eq(petition_timestamp)
+                  end
+                end
+              end
+
+              it "should email out to the validated signees who have opted in when the delayed job runs" do
+                ActionMailer::Base.deliveries.clear
+                perform_enqueued_jobs do
+                  do_patch
+                  expect(ActionMailer::Base.deliveries.length).to eq 4
+                  expect(ActionMailer::Base.deliveries.map(&:to)).to eq([
+                    [petition.creator.email],
+                    ['laura_0@example.com'],
+                    ['laura_1@example.com'],
+                    ['laura_2@example.com']
+                  ])
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            before do
+              # NOTE this can't fail as there's no validation
+              allow_any_instance_of(Archived::Petition).to receive(:valid?) do |receiver|
+                receiver.errors.add(:base, 'this is all messed up')
+                false
+              end
+            end
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:petition).errors).to be_present
+            end
+
+            it 'does not store the supplied debate scheduled date in the db' do
+              do_patch
+              petition.reload
+              expect(petition.scheduled_debate_date).to be_nil
+            end
+          end
+        end
+
+        shared_examples_for 'scheduling a debate date' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'stores the supplied schedule date on the petition' do
+            do_patch
+            petition.reload
+            expect(petition.scheduled_debate_date).to eq Date.parse('2014-12-01')
+          end
+        end
+
+        describe 'for an open petition' do
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'scheduling a debate date'
+        end
+      end
+
+      context 'when clicking the Save button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            archived_petition: scheduled_debate_date_attributes,
+            save: "Save"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'scheduling a debate date for a petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their changes were saved' do
+              do_patch
+              expect(flash[:notice]).to eq 'Updated the scheduled debate date successfully'
+            end
+
+            it 'stores the supplied scheduled debate date against the petition in the db' do
+              do_patch
+              petition.reload
+              expect(petition.scheduled_debate_date).to eq Date.parse('2014-12-01')
+            end
+
+            describe "does not email out debate scheduled response" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :validated, attributes)
+                end
+
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+
+                  FactoryGirl.create(:archived_signature, :pending, attributes)
+                end
+
+                petition.reload
+              end
+
+              it "does not queue a job to process the emails" do
+                assert_enqueued_jobs 0 do
+                  do_patch
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            before do
+              # NOTE this can't fail as there's no validation
+              allow_any_instance_of(Archived::Petition).to receive(:valid?) do |receiver|
+                receiver.errors.add(:base, 'this is all messed up')
+                false
+              end
+            end
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:petition).errors).to be_present
+            end
+
+            it 'does not store the supplied debate scheduled date in the db' do
+              do_patch
+              petition.reload
+              expect(petition.scheduled_debate_date).to be_nil
+            end
+          end
+        end
+
+        shared_examples_for 'scheduling a debate date' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'stores the supplied schedule date on the petition' do
+            do_patch
+            petition.reload
+            expect(petition.scheduled_debate_date).to eq Date.parse('2014-12-01')
+          end
+        end
+
+        describe 'for an open petition' do
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a rejected petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :rejected) }
+
+          it_behaves_like 'scheduling a debate date'
+        end
+
+        describe 'for a hidden petition' do
+          let!(:petition) { FactoryGirl.create(:archived_petition, :hidden) }
+
+          it_behaves_like 'scheduling a debate date'
+        end
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -188,8 +188,16 @@ FactoryGirl.define do
     sequence(:email)  { |n| "jo#{n}@public.com" }
     postcode            "SW1A 1AA"
     location_code       "GB"
-    state               Signature::VALIDATED_STATE
+    state               Archived::Signature::VALIDATED_STATE
     unsubscribe_token { Authlogic::Random.friendly_token }
+
+    trait :pending do
+      state Archived::Signature::PENDING_STATE
+    end
+
+    trait :validated do
+      state Archived::Signature::VALIDATED_STATE
+    end
   end
 
   factory :petition do

--- a/spec/models/archived/government_response_spec.rb
+++ b/spec/models/archived/government_response_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Archived::GovernmentResponse, type: :model do
     subject { FactoryGirl.build(:archived_government_response) }
 
     it { is_expected.to validate_presence_of(:petition) }
-    it { is_expected.not_to validate_presence_of(:summary) }
-    it { is_expected.to validate_length_of(:summary).is_at_most(200) }
+    it { is_expected.to validate_presence_of(:summary) }
+    it { is_expected.to validate_length_of(:summary).is_at_most(500) }
     it { is_expected.to validate_length_of(:details).is_at_most(10000) }
   end
 


### PR DESCRIPTION
This is so that the current government can respond and parliament can debate petitions from a previous parliament and update the website.