### PR TITLE
Enforce UTF-8 encoding for token parameters

### DIFF
--- a/app/controllers/archived/signatures_controller.rb
+++ b/app/controllers/archived/signatures_controller.rb
@@ -14,8 +14,12 @@ module Archived
 
     private
 
+    def signature_id
+      @signature_id ||= Integer(params[:id])
+    end
+
     def token_param
-      @token_param ||= params[:token].to_s
+      @token_param ||= params[:token].to_s.encode('utf-8', invalid: :replace)
     end
 
     def verify_unsubscribe_token
@@ -29,7 +33,7 @@ module Archived
       @petition = @signature.petition
 
       if @signature.invalidated? || @signature.fraudulent?
-        raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+        raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
       end
     end
   end

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -87,13 +87,21 @@ class SignaturesController < ApplicationController
 
   private
 
+  def petition_id
+    @petition_id ||= Integer(params[:petition_id])
+  end
+
+  def signature_id
+    @signature_id ||= Integer(params[:id])
+  end
+
   def token_param
-    @token_param ||= params[:token].to_s
+    @token_param ||= params[:token].to_s.encode('utf-8', invalid: :replace)
   end
 
   def verify_token
     unless @signature.perishable_token == token_param
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with token: token_param.inspect}"
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with token: #{token_param.inspect}"
     end
   end
 
@@ -104,19 +112,19 @@ class SignaturesController < ApplicationController
   end
 
   def retrieve_petition
-    @petition = Petition.visible.find(params[:petition_id])
+    @petition = Petition.visible.find(petition_id)
   end
 
   def retrieve_signature
-    @signature = Signature.find(params[:id])
+    @signature = Signature.find(signature_id)
     @petition = @signature.petition
 
     unless @petition.visible?
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
 
     if @signature.invalidated? || @signature.fraudulent?
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
   end
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -30,27 +30,27 @@ class SponsorsController < SignaturesController
   private
 
   def retrieve_petition
-    @petition = Petition.not_hidden.find_by!(sponsor_token_and_id)
+    @petition = Petition.not_hidden.find(petition_id)
 
     if @petition.flagged? || @petition.stopped?
-      raise ActiveRecord::RecordNotFound, "Unable to find Petition with id: #{params[:petition_id]}"
+      raise ActiveRecord::RecordNotFound, "Unable to find Petition with id: #{petition_id}"
     end
-  end
 
-  def sponsor_token_and_id
-    { sponsor_token: params[:token].to_s, id: params[:petition_id].to_i }
+    unless @petition.sponsor_token == token_param
+      raise ActiveRecord::RecordNotFound, "Unable to find Petition with sponsor token: #{token_param.inspect}"
+    end
   end
 
   def retrieve_signature
-    @signature = Signature.sponsors.find(params[:id])
+    @signature = Signature.sponsors.find(signature_id)
     @petition = @signature.petition
 
     if @petition.flagged? || @petition.hidden? || @petition.stopped?
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
 
     if @signature.invalidated? || @signature.fraudulent?
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{params[:id]}"
+      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
   end
 

--- a/spec/requests/invalid_encoding_spec.rb
+++ b/spec/requests/invalid_encoding_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe "invalid encoding", type: :request do
+  describe "when sponsoring a petition" do
+    let(:petition) { FactoryBot.create(:validated_petition, sponsor_token: "foobar") }
+
+    it "raises an ActiveRecord::RecordNotFound exception" do
+      expect {
+        get "/petitions/#{petition.id}/sponsors/new?token=foobar%91"
+      }.to raise_error(ActiveRecord::RecordNotFound, 'Unable to find Petition with sponsor token: "foobar�"')
+    end
+  end
+
+  describe "when validating a sponsor signature" do
+    let(:petition) { FactoryBot.create(:validated_petition) }
+    let(:signature) { FactoryBot.create(:pending_signature, sponsor: true, perishable_token: "foobar", petition: petition)}
+
+    it "raises an ActiveRecord::RecordNotFound exception" do
+      expect {
+        get "/sponsors/#{signature.id}/verify?token=foobar%91"
+      }.to raise_error(ActiveRecord::RecordNotFound, 'Unable to find Signature with token: "foobar�"')
+    end
+  end
+
+  describe "when validating a signature" do
+    let(:petition) { FactoryBot.create(:open_petition) }
+    let(:signature) { FactoryBot.create(:pending_signature, perishable_token: "foobar", petition: petition)}
+
+    it "raises an ActiveRecord::RecordNotFound exception" do
+      expect {
+        get "/signatures/#{signature.id}/verify?token=foobar%91"
+      }.to raise_error(ActiveRecord::RecordNotFound, 'Unable to find Signature with token: "foobar�"')
+    end
+  end
+
+  describe "when unsubscribing a signature" do
+    let(:petition) { FactoryBot.create(:open_petition) }
+    let(:signature) { FactoryBot.create(:pending_signature, unsubscribe_token: "foobar", petition: petition)}
+
+    it "raises an ActiveRecord::RecordNotFound exception" do
+      expect {
+        get "/signatures/#{signature.id}/unsubscribe?token=foobar%91"
+      }.to raise_error(ActiveRecord::RecordNotFound, 'Unable to find Signature with unsubscribe token: "foobar�"')
+    end
+  end
+
+  describe "when unsubscribing an archived signature" do
+    let(:petition) { FactoryBot.create(:archived_petition) }
+    let(:signature) { FactoryBot.create(:archived_signature, unsubscribe_token: "foobar", petition: petition)}
+
+    it "raises an ActiveRecord::RecordNotFound exception" do
+      expect {
+        get "/archived/signatures/#{signature.id}/unsubscribe?token=foobar%91"
+      }.to raise_error(ActiveRecord::RecordNotFound, 'Unable to find Signature with unsubscribe token: "foobar�"')
+    end
+  end
+end


### PR DESCRIPTION
Although the encoding was technically already being forced by Rails the param could still have a invalid character which blew up when passed to PostgreSQL as a `PG::CharacterNotInRepertoire` exception.

Fix this by replacing invalid characters with a `�` and also don't pass the token param to the Active Record finder method, just compare it in memory instead.