### PR TITLE
Add markdown formatting to petition emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'logstash-logger'
 gem 'jbuilder'
 gem 'paperclip'
 gem 'maxminddb'
+gem 'redcarpet'
 
 gem 'aws-sdk', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.0)
+    redcarpet (3.4.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -337,6 +338,7 @@ DEPENDENCIES
   puma
   rails (= 4.2.10)
   rake
+  redcarpet
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers

--- a/app/assets/stylesheets/petitions/views/_petition-show.scss
+++ b/app/assets/stylesheets/petitions/views/_petition-show.scss
@@ -73,3 +73,69 @@
     margin-top: 10px;
   }
 }
+
+.about-item-other-business {
+  ul {
+    list-style-type: disc;
+    padding-left: 20px;
+  }
+
+  ol {
+    list-style-type: decimal;
+    padding-left: 20px;
+
+    @include ie-lte(7) {
+      padding-left: 28px;
+    }
+  }
+
+  ul, ol {
+    margin-top: em(5, 16);
+    margin-bottom: em(10, 16);
+
+    @include media(tablet) {
+      margin-top: em(10, 16);
+      margin-bottom: em(10, 16);
+    }
+
+    & li {
+      margin: 0 0 em(2, 16);
+
+      @include media(tablet) {
+        margin: 0 0 em(2, 19);
+      }
+    }
+  }
+
+  h3 {
+    margin: em(15, 16) 0 em(5, 16);
+
+    @include media(tablet) {
+      margin: em(15, 19) 0 em(5, 19);
+    }
+  }
+
+  p {
+    margin: 0 0 em(10, 16);
+
+    @include media(tablet) {
+      margin: 0 0 em(10, 19);
+    }
+  }
+
+  .panel-indent {
+    margin: 0;
+  }
+
+  hr {
+    height: 0px;
+    border: none;
+    border-top: 1px solid $grey-2;
+
+    margin: em(15, 16) 0;
+
+    @include media(tablet) {
+      margin: em(15, 19) 0;
+    }
+  }
+}

--- a/app/controllers/admin/archived/petition_emails_controller.rb
+++ b/app/controllers/admin/archived/petition_emails_controller.rb
@@ -11,7 +11,11 @@ class Admin::Archived::PetitionEmailsController < Admin::AdminController
     if @email.update(email_params)
       if send_email_to_petitioners?
         schedule_email_petitioners_job
+        send_preview_email
         message = :email_sent_overnight
+      elsif send_preview_email?
+        send_preview_email
+        message = :preview_email_sent
       else
         message = :petition_email_created
       end
@@ -29,7 +33,11 @@ class Admin::Archived::PetitionEmailsController < Admin::AdminController
     if @email.update(email_params)
       if send_email_to_petitioners?
         schedule_email_petitioners_job
+        send_preview_email
         message = :email_sent_overnight
+      elsif send_preview_email?
+        send_preview_email
+        message = :preview_email_sent
       else
         message = :petition_email_updated
       end
@@ -76,8 +84,15 @@ class Admin::Archived::PetitionEmailsController < Admin::AdminController
     params.key?(:save_and_email)
   end
 
+  def send_preview_email?
+    params.key?(:save_and_preview)
+  end
+
   def schedule_email_petitioners_job
     ::Archived::EmailPetitionersJob.run_later_tonight(petition: @petition, email: @email)
+  end
+
+  def send_preview_email
     ::Archived::PetitionMailer.email_signer(@petition, feedback_signature, @email).deliver_now
   end
 end

--- a/app/controllers/admin/petition_emails_controller.rb
+++ b/app/controllers/admin/petition_emails_controller.rb
@@ -11,7 +11,11 @@ class Admin::PetitionEmailsController < Admin::AdminController
     if @email.update(email_params)
       if send_email_to_petitioners?
         schedule_email_petitioners_job
+        send_preview_email
         message = :email_sent_overnight
