### PR TITLE
Prevent boolean argument to prepared statements

### DIFF
--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -16,7 +16,7 @@ module Archived
     belongs_to :parliament, inverse_of: :petitions, required: true
     belongs_to :locked_by, class_name: 'AdminUser'
 
-    has_one :creator, -> { where(creator: true) }, class_name: "Signature"
+    has_one :creator, -> { creator }, class_name: "Signature"
     has_one :debate_outcome, dependent: :destroy
     has_one :government_response, dependent: :destroy
     has_one :note, dependent: :destroy
@@ -24,7 +24,7 @@ module Archived
 
     has_many :emails, :dependent => :destroy
     has_many :signatures
-    has_many :sponsors, -> { where(sponsor: true) }, class_name: "Signature"
+    has_many :sponsors, -> { sponsors }, class_name: "Signature"
 
     validates :action, presence: true, length: { maximum: 150 }
     validates :background, length: { maximum: 300 }, allow_blank: true

--- a/app/models/archived/signature.rb
+++ b/app/models/archived/signature.rb
@@ -56,6 +56,14 @@ module Archived
       def validated
         where(state: VALIDATED_STATE)
       end
+
+      def creator
+        where(arel_table[:creator].eq(true))
+      end
+
+      def sponsors
+        where(arel_table[:sponsor].eq(true))
+      end
     end
 
     def get_email_sent_at_for(timestamp)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -65,7 +65,7 @@ class Petition < ActiveRecord::Base
   facet :tagged_in_moderation,         -> { tagged_in_moderation.by_most_recent_moderation_threshold_reached }
   facet :untagged_in_moderation,       -> { untagged_in_moderation.by_most_recent_moderation_threshold_reached }
 
-  has_one :creator, -> { where(creator: true) }, class_name: 'Signature'
+  has_one :creator, -> { creator }, class_name: 'Signature'
   accepts_nested_attributes_for :creator, update_only: true
 
   belongs_to :locked_by, class_name: 'AdminUser'
@@ -77,7 +77,7 @@ class Petition < ActiveRecord::Base
   has_one :rejection, dependent: :destroy
 
   has_many :signatures
-  has_many :sponsors, -> { where(sponsor: true) }, class_name: 'Signature'
+  has_many :sponsors, -> { sponsors }, class_name: 'Signature'
   has_many :country_petition_journals, dependent: :destroy
   has_many :constituency_petition_journals, dependent: :destroy
   has_many :emails, dependent: :destroy

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -165,8 +165,12 @@ class Signature < ActiveRecord::Base
       scope.paginate(page: page, per_page: 50)
     end
 
+    def creator
+      where(arel_table[:creator].eq(true))
+    end
+
     def sponsors
-      where(sponsor: true)
+      where(arel_table[:sponsor].eq(true))
     end
 
     def subscribed


### PR DESCRIPTION
When using hash conditions to `where`, Active Record will treat that
as an argument for the prepared statement even though it will never change in reality. This causes problems for our partial indexes on `creator` and `sponsor` columns in the signatures and the archived_signatures tables because of the following behaviour as documented in [PREPARE][1]:

> Prepared statements can use generic plans rather than re-planning with each set of supplied EXECUTE values. This occurs immediately for prepared statements with no parameters; otherwise it occurs only after five or more executions produce plans whose estimated cost average (including planning overhead) is more expensive than the generic plan cost estimate. Once a generic plan is chosen, it is used for the remaining lifetime of the prepared statement.

What this means in effect is that after each Active Record connection was used five times to fetch a petition creator it was defaulting to the generic query plan which in our case turned out to be a sequential scan of the signatures table.

By using an opaque Arel attribute node passed to `where` we can prevent Active Record from seeing that as an argument to a prepared statement so the plan used by PostgreSQL continues to use our partial index even after the statement has been used five times.

[1]: https://www.postgresql.org/docs/9.6/static/sql-prepare.html#SQL-PREPARE-NOTES