### PR TITLE
Switch to using aws-sdk for paperclip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,11 +34,7 @@ gem 'jbuilder'
 gem 'paperclip'
 gem 'maxminddb'
 
-# Two AWS libraries:
-#   - aws-sdk v2 for CodeDeploy, which neither Fog nor aws-sdk v1 support
-#   - fog for image uploads, as Paperclip doesn't support aws-sdk v2
 gem 'aws-sdk', '~> 2.0'
-gem 'fog-aws', '~> 1.0'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,6 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.6)
     erubis (2.7.0)
-    excon (0.59.0)
     execjs (2.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -128,22 +127,6 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fog-aws (1.4.1)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.45.0)
-      builder
-      excon (~> 0.58)
-      formatador (~> 0.2)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
-      multi_json (~> 1.10)
-    fog-xml (0.1.3)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
-    formatador (0.2.5)
     gherkin (4.1.3)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -151,7 +134,6 @@ GEM
     htmlentities (4.3.4)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
-    ipaddress (0.8.3)
     jasmine-core (2.8.0)
     jasmine-rails (0.14.7)
       jasmine-core (>= 1.3, < 3.0)
@@ -337,7 +319,6 @@ DEPENDENCIES
   faker
   faraday
   faraday_middleware
-  fog-aws (~> 1.0)
   jasmine-rails
   jbuilder
   jquery-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,15 +106,12 @@ Rails.application.configure do
   # any url that starts with /attachments/ to the S3 bucket
 
   config.paperclip_defaults = {
-    storage: :fog,
-    fog_directory: ENV.fetch('UPLOADED_IMAGES_S3_BUCKET'),
-    fog_credentials: {
-      use_iam_profile: true,
-      provider: 'AWS',
-      region: 'eu-west-1',
-      scheme: 'https'
+    storage: :s3,
+    s3_region: 'eu-west-1',
+    s3_credentials: {
+      bucket: ENV.fetch('UPLOADED_IMAGES_S3_BUCKET')
     },
-    # Proxied to S3 via the webserver
-    fog_host: '/attachments'
+    path: '/:class/:attachment/:id_partition/:style/:filename',
+    url: ':s3_attachment_url'
   }
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,0 +1,7 @@
+# Add a custom interpolation for S3 to prefix the url with '/attachments'.
+# This is so we don't publish asset urls with S3 domains, making it easier
+# to migrate to different hosting in the future.
+
+Paperclip.interpolates(:s3_attachment_url) do |attachment, style|
+  "/attachments#{attachment.path(style)}"
+end


### PR DESCRIPTION
This allows us to remove fog from our list of dependencies.