+      elsif send_preview_email?
+        send_preview_email
+        message = :preview_email_sent
       else
         message = :petition_email_created
       end
@@ -29,7 +33,11 @@ class Admin::PetitionEmailsController < Admin::AdminController
     if @email.update(email_params)
       if send_email_to_petitioners?
         schedule_email_petitioners_job
+        send_preview_email
         message = :email_sent_overnight
+      elsif send_preview_email?
+        send_preview_email
+        message = :preview_email_sent
       else
         message = :petition_email_updated
       end
@@ -76,8 +84,15 @@ class Admin::PetitionEmailsController < Admin::AdminController
     params.key?(:save_and_email)
   end
 
+  def send_preview_email?
+    params.key?(:save_and_preview)
+  end
+
   def schedule_email_petitioners_job
     EmailPetitionersJob.run_later_tonight(petition: @petition, email: @email)
+  end
+
+  def send_preview_email
     PetitionMailer.email_signer(@petition, feedback_signature, @email).deliver_now
   end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,47 @@
+require 'redcarpet/render_strip'
+
+module MarkdownHelper
+  HTML_DEFAULTS = {
+    escape_html: false, filter_html: false,
+    hard_wrap: true, xhtml: true, safe_links_only: true,
+    no_styles: true, no_images: true, no_links: false,
+    with_toc_data: false, prettify: false, link_attributes: {}
+  }
+
+  PARSER_DEFAULTS = {
+    no_intra_emphasis: true, tables: false, fenced_code_blocks: false,
+    autolink: true, disable_indented_code_blocks: false, strikethrough: true,
+    lax_spacing: false, space_after_headers: true, superscript: true,
+    underline: false, highlight: false, quote: false, footnotes: false
+  }
+
+  def markdown_to_html(markup, options = {})
+    markdown_parser(html_renderer(options), options).render(markup).html_safe
+  end
+
+  def markdown_to_text(markup, options = {})
+    markdown_parser(text_renderer, options).render(markup).html_safe
+  end
+
+  private
+
+  def html_renderer(options)
+    Redcarpet::Render::HTML.new(options_for_renderer(options))
+  end
+
+  def text_renderer
+    Redcarpet::Render::StripDown.new
+  end
+
+  def markdown_parser(renderer, options)
+    Redcarpet::Markdown.new(renderer, options_for_parser(options))
+  end
+
+  def options_for_parser(options)
+    PARSER_DEFAULTS.merge(options.slice(*PARSER_DEFAULTS.keys))
+  end
+
+  def options_for_renderer(options)
+    HTML_DEFAULTS.merge(options.slice(*HTML_DEFAULTS.keys))
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,7 @@ class ApplicationMailer < ActionMailer::Base
   default_url_options[:protocol] = Site.email_protocol
   default from: ->(email){ Site.email_from }
 
-  helper :date_time, :rejection, :auto_link
+  helper :date_time, :rejection, :auto_link, :markdown
 
   layout 'default_mail'
 end

--- a/app/views/admin/archived/petition_emails/_petition_action_email_petitioners.html.erb
+++ b/app/views/admin/archived/petition_emails/_petition_action_email_petitioners.html.erb
@@ -38,7 +38,8 @@
   <% end %>
 
   <%= email_petitioners_with_count_submit_button(f, petition) %>
-  <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+  <%= f.submit "Save and preview", name: 'save_and_preview', class: 'button-secondary' %>
+  <%= f.submit "Save", name: 'save', class: 'button-secondary' %>
 
 <% end -%>
 

--- a/app/views/admin/archived/petition_emails/edit.html.erb
+++ b/app/views/admin/archived/petition_emails/edit.html.erb
@@ -18,7 +18,8 @@
       <% end %>
 
       <%= email_petitioners_with_count_submit_button(f, @petition) %>
