### PR TITLE
Improve moderation

### DIFF
--- a/app/assets/stylesheets/petitions/admin/views/_hub.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_hub.scss
@@ -76,7 +76,22 @@
           float: right;
         }
 
+        small {
+          @include core-14;
+          line-height: 40px;
+          float: right;
+          margin-right: $gutter-half;
+        }
+
         .tagged-in-moderation {
+          background-color: $grey-1;
+
+          a {
+            color: $white;
+          }
+        }
+
+        .untagged-in-moderation {
           background-color: $grey-3;
 
           a {
@@ -85,8 +100,8 @@
         }
 
         div {
-          line-height: 50px;
-          height: 50px;
+          line-height: 40px;
+          height: 40px;
         }
 
         a {

--- a/app/controllers/admin/archived/petitions_controller.rb
+++ b/app/controllers/admin/archived/petitions_controller.rb
@@ -32,7 +32,9 @@ class Admin::Archived::PetitionsController < Admin::AdminController
   end
 
   def scope
-    if params[:tags].present?
+    if params[:match] == "none"
+      @parliament.petitions.untagged
+    elsif params[:tags].present?
       if params[:match] == "all"
         @parliament.petitions.tagged_with_all(params[:tags])
       else

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -31,7 +31,9 @@ class Admin::PetitionsController < Admin::AdminController
   end
 
   def scope
-    if params[:tags].present?
+    if params[:match] == "none"
+      Petition.untagged
+    elsif params[:tags].present?
       if params[:match] == "all"
         Petition.tagged_with_all(params[:tags])
       else

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -21,7 +21,9 @@ class Admin::SearchesController < Admin::AdminController
 
   def search_params
     if petition_search?
-      if params[:tags].present?
+      if params[:match] == "none"
+        params.slice(:q, :match)
+      elsif params[:tags].present?
         params.slice(:q, :tags, :match)
       else
         params.slice(:q)

--- a/app/helpers/admin_hub_helper.rb
+++ b/app/helpers/admin_hub_helper.rb
@@ -15,6 +15,14 @@ module AdminHubHelper
     @recently_in_moderation_count ||= Petition.recently_in_moderation.count
   end
 
+  def recently_in_moderation_untagged_count
+    @recently_in_moderation_untagged_count ||= Petition.untagged.recently_in_moderation.count
+  end
+
+  def nearly_overdue_in_moderation_untagged_count
+    @nearly_overdue_in_moderation_untagged_count ||= Petition.untagged.nearly_overdue_in_moderation.count
+  end
+
   def nearly_overdue_in_moderation_count
     @nearly_overdue_in_moderation_count ||= Petition.nearly_overdue_in_moderation.count
   end
@@ -23,8 +31,16 @@ module AdminHubHelper
     @overdue_in_moderation_count ||= Petition.overdue_in_moderation.count
   end
 
+  def overdue_in_moderation_untagged_count
+    @overdue_in_moderation_untagged_count ||= Petition.untagged.overdue_in_moderation.count
+  end
+
   def tagged_in_moderation_count
     @tagged_in_moderation_count ||= Petition.tagged_in_moderation.count
+  end
+
+  def untagged_in_moderation_count
+    @untagged_in_moderation_count ||= Petition.untagged_in_moderation.count
   end
 
   def summary_class_name_for_in_moderation

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -63,6 +63,7 @@ class Petition < ActiveRecord::Base
   facet :nearly_overdue_in_moderation, -> { nearly_overdue_in_moderation.by_most_recent_moderation_threshold_reached }
   facet :overdue_in_moderation,        -> { overdue_in_moderation.by_most_recent_moderation_threshold_reached }
   facet :tagged_in_moderation,         -> { tagged_in_moderation.by_most_recent_moderation_threshold_reached }
+  facet :untagged_in_moderation,       -> { untagged_in_moderation.by_most_recent_moderation_threshold_reached }
 
   has_one :creator, -> { where(creator: true) }, class_name: 'Signature'
   accepts_nested_attributes_for :creator, update_only: true
@@ -375,6 +376,10 @@ class Petition < ActiveRecord::Base
 
     def tagged_in_moderation
       tagged.in_moderation
+    end
+
+    def untagged_in_moderation
+      untagged.in_moderation
     end
 
     private

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -16,7 +16,8 @@
         <p>
           <small>
             Match <label><input type="radio" name="match" value="any" checked /> any selected tags</label>
-            or <label><input type="radio" name="match" value="all" /> all selected tags</label>
+            <label><input type="radio" name="match" value="all" /> all selected tags</label>
+            <label><input type="radio" name="match" value="none" /> no tags</label>
           </small>
         </p>
         <div class="inline tag-list">
@@ -64,25 +65,43 @@
           <div class="details">
             <div class="recently-in-moderation queue-stable">
               <%= link_to admin_petitions_url(state: :recently_in_moderation) do %>
-                <%= recently_in_moderation_count %><span class="label">0-5 days</span>
+                <%= recently_in_moderation_count %>
+                <% unless recently_in_moderation_untagged_count.zero? %>
+                 / <%= recently_in_moderation_untagged_count %>
+                <% end %>
+                <span class="label">0-5 days</span>
               <% end %>
             </div>
 
             <div class="nearly-overdue-in-moderation queue-caution">
               <%= link_to admin_petitions_url(state: :nearly_overdue_in_moderation) do %>
-                <%= nearly_overdue_in_moderation_count %><span class="label">6-7 days</span>
+                <%= nearly_overdue_in_moderation_count %>
+                <span class="label">6-7 days</span>
+                <% unless nearly_overdue_in_moderation_untagged_count.zero? %>
+                 / <%= nearly_overdue_in_moderation_untagged_count %>
+                <% end %>
               <% end %>
             </div>
 
             <div class="overdue-in-moderation queue-danger">
               <%= link_to admin_petitions_url(state: :overdue_in_moderation) do %>
-                <%= overdue_in_moderation_count %><span class="label">&gt; 7 days</span>
+                <%= overdue_in_moderation_count %>
+                <span class="label">&gt; 7 days</span>
+                <% unless overdue_in_moderation_untagged_count.zero? %>
+                  <small>(<%= overdue_in_moderation_untagged_count %> untagged)</small>
+                <% end %>
               <% end %>
             </div>
 
             <div class="tagged-in-moderation">
               <%= link_to admin_petitions_url(state: :tagged_in_moderation) do %>
                 <%= tagged_in_moderation_count %><span class="label">Tagged</span>
+              <% end %>
+            </div>
+
+            <div class="untagged-in-moderation">
+              <%= link_to admin_petitions_url(state: :untagged_in_moderation) do %>
+                <%= untagged_in_moderation_count %><span class="label">Untagged</span>
               <% end %>
             </div>
           </div>

--- a/app/views/admin/archived/petitions/index.html.erb
+++ b/app/views/admin/archived/petitions/index.html.erb
@@ -22,12 +22,13 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <%= content_tag(:details, class: "tag-selector", open: selected_tags.present?) do %>
+      <%= content_tag(:details, class: "tag-selector", open: selected_tags.present? || params[:match] == "none") do %>
         <summary><span>Tags</span></summary>
         <p>
           <small>
-            Match <label><%= radio_button_tag :match, "any", params[:match] != "all" %> any selected tags</label>
-            or <label><%= radio_button_tag :match, "all", params[:match] == "all" %> all selected tags</label>
+            Match <label><%= radio_button_tag :match, "any", %w[all none].exclude?(params[:match]) %> any selected tags</label>
+            <label><%= radio_button_tag :match, "all", params[:match] == "all" %> all selected tags</label>
+            <label><%= radio_button_tag :match, "none", params[:match] == "none" %> no tags</label>
           </small>
         </p>
         <div class="inline tag-list">

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -17,6 +17,8 @@
   <dt>Created on</dt>
   <dd><%= date_time_format(@petition.created_at) %></dd>
 
+  <dt>Sponsored on</dt>
+  <dd><%= date_time_format(@petition.moderation_threshold_reached_at) %></dd>
 <% else %>
   <dt>Deadline</dt>
   <dd><%= date_format_admin(@petition.deadline) %></dd>

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -18,12 +18,13 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <%= content_tag(:details, class: "tag-selector", open: selected_tags.present?) do %>
+      <%= content_tag(:details, class: "tag-selector", open: selected_tags.present? || params[:match] == "none") do %>
         <summary><span>Tags</span></summary>
         <p>
           <small>
-            Match <label><%= radio_button_tag :match, "any", params[:match] != "all" %> any selected tags</label>
-            or <label><%= radio_button_tag :match, "all", params[:match] == "all" %> all selected tags</label>
+            Match <label><%= radio_button_tag :match, "any", params[:match] == "any" %> any selected tags</label>
+            <label><%= radio_button_tag :match, "all", params[:match] == "all" %> all selected tags</label>
+            <label><%= radio_button_tag :match, "none", params[:match] == "none" %> no tags</label>
           </small>
         </p>
         <div class="inline tag-list">

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -74,6 +74,7 @@ en-GB:
         - :nearly_overdue_in_moderation
         - :overdue_in_moderation
         - :tagged_in_moderation
+        - :untagged_in_moderation
         - :open
         - :closed
         - :rejected
@@ -104,6 +105,7 @@ en-GB:
           nearly_overdue_in_moderation: "Awaiting moderation - nearly overdue (%{quantity})"
           overdue_in_moderation: "Awaiting moderation - overdue (%{quantity})"
           tagged_in_moderation: "Awaiting moderation - tagged (%{quantity})"
+          untagged_in_moderation: "Awaiting moderation - untagged (%{quantity})"
           open: "Open (%{quantity})"
           closed: "Closed (%{quantity})"
           rejected: "Rejected (%{quantity})"

--- a/spec/controllers/admin/searches_controller_spec.rb
+++ b/spec/controllers/admin/searches_controller_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Admin::SearchesController, type: :controller, admin: true do
         end
       end
 
+      context "when searching for petitions with no tags" do
+        it "redirects to the petitions search url" do
+          get :show, type: "petition", q: "foo", match: "none"
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions?match=none&q=foo")
+        end
+      end
+
       context "when searching for signatures" do
         it "redirects to the signatures search url" do
           get :show, type: "signature", q: "foo"

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe AdminHelper, type: :helper do
       {
         all: 1, collecting_sponsors: 2, in_moderation: 3,
         recently_in_moderation: 4, nearly_overdue_in_moderation: 5,
-        overdue_in_moderation: 6, tagged_in_moderation: 7,
-        open: 8, closed: 9, rejected: 10, hidden: 11, stopped: 12,
-        awaiting_response: 13, with_response: 14, awaiting_debate_date: 15,
-        with_debate_outcome: 16, in_debate_queue: 17
+        overdue_in_moderation: 6, tagged_in_moderation: 7, untagged_in_moderation: 8,
+        open: 9, closed: 10, rejected: 11, hidden: 12, stopped: 13,
+        awaiting_response: 14, with_response: 15, awaiting_debate_date: 16,
+        with_debate_outcome: 17, in_debate_queue: 18
       }
     end
 
     subject { helper.admin_petition_facets_for_select(facets, selected) }
 
     it "generates the correct number of options" do
-      expect(subject).to have_css("option", count: 17)
+      expect(subject).to have_css("option", count: 18)
     end
 
     it "generates the correct option for 'all'" do
@@ -49,44 +49,48 @@ RSpec.describe AdminHelper, type: :helper do
       expect(subject).to have_css("option:nth-of-type(7)[value='tagged_in_moderation']", text: "Awaiting moderation - tagged (7)")
     end
 
+    it "generates the correct option for 'untagged_in_moderation'" do
+      expect(subject).to have_css("option:nth-of-type(8)[value='untagged_in_moderation']", text: "Awaiting moderation - untagged (8)")
+    end
+
     it "generates the correct option for 'open'" do
-      expect(subject).to have_css("option:nth-of-type(8)[value='open']", text: "Open (8)")
+      expect(subject).to have_css("option:nth-of-type(9)[value='open']", text: "Open (9)")
     end
 
     it "generates the correct option for 'closed'" do
-      expect(subject).to have_css("option:nth-of-type(9)[value='closed']", text: "Closed (9)")
+      expect(subject).to have_css("option:nth-of-type(10)[value='closed']", text: "Closed (10)")
     end
 
     it "generates the correct option for 'rejected'" do
-      expect(subject).to have_css("option:nth-of-type(10)[value='rejected']", text: "Rejected (10)")
+      expect(subject).to have_css("option:nth-of-type(11)[value='rejected']", text: "Rejected (11)")
     end
 
     it "generates the correct option for 'hidden'" do
-      expect(subject).to have_css("option:nth-of-type(11)[value='hidden']", text: "Hidden (11)")
+      expect(subject).to have_css("option:nth-of-type(12)[value='hidden']", text: "Hidden (12)")
     end
 
     it "generates the correct option for 'hidden'" do
-      expect(subject).to have_css("option:nth-of-type(12)[value='stopped']", text: "Stopped (12)")
+      expect(subject).to have_css("option:nth-of-type(13)[value='stopped']", text: "Stopped (13)")
     end
 
     it "generates the correct option for 'awaiting_response'" do
-      expect(subject).to have_css("option:nth-of-type(13)[value='awaiting_response']", text: "Awaiting a government response (13)")
+      expect(subject).to have_css("option:nth-of-type(14)[value='awaiting_response']", text: "Awaiting a government response (14)")
     end
 
     it "generates the correct option for 'with_response'" do
-      expect(subject).to have_css("option:nth-of-type(14)[value='with_response']", text: "With a government response (14)")
+      expect(subject).to have_css("option:nth-of-type(15)[value='with_response']", text: "With a government response (15)")
     end
 
     it "generates the correct option for 'awaiting_debate_date'" do
-      expect(subject).to have_css("option:nth-of-type(15)[value='awaiting_debate_date']", text: "Awaiting a debate in parliament (15)")
+      expect(subject).to have_css("option:nth-of-type(16)[value='awaiting_debate_date']", text: "Awaiting a debate in parliament (16)")
     end
 
     it "generates the correct option for 'with_debate_outcome'" do
-      expect(subject).to have_css("option:nth-of-type(16)[value='with_debate_outcome']", text: "Has been debated in parliament (16)")
+      expect(subject).to have_css("option:nth-of-type(17)[value='with_debate_outcome']", text: "Has been debated in parliament (17)")
     end
 
     it "generates the correct option for 'in_debate_queue'" do
-      expect(subject).to have_css("option:nth-of-type(17)[value='in_debate_queue']", text: "In debate queue (17)")
+      expect(subject).to have_css("option:nth-of-type(18)[value='in_debate_queue']", text: "In debate queue (18)")
     end
 
     it "marks the correct option as selected" do

--- a/spec/helpers/admin_hub_helper_spec.rb
+++ b/spec/helpers/admin_hub_helper_spec.rb
@@ -6,36 +6,59 @@ RSpec.describe AdminHubHelper, type: :helper do
     let!(:petition_recently_in_moderation) { FactoryGirl.create(:sponsored_petition, :recent) }
     let!(:petition_nearly_overdue_moderation) { FactoryGirl.create(:sponsored_petition, :nearly_overdue) }
     let!(:petition_overdue_moderation) { FactoryGirl.create(:sponsored_petition, :overdue) }
-    let!(:tagged_in_moderation_petition) { FactoryGirl.create(:validated_petition, tags: [tag.id]) }
-    let!(:sponsored_petition) { FactoryGirl.create(:sponsored_petition, tags: [tag.id]) }
+    let!(:tagged_in_moderation_petition) { FactoryGirl.create(:sponsored_petition, tags: [tag.id]) }
 
     describe "in_moderation_count" do
-      it 'returns the number in moderation' do
+      it "returns the number in moderation" do
         expect(helper.in_moderation_count).to eq 4
       end
     end
 
     describe "recently_in_moderation_count" do
-      it 'returns the number recently in moderation' do
+      it "returns the number recently in moderation" do
         expect(helper.recently_in_moderation_count).to eq 2
       end
     end
 
+    describe "recently_in_moderation_untagged_count" do
+      it "returns the number recently in moderation that are untagged" do
+        expect(helper.recently_in_moderation_untagged_count).to eq 1
+      end
+    end
+
     describe "nearly_overdue_in_moderation_count" do
-      it 'returns the number nearly overdue moderation' do
+      it "returns the number nearly overdue moderation" do
         expect(helper.nearly_overdue_in_moderation_count).to eq 1
       end
     end
 
+    describe "nearly_overdue_in_moderation_untagged_count" do
+      it "returns the number nearly overdue moderation that are untagged" do
+        expect(helper.nearly_overdue_in_moderation_untagged_count).to eq 1
+      end
+    end
+
     describe "overdue_in_moderation_count" do
-      it 'returns the number overdue moderation' do
+      it "returns the number overdue moderation" do
         expect(helper.overdue_in_moderation_count).to eq 1
       end
     end
 
+    describe "overdue_in_moderation_untagged_count" do
+      it "returns the number overdue moderation that are untagged" do
+        expect(helper.overdue_in_moderation_untagged_count).to eq 1
+      end
+    end
+
     describe "tagged_in_moderation_count" do
-      it 'returns the number of tagged petitions' do
+      it "returns the number of tagged petitions" do
         expect(helper.tagged_in_moderation_count).to eq 1
+      end
+    end
+
+    describe "untagged_in_moderation_count" do
+      it "returns the number of untagged petitions" do
+        expect(helper.untagged_in_moderation_count).to eq 3
       end
     end
   end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -738,6 +738,23 @@ RSpec.describe Petition, type: :model do
         expect(Petition.tagged_in_moderation).not_to include(recent_petition, overdue_petition, nearly_overdue_petition)
       end
     end
+
+    describe ".untagged_in_moderation" do
+      let!(:recent_petition) { FactoryGirl.create(:sponsored_petition, :recent) }
+      let!(:overdue_petition) { FactoryGirl.create(:sponsored_petition, :overdue) }
+      let!(:nearly_overdue_petition) { FactoryGirl.create(:sponsored_petition, :nearly_overdue) }
+      let!(:tagged_recent_petition) { FactoryGirl.create(:sponsored_petition, :recent, :tagged) }
+      let!(:tagged_overdue_petition) { FactoryGirl.create(:sponsored_petition, :overdue, :tagged) }
+      let!(:tagged_nearly_overdue_petition) { FactoryGirl.create(:sponsored_petition, :nearly_overdue, :tagged) }
+
+      it "returns petitions that are in the moderation queue and are untagged" do
+        expect(Petition.untagged_in_moderation).to include(recent_petition, overdue_petition, nearly_overdue_petition)
+      end
+
+      it "doesn't return petitions that are in the moderation queue and are tagged" do
+        expect(Petition.untagged_in_moderation).not_to include(tagged_recent_petition, tagged_overdue_petition, tagged_nearly_overdue_petition)
+      end
+    end
   end
 
   it_behaves_like "a taggable model"


### PR DESCRIPTION
* Adds untagged counts to the admin hub
* Adds the ability to search for untagged petitions in any scope
* Adds the date/time when the petition passed the sponsored threshold to the moderation page