### PR TITLE
Upgrade Appsignal and add an admin namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,9 +36,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    appsignal (2.1.0)
+    appsignal (2.3.4)
       rack
-      thread_safe
     arel (6.0.4)
     authlogic (3.4.6)
       activerecord (>= 3.2)
@@ -204,7 +203,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     puma (3.4.0)
-    rack (1.6.7)
+    rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.8)

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -4,10 +4,17 @@ class Admin::AdminController < ApplicationController
   skip_before_action :service_unavailable
   skip_before_action :authenticate
 
+  before_action :set_appsignal_namespace
   before_action :do_not_cache
 
   layout 'admin'
 
   def index
+  end
+
+  private
+
+  def set_appsignal_namespace
+    Appsignal.set_namespace("admin")
   end
 end


### PR DESCRIPTION
Version 2.2 of the Appsignal gem adds support for custom namespaces so upgrade and add an admin namespace to separate out those actions from the public website where we want to focus any performance work.