-      <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+      <%= f.submit "Save and preview", name: 'save_and_preview', class: 'button-secondary' %>
+      <%= f.submit "Save", name: 'save', class: 'button-secondary' %>
 
     <% end -%>
   </div>

--- a/app/views/admin/petition_emails/_petition_action_email_petitioners.html.erb
+++ b/app/views/admin/petition_emails/_petition_action_email_petitioners.html.erb
@@ -42,7 +42,8 @@
   <% if @petition.editing_disabled? %>
     <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
   <% else %>
-    <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+    <%= f.submit "Save and preview", name: 'save_and_preview', class: 'button-secondary' %>
+    <%= f.submit "Save", name: 'save', class: 'button-secondary' %>
   <% end %>
 <% end -%>
 

--- a/app/views/admin/petition_emails/edit.html.erb
+++ b/app/views/admin/petition_emails/edit.html.erb
@@ -22,7 +22,8 @@
       <% if @petition.editing_disabled? %>
         <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
       <% else %>
-        <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+        <%= f.submit "Save and preview", name: 'save_and_preview', class: 'button-secondary' %>
+        <%= f.submit "Save", name: 'save', class: 'button-secondary' %>
       <% end %>
     <% end -%>
   </div>

--- a/app/views/archived/petition_mailer/email_creator.html.erb
+++ b/app/views/archived/petition_mailer/email_creator.html.erb
@@ -7,7 +7,7 @@
 <p>You recently created the petition “<%= @petition.action %>”:<br />
 <%= link_to nil, archived_petition_url(@petition) %></p>
 
-<%= auto_link(simple_format(h(@email.body))) %>
+<%= markdown_to_html(@email.body) %>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/archived/petition_mailer/email_creator.text.erb
+++ b/app/views/archived/petition_mailer/email_creator.text.erb
@@ -7,7 +7,7 @@ Dear <%= @signature.name %>,
 You recently created the petition “<%= @petition.action %>”:
 <%= archived_petition_url(@petition) %>
 
-<%= @email.body %>
+<%= markdown_to_text(@email.body) %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/archived/petition_mailer/email_signer.html.erb
+++ b/app/views/archived/petition_mailer/email_signer.html.erb
@@ -7,7 +7,7 @@
 <p>You recently signed the petition “<%= @petition.action %>”:<br />
 <%= link_to nil, archived_petition_url(@petition) %></p>
 
-<%= auto_link(simple_format(h(@email.body))) %>
+<%= markdown_to_html(@email.body) %>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/archived/petition_mailer/email_signer.text.erb
+++ b/app/views/archived/petition_mailer/email_signer.text.erb
@@ -7,7 +7,7 @@ Dear <%= @signature.name %>,
 You recently signed the petition “<%= @petition.action %>”:
 <%= archived_petition_url(@petition) %>
 
-<%= @email.body %>
+<%= markdown_to_text(@email.body) %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -171,7 +171,7 @@
           <details>
             <summary><span class="summary"><%= email.subject %></span></summary>
             <div class="panel-indent panel-no-border">
-              <%= auto_link(simple_format(h(email.body)), html: { rel: 'nofollow' }) %>
+              <%= markdown_to_html(email.body, link_attributes: { rel: 'nofollow' }) %>
             </div>
           </details>
         <% end %>

--- a/app/views/petition_mailer/email_creator.html.erb
+++ b/app/views/petition_mailer/email_creator.html.erb
@@ -7,7 +7,7 @@
 <p>You recently created the petition “<%= @petition.action %>”:<br />
 <%= link_to nil, petition_url(@petition) %></p>
 
-<%= auto_link(simple_format(h(@email.body))) %>
+<%= markdown_to_html(@email.body) %>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/email_creator.text.erb
+++ b/app/views/petition_mailer/email_creator.text.erb
@@ -7,7 +7,7 @@ Dear <%= @signature.name %>,
 You recently created the petition “<%= @petition.action %>”:
 <%= petition_url(@petition) %>
 
