### PR TITLE
Configure lograge to ignore spammy actions

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -12,6 +12,10 @@ class Admin::AdminController < ApplicationController
   def index
   end
 
+  def admin_request?
+    true
+  end
+
   private
 
   def set_appsignal_namespace

--- a/app/controllers/admin/archived/locks_controller.rb
+++ b/app/controllers/admin/archived/locks_controller.rb
@@ -33,11 +33,11 @@ class Admin::Archived::LocksController < Admin::AdminController
     end
   end
 
+  private
+
   def last_request_update_allowed?
     false
   end
-
-  private
 
   def fetch_petition
     @petition = ::Archived::Petition.find(params[:petition_id])

--- a/app/controllers/admin/locks_controller.rb
+++ b/app/controllers/admin/locks_controller.rb
@@ -33,11 +33,11 @@ class Admin::LocksController < Admin::AdminController
     end
   end
 
+  private
+
   def last_request_update_allowed?
     false
   end
-
-  private
 
   def fetch_petition
     @petition = Petition.find(params[:petition_id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,12 @@ class ApplicationController < ActionController::Base
   before_action :set_seen_cookie_message, if: :show_cookie_message?
   helper_method :show_cookie_message?, :public_petition_facets
 
+  hide_action :admin_request?
+
+  def admin_request?
+    false
+  end
+
   protected
 
   def authenticate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,22 @@ Rails.application.configure do
 
   # Turn on lograge, to give us more parseable logs
   config.lograge.enabled = true
+  config.lograge.ignore_actions = %w[
+    PingController#ping
+    Admin::UserSessionsController#status
+    Admin::LocksController#show
+    Admin::LocksController#create
+    Admin::LocksController#update
+    Admin::LocksController#destroy
+    Admin::Archived::LocksController#show
+    Admin::Archived::LocksController#create
+    Admin::Archived::LocksController#update
+    Admin::Archived::LocksController#destroy
+  ]
+
+  config.lograge.custom_payload do |controller|
+    controller.admin_request? ? { user_id: controller.current_user.try(:id) } : {}
+  end
 
   # Log in logstash format, so that we can easily parse the output
   config.logger = LogStashLogger.new(


### PR DESCRIPTION
This reduces some of the verbosity in the CloudWatch logs.