### PR TITLE
Fix race condition when locking a petition

### DIFF
--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -313,7 +313,7 @@ module Archived
     def checkout!(user, now = Time.current)
       with_lock do
         if locked_by.present? && locked_by != user
-          raise RuntimeError, "Petition already being edited by #{locked_by.pretty_name}"
+          false
         else
           update!(locked_by: user, locked_at: now)
         end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -678,7 +678,7 @@ class Petition < ActiveRecord::Base
   def checkout!(user, now = Time.current)
     with_lock do
       if locked_by.present? && locked_by != user
-        raise RuntimeError, "Petition already being edited by #{locked_by.pretty_name}"
+        false
       else
         update!(locked_by: user, locked_at: now)
       end

--- a/spec/controllers/admin/archived/locks_controller_spec.rb
+++ b/spec/controllers/admin/archived/locks_controller_spec.rb
@@ -143,13 +143,17 @@ RSpec.describe Admin::Archived::LocksController, type: :controller, admin: true 
         it "doesn't update the locked_by association" do
           expect {
             get :create, petition_id: petition.to_param, format: :json
-          }.to raise_error(RuntimeError, /Petition already being edited/)
+          }.not_to change {
+            petition.reload.locked_by
+          }
         end
 
         it "doesn't update the locked_at timestamp" do
           expect {
             get :create, petition_id: petition.to_param, format: :json
-          }.to raise_error(RuntimeError, /Petition already being edited/)
+          }.not_to change {
+            petition.reload.locked_at
+          }
         end
       end
     end

--- a/spec/controllers/admin/locks_controller_spec.rb
+++ b/spec/controllers/admin/locks_controller_spec.rb
@@ -143,13 +143,17 @@ RSpec.describe Admin::LocksController, type: :controller, admin: true do
         it "doesn't update the locked_by association" do
           expect {
             get :create, petition_id: petition.to_param, format: :json
-          }.to raise_error(RuntimeError, /Petition already being edited/)
+          }.not_to change {
+            petition.reload.locked_by
+          }
         end
 
         it "doesn't update the locked_at timestamp" do
           expect {
             get :create, petition_id: petition.to_param, format: :json
-          }.to raise_error(RuntimeError, /Petition already being edited/)
+          }.not_to change {
+            petition.reload.locked_at
+          }
         end
       end
     end

--- a/spec/models/archived/petition_spec.rb
+++ b/spec/models/archived/petition_spec.rb
@@ -941,10 +941,8 @@ RSpec.describe Archived::Petition, type: :model do
       let(:other_user) { FactoryGirl.create(:moderator_user) }
       let(:petition) { FactoryGirl.create(:petition, locked_by: other_user, locked_at: 1.hour.ago) }
 
-      it "raises an error" do
-        expect {
-          petition.checkout!(current_user)
-        }.to raise_error(RuntimeError, /Petition already being edited/)
+      it "returns false" do
+        expect(petition.checkout!(current_user)).to eq(false)
       end
     end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2649,10 +2649,8 @@ RSpec.describe Petition, type: :model do
       let(:other_user) { FactoryGirl.create(:moderator_user) }
       let(:petition) { FactoryGirl.create(:petition, locked_by: other_user, locked_at: 1.hour.ago) }
 
-      it "raises an error" do
-        expect {
-          petition.checkout!(current_user)
-        }.to raise_error(RuntimeError, /Petition already being edited/)
+      it "returns false" do
+        expect(petition.checkout!(current_user)).to eq(false)
       end
     end
 


### PR DESCRIPTION
When two moderators go to edit a petition at the same time they can both try to obtain locks thinking the petition is unlocked. Rather than one of them blowing up with a 500 error just return false and the JSON returned will trigger the JS locking script to automatically popup the petition locked by someone else screen.