-<%= @email.body %>
+<%= markdown_to_text(@email.body) %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petition_mailer/email_signer.html.erb
+++ b/app/views/petition_mailer/email_signer.html.erb
@@ -7,7 +7,7 @@
 <p>You recently signed the petition “<%= @petition.action %>”:<br />
 <%= link_to nil, petition_url(@petition) %></p>
 
-<%= auto_link(simple_format(h(@email.body))) %>
+<%= markdown_to_html(@email.body) %>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/email_signer.text.erb
+++ b/app/views/petition_mailer/email_signer.text.erb
@@ -7,7 +7,7 @@ Dear <%= @signature.name %>,
 You recently signed the petition “<%= @petition.action %>”:
 <%= petition_url(@petition) %>
 
-<%= @email.body %>
+<%= markdown_to_text(@email.body) %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petitions/_other_business_details.html.erb
+++ b/app/views/petitions/_other_business_details.html.erb
@@ -6,7 +6,7 @@
       <details>
         <summary><span class="summary"><%= email.subject %></span></summary>
         <div class="panel-indent panel-no-border">
-          <%= auto_link(simple_format(h(email.body)), html: { rel: 'nofollow' }) %>
+          <%= markdown_to_html(email.body, link_attributes: { rel: 'nofollow' }) %>
         </div>
       </details>
     <% end %>

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -68,6 +68,7 @@ en-GB:
       petition_email_not_deleted: "Unable to delete other parliamentary business - please contact support"
       petition_not_found: "Cannot find petition with id: %{query}"
       petition_updated: "Petition has been successfully updated"
+      preview_email_sent: "Preview email successfully sent"
       rate_limits_updated: "Rate limits updated successfully"
       signature_validated: "Signature validated successfully"
       signature_not_validated: "Signature could not be validated - please contact support"

--- a/features/admin/petition_email.feature
+++ b/features/admin/petition_email.feature
@@ -22,6 +22,24 @@ Feature: Emailing petitioner supporters
     And all the signatories of the petition should have been emailed with the update
     And the feedback email address should have been emailed a copy
 
+  Scenario: Previewing an email to all petitioners
+    Given an open petition "Ban Badger Baiting" with some signatures
+    And I am logged in as a sysadmin with the email "admin@example.com", first_name "Admin", last_name "User"
+    When I am on the admin all petitions page
+    And I follow "Ban Badger Baiting"
+    And I follow "Other parliamentary business"
+    Then I should be on the admin email petitioners form page for "Ban Badger Baiting"
+    And the markup should be valid
+    When I press "Save"
+    Then the petition should not have any emails
+    And I should see an error
+    When I fill in the email details
+    And press "Save and preview"
+    Then the petition should have the email details I provided
+    And the petition creator should not have been emailed with the update
+    And all the signatories of the petition should not have been emailed with the update
+    And the feedback email address should have been emailed a copy
+
   Scenario: Saving an email to all petitioners
     Given an open petition "Ban Badger Baiting" with some signatures
     And I am logged in as a sysadmin with the email "admin@example.com", first_name "Admin", last_name "User"
@@ -30,11 +48,11 @@ Feature: Emailing petitioner supporters
     And I follow "Other parliamentary business"
     Then I should be on the admin email petitioners form page for "Ban Badger Baiting"
     And the markup should be valid
-    When I press "Save without emailing"
+    When I press "Save"
     Then the petition should not have any emails
     And I should see an error
     When I fill in the email details
-    And press "Save without emailing"
+    And press "Save"
     Then the petition should have the email details I provided
     And the petition creator should not have been emailed with the update
     And all the signatories of the petition should not have been emailed with the update
@@ -53,7 +71,7 @@ Feature: Emailing petitioner supporters
     When I press "Edit"
     Then I should see "Edit other parliamentary business"
     When I fill in "Subject" with "This will not be debated"
