### PR TITLE
Capture exception when petition creator is updated

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -337,6 +337,16 @@ class Signature < ActiveRecord::Base
     update seen_signed_confirmation_page: true
   end
 
+  def save(*args)
+    super
+  rescue ActiveRecord::RecordNotUnique => e
+    if creator?
+      errors.add(:name, :already_signed, name: name, email: email) and return false
+    else
+      raise e
+    end
+  end
+
   def unsubscribe!(token)
     if unsubscribed?
       errors.add(:base, "Already Unsubscribed")

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -31,7 +31,7 @@
         <%= f.text_area :additional_details, tabindex: increment, rows: 7, class: 'form-control', disabled: @petition.editing_disabled? %>
       <% end %>
 
-      <%= form_row for: [f.object, :creator_name] do %>
+      <%= form_row for: [@petition.creator, :name] do %>
         <%= f.fields_for :creator do |c| %>
           <%= c.label :name, "Creator", class: 'form-label' %>
           <%= error_messages_for_field @petition.creator, :name %>

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -51,6 +51,8 @@ en-GB:
           attributes:
             state:
               inclusion: "State '%{value}' not recognised"
+            name:
+              already_signed: "%{name} has already signed this petition using %{email}"
 
         sponsor:
           attributes:


### PR DESCRIPTION
When a petition creator's name is updated to match an existing signature then an ActiveRecord::RecordNotUnique exception will be raised. We can capture this exception for creator signatures and turn it into a form error to present to the moderators rather than a 500 error page.