### PR TITLE
Adds `email` namespace in AppSignal

### DIFF
--- a/app/jobs/concerns/email_all_petition_signatories.rb
+++ b/app/jobs/concerns/email_all_petition_signatories.rb
@@ -5,6 +5,8 @@ module EmailAllPetitionSignatories
   extend ActiveSupport::Concern
 
   included do
+    before_perform :set_appsignal_namespace
+
     class_attribute :email_delivery_job_class
     class_attribute :timestamp_name
 
@@ -88,5 +90,9 @@ module EmailAllPetitionSignatories
 
   def signatures_to_email
     petition.signatures_to_email_for(timestamp_name)
+  end
+
+  def set_appsignal_namespace
+    Appsignal.set_namespace("email")
   end
 end

--- a/app/jobs/concerns/email_delivery.rb
+++ b/app/jobs/concerns/email_delivery.rb
@@ -23,6 +23,8 @@ module EmailDelivery
   ]
 
   included do
+    before_perform :set_appsignal_namespace
+
     attr_reader :signature, :timestamp_name, :petition, :requested_at
     queue_as :low_priority
 
@@ -100,5 +102,9 @@ module EmailDelivery
   def email_not_previously_sent?
     # check that the signature is still in the list of signatures
     petition.signatures_to_email_for(timestamp_name).where(id: signature.id).exists?
+  end
+
+  def set_appsignal_namespace
+    Appsignal.set_namespace("email")
   end
 end

--- a/app/jobs/email_job.rb
+++ b/app/jobs/email_job.rb
@@ -1,4 +1,6 @@
 class EmailJob < ApplicationJob
+  before_perform :set_appsignal_namespace
+
   class_attribute :mailer, :email
 
   PERMANENT_FAILURES = [
@@ -41,5 +43,9 @@ class EmailJob < ApplicationJob
 
   def log_message(exception)
     "#{exception.class.name} while sending email for #{self.class.name}"
+  end
+
+  def set_appsignal_namespace
+    Appsignal.set_namespace("email")
   end
 end


### PR DESCRIPTION
We're moving the email delivery background job into its own namespace (`email`), so we can put triggers on the ` admin`namespace without activating them for the email job as well.

This will enable us to get warnings for events that involve signatures (from the "admin" namespace), while the emails have their own namespace where they can run quietly.