-    And I press "Save without emailing"
+    And I press "Save"
     Then I should see "Updated other parliamentary business successfully"
     When I follow "Other parliamentary business"
     Then I should see "This will not be debated"

--- a/spec/controllers/admin/petition_emails_controller_spec.rb
+++ b/spec/controllers/admin/petition_emails_controller_spec.rb
@@ -431,6 +431,142 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           it_behaves_like 'trying to email supporters of a petition in the wrong state'
         end
       end
+
+      context 'when clicking the Preview button' do
+        def do_post(overrides = {})
+          params = {
+            petition_id: petition.id,
+            petition_email: petition_email_attributes,
+            save_and_preview: "Save and preview"
+          }
+
+          post :create, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_post
+            expect(assigns(:petition)).to eq petition
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_post
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their changes were saved' do
+              do_post
+              expect(flash[:notice]).to eq 'Preview email successfully sent'
+            end
+
+            it 'stores the supplied email details in the db' do
+              do_post
+              petition.reload
+              email = petition.emails.last
+              expect(email).to be_present
+              expect(email.subject).to eq "Petition email subject"
+              expect(email.body).to eq "Petition email body"
+              expect(email.sent_by).to eq user.pretty_name
+            end
+
+            context "does not email out the petition email" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+                  s = FactoryBot.create(:pending_signature, attributes)
+                  s.validate!
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  s = FactoryBot.create(:pending_signature, attributes)
+                  s.validate!
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+                  FactoryBot.create(:pending_signature, attributes)
+                end
+                petition.reload
+              end
+
+              it "does not queue a job to process the emails" do
+                assert_enqueued_jobs 0 do
+                  do_post
+                end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            let(:petition_email_attributes) do
+              { subject: "", body: "" }
+            end
+
+            it 're-renders the petitions/show template' do
+              do_post
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_post
+              expect(assigns(:email)).to be_present
+              expect(assigns(:email).errors).not_to be_empty
+            end
+
+            it 'does not stores the email details in the db' do
+              do_post
+              petition.reload
+              expect(petition.emails).to be_empty
+            end
+          end
+        end
+
+        shared_examples_for 'trying to email supporters of a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_post
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not store the supplied email details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_post }
+            petition.reload
+            expect(petition.emails).to be_empty
+          end
+        end
+
+        describe 'for a pending petition' do
+          before { petition.update_column(:state, Petition::PENDING_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a validated petition' do
+          before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a sponsored petition' do
+          before { petition.update_column(:state, Petition::SPONSORED_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+      end
     end
 
     describe 'GET /:id/edit' do
@@ -756,6 +892,159 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
                 assert_enqueued_jobs 0 do
                   do_patch
                 end
+              end
+            end
+          end
+
+          describe 'with invalid params' do
+            let(:petition_email_attributes) do
+              { subject: "", body: "" }
+            end
+
+            it 're-renders the petitions/show template' do
+              do_patch
+              expect(response).to be_success
+              expect(response).to render_template('petitions/show')
+            end
+
+            it 'leaves the in-memory instance with errors' do
+              do_patch
+              expect(assigns(:email)).to be_present
+              expect(assigns(:email).errors).not_to be_empty
+            end
+
+            it 'does not stores the email details in the db' do
+              do_patch
+              email.reload
+              expect(email.subject).to eq("Petition email subject")
+              expect(email.body).to eq("Petition email body")
+            end
+          end
+        end
+
+        shared_examples_for 'trying to email supporters of a petition in the wrong state' do
+          it 'raises a 404 error' do
+            expect {
+              do_patch
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'does not store the supplied email details in the db' do
+            suppress(ActiveRecord::RecordNotFound) { do_patch }
+            email.reload
+            expect(email.subject).to eq("Petition email subject")
+            expect(email.body).to eq("Petition email body")
+          end
+        end
+
+        describe 'for a pending petition' do
+          before { petition.update_column(:state, Petition::PENDING_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a validated petition' do
+          before { petition.update_column(:state, Petition::VALIDATED_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+
+        describe 'for a sponsored petition' do
+          before { petition.update_column(:state, Petition::SPONSORED_STATE) }
+          it_behaves_like 'trying to email supporters of a petition in the wrong state'
+        end
+      end
+
+      context 'when clicking the Preview button' do
+        def do_patch(overrides = {})
+          params = {
+            petition_id: petition.id,
+            id: email.id,
+            petition_email: petition_email_attributes,
+            save_and_preview: "Save and preview"
+          }
+
+          patch :update, params.merge(overrides)
+        end
+
+        describe 'for an open petition' do
+          it 'fetches the requested petition' do
+            do_patch
+            expect(assigns(:petition)).to eq petition
+          end
+
+          it 'fetches the requested email' do
+            do_patch
+            expect(assigns(:email)).to eq email
+          end
+
+          describe 'with valid params' do
+            it 'redirects to the petition show page' do
+              do_patch
+              expect(response).to redirect_to "https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}"
+            end
+
+            it 'tells the moderator that their changes were saved' do
+              do_patch
+              expect(flash[:notice]).to eq 'Preview email successfully sent'
+            end
+
+            it 'stores the supplied email details in the db' do
+              do_patch
+              email.reload
+              expect(email).to be_present
+              expect(email.subject).to eq "New petition email subject"
+              expect(email.body).to eq "New petition email body"
+              expect(email.sent_by).to eq user.pretty_name
+            end
+
+            context "does not email out the petition email" do
+              before do
+                3.times do |i|
+                  attributes = {
+                    name: "Laura #{i}",
+                    email: "laura_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+                  s = FactoryBot.create(:pending_signature, attributes)
+                  s.validate!
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Sarah #{i}",
+                    email: "sarah_#{i}@example.com",
+                    notify_by_email: false,
+                    petition: petition
+                  }
+
+                  s = FactoryBot.create(:pending_signature, attributes)
+                  s.validate!
+                end
+                2.times do |i|
+                  attributes = {
+                    name: "Brian #{i}",
+                    email: "brian_#{i}@example.com",
+                    notify_by_email: true,
+                    petition: petition
+                  }
+                  FactoryBot.create(:pending_signature, attributes)
+                end
+                petition.reload
+              end
+
+              it "does not queue a job to process the emails" do
+                assert_enqueued_jobs 0 do
+                  do_patch
+                end
+              end
+            end
+
+            it "should email out a preview email" do
+              perform_enqueued_jobs do
+                do_patch
+                expect(deliveries.length).to eq 1
+                expect(deliveries.map(&:to)).to eq([
+                  ['petitionscommittee@parliament.uk']
+                ])
               end
             end
           end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe MarkdownHelper, type: :helper do
+  describe "#markdown_to_html" do
+    it "converts markdown to html" do
+      expect(helper.markdown_to_html("## Petitions: UK Government and Parliament")).to eq(%[<h2>Petitions: UK Government and Parliament</h2>\n])
+    end
+
+    it "autolinks urls" do
+      expect(helper.markdown_to_html("www.example.com")).to eq(%[<p><a href="http://www.example.com">www.example.com</a></p>\n])
+    end
+  end
+
+  describe "#markdown_to_text" do
+    it "converts markdown to text" do
+      expect(helper.markdown_to_text("## Petitions: UK Government and Parliament")).to eq(%[Petitions: UK Government and Parliament\n])
+    end
+
+    it "autolinks urls" do
+      expect(helper.markdown_to_text("www.example.com")).to eq(%[www.example.com (http://www.example.com)\n])
+    end
+  end
+end


### PR DESCRIPTION
This allows the moderators more flexibility when formatting other parliamentary business emails for maximum effect as often they are missed by people viewing the petition.

Also adds the ability to preview the email before it is sent