### PR TITLE
Display date of government response on home page and petition page

### DIFF
--- a/app/controllers/admin/archived/government_response_controller.rb
+++ b/app/controllers/admin/archived/government_response_controller.rb
@@ -36,7 +36,7 @@ class Admin::Archived::GovernmentResponseController < Admin::AdminController
   end
 
   def government_response_params
-    params.require(:archived_government_response).permit(:summary, :details)
+    params.require(:archived_government_response).permit(:responded_on, :summary, :details)
   end
 
   def send_email_to_petitioners?

--- a/app/controllers/admin/government_response_controller.rb
+++ b/app/controllers/admin/government_response_controller.rb
@@ -36,7 +36,7 @@ class Admin::GovernmentResponseController < Admin::AdminController
   end
 
   def government_response_params
-    params.require(:government_response).permit(:summary, :details)
+    params.require(:government_response).permit(:responded_on, :summary, :details)
   end
 
   def send_email_to_petitioners?

--- a/app/jobs/archive_petition_job.rb
+++ b/app/jobs/archive_petition_job.rb
@@ -65,6 +65,7 @@ class ArchivePetitionJob < ApplicationJob
 
         if government_response = petition.government_response
           p.build_government_response do |r|
+            r.responded_on = government_response.responded_on
             r.summary = government_response.summary
             r.details = government_response.details
             r.created_at = government_response.created_at

--- a/app/models/archived/government_response.rb
+++ b/app/models/archived/government_response.rb
@@ -7,9 +7,24 @@ module Archived
     validates :petition, presence: true
     validates :summary, presence: true, length: { maximum: 500 }
     validates :details, length: { maximum: 10000 }, allow_blank: true
+    validates :responded_on, presence: true
 
     after_create do
       petition.touch(:government_response_at) unless petition.government_response_at?
+    end
+
+    def responded_on
+      super || default_responded_on
+    end
+
+    private
+
+    def default_responded_on
+      if petition && petition.government_response_at
+        petition.government_response_at.to_date
+      elsif created_at
+        created_at.to_date
+      end
     end
   end
 end

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -112,7 +112,7 @@ module Archived
       end
 
       def with_response
-        where.not(government_response_at: nil)
+        where.not(government_response_at: nil).preload(:government_response)
       end
 
       def response_threshold_reached
@@ -148,7 +148,7 @@ module Archived
       end
 
       def debated
-        where(debate_state: 'debated')
+        where(debate_state: 'debated').preload(:debate_outcome)
       end
 
       def not_debated

--- a/app/models/government_response.rb
+++ b/app/models/government_response.rb
@@ -4,8 +4,25 @@ class GovernmentResponse < ActiveRecord::Base
   validates :petition, presence: true
   validates :summary, presence: true, length: { maximum: 200 }
   validates :details, length: { maximum: 6000 }, allow_blank: true
+  validates :responded_on, presence: true
 
   after_create do
     petition.touch(:government_response_at) unless petition.government_response_at?
+  end
+
+  def responded_on
+    super || default_responded_on
+  end
+
+  private
+
+  def default_responded_on
+    if petition && petition.government_response_at
+      petition.government_response_at.to_date
+    elsif created_at
+      created_at.to_date
+    elsif new_record?
+      Date.current
+    end
   end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -191,7 +191,7 @@ class Petition < ActiveRecord::Base
     end
 
     def debated
-      where(debate_state: 'debated')
+      where(debate_state: 'debated').preload(:debate_outcome)
     end
 
     def for_state(state)
@@ -275,7 +275,7 @@ class Petition < ActiveRecord::Base
     end
 
     def with_response
-      where.not(government_response_at: nil)
+      where.not(government_response_at: nil).preload(:government_response)
     end
 
     def trending(since = 1.hour.ago, limit = 3)

--- a/app/views/admin/archived/government_response/_petition_action_government_response.html.erb
+++ b/app/views/admin/archived/government_response/_petition_action_government_response.html.erb
@@ -1,5 +1,11 @@
 <h2 class="petition-action-heading">Government response</h2>
 <%= form_for @government_response, :url => admin_archived_petition_government_response_path(petition), method: :put do |f| -%>
+  <%= form_row :for => [f.object, :responded_on] do %>
+    <%= f.label :responded_on, class: 'form-label' %>
+    <%= error_messages_for_field f.object, :responded_on %>
+    <%= f.date_field :responded_on, tabindex: increment, class: 'form-control' %>
+  <% end %>
+
   <%= form_row :for => [f.object, :summary] do %>
     <%= f.label :summary, 'Summary quote', class: 'form-label' %>
     <%= error_messages_for_field f.object, :summary %>
@@ -10,7 +16,8 @@
   <%= form_row :for => [f.object, :details] do %>
     <%= f.label :details, 'Response in full', class: 'form-label' %>
     <%= error_messages_for_field f.object, :details %>
-    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, class: 'form-control' %>
+    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, data: { max_length: 10000 }, class: 'form-control' %>
+    <p class="character-count">10000 characters max</p>
   <% end %>
 
   <%= email_petitioners_with_count_submit_button(f, petition) %>

--- a/app/views/admin/government_response/_petition_action_government_response.html.erb
+++ b/app/views/admin/government_response/_petition_action_government_response.html.erb
@@ -1,5 +1,11 @@
 <h2 class="petition-action-heading">Government response</h2>
 <%= form_for @government_response, :url => admin_petition_government_response_path(petition), method: :put do |f| -%>
+  <%= form_row :for => [f.object, :responded_on] do %>
+    <%= f.label :responded_on, class: 'form-label' %>
+    <%= error_messages_for_field f.object, :responded_on %>
+    <%= f.date_field :responded_on, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+  <% end %>
+
   <%= form_row :for => [f.object, :summary] do %>
     <%= f.label :summary, 'Summary quote', class: 'form-label' %>
     <%= error_messages_for_field f.object, :summary %>
@@ -10,7 +16,8 @@
   <%= form_row :for => [f.object, :details] do %>
     <%= f.label :details, 'Response in full', class: 'form-label' %>
     <%= error_messages_for_field f.object, :details %>
-    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+    <%= f.text_area :details, rows: 8, cols: 70, tabindex: increment, data: { max_length: 10000 }, class: 'form-control', disabled: @petition.editing_disabled? %>
+    <p class="character-count">10000 characters max</p>
   <% end %>
 
   <%= email_petitioners_with_count_submit_button(f, petition, disabled: @petition.editing_disabled?) %>

--- a/app/views/archived/petitions/_petition.json.jbuilder
+++ b/app/views/archived/petitions/_petition.json.jbuilder
@@ -35,6 +35,7 @@ json.attributes do
 
   if response = petition.government_response
     json.government_response do
+      json.responded_on api_date_format(response.responded_on)
       json.summary response.summary
       json.details response.details
       json.created_at api_date_format(response.created_at)

--- a/app/views/archived/petitions/show.html.erb
+++ b/app/views/archived/petitions/show.html.erb
@@ -138,6 +138,7 @@
       <% if government_response = @petition.government_response? %>
         <section class="about-item about-item-count-response" id="response-threshold" aria-labelledby="response-threshold-heading">
           <h2 id="response-threshold-heading">Government responded</h2>
+          <p class="secondary">This response was given on <%= short_date_format government_response.responded_on %></p>
           <% if government_response.summary? %>
             <blockquote class="pull-quote">
               <%= auto_link(simple_format(h(government_response.summary)), html: { rel: 'nofollow' } ) %>

--- a/app/views/pages/home/_responded_petitions.html.erb
+++ b/app/views/pages/home/_responded_petitions.html.erb
@@ -5,7 +5,7 @@
     <% actioned[:with_response][:list].each do |petition| %>
       <li class="petition-item">
         <h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold'), class: "threshold-petition-title" %></h3>
-        <p class="intro">The government responded</p>
+        <p class="intro">The government responded on <%= short_date_format(petition.government_response_at) %></p>
         <blockquote class="pull-quote"><%= simple_format(petition.government_response.summary) %></blockquote>
         <p><%= link_to "Read the response in full", petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></p>
       </li>

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -41,6 +41,7 @@ json.attributes do
 
   if response = petition.government_response
     json.government_response do
+      json.responded_on api_date_format(response.responded_on)
       json.summary response.summary
       json.details response.details
       json.created_at api_date_format(response.created_at)

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -2,6 +2,7 @@
   <%# Has a government response #%>
   <% if government_response = petition.government_response? -%>
     <h2 id="response-threshold-heading">Government responded</h2>
+    <p class="secondary">This response was given on <%= short_date_format government_response.responded_on %></p>
     <blockquote class="pull-quote">
       <%= auto_link(simple_format(h(government_response.summary)), html: { rel: 'nofollow' } ) %>
     </blockquote>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
@@ -1,4 +1,4 @@
 <h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></h3>
-<p>Government responded – <%= short_date_format(petition.government_response_at) %></p>
+<p>Government responded – <%= short_date_format(petition.government_response.responded_on) %></p>
 <p><%= petition.government_response.summary %></p>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/db/migrate/20180623131406_add_responded_on_to_government_responses.rb
+++ b/db/migrate/20180623131406_add_responded_on_to_government_responses.rb
@@ -1,0 +1,11 @@
+class AddRespondedOnToGovernmentResponses < ActiveRecord::Migration
+  def change
+    change_table :archived_government_responses do |t|
+      t.date :responded_on
+    end
+
+    change_table :government_responses do |t|
+      t.date :responded_on
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -140,7 +140,8 @@ CREATE TABLE archived_government_responses (
     summary character varying(500) NOT NULL,
     details text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    responded_on date
 );
 
 
@@ -635,7 +636,8 @@ CREATE TABLE government_responses (
     summary character varying(500) NOT NULL,
     details text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    responded_on date
 );
 
 
@@ -2667,4 +2669,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180329062433');
 INSERT INTO schema_migrations (version) VALUES ('20180510122656');
 
 INSERT INTO schema_migrations (version) VALUES ('20180510131346');
+
+INSERT INTO schema_migrations (version) VALUES ('20180623131406');
 

--- a/spec/controllers/admin/archived/government_response_controller_spec.rb
+++ b/spec/controllers/admin/archived/government_response_controller_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
     describe 'PATCH /update' do
       let(:government_response_attributes) do
         {
+          responded_on: Date.civil(2018, 6, 23),
           summary: 'The government agrees',
           details: 'Your petition is brilliant and we will do our utmost to make it law.'
         }
@@ -118,6 +119,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
           it 'stores the supplied government response in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -218,6 +220,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
 
         describe 'using no params to add a government response' do
           before do
+            government_response_attributes[:responded_on] = nil
             government_response_attributes[:summary] = nil
             government_response_attributes[:details] = nil
           end
@@ -296,6 +299,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
           it 'stores the supplied response on the petition in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -359,6 +363,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
           it 'stores the supplied government response in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -429,6 +434,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
 
         describe 'using no params to add a government response' do
           before do
+            government_response_attributes[:responded_on] = nil
             government_response_attributes[:summary] = nil
             government_response_attributes[:details] = nil
           end
@@ -507,6 +513,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
           it 'stores the supplied response on the petition in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -545,7 +552,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
 
       context "when two moderators update the response for the first time simultaneously" do
         let(:government_response) do
-          FactoryBot.build(:archived_government_response, summary: "", details: "", petition: petition)
+          FactoryBot.build(:archived_government_response, responded_on: "", summary: "", details: "", petition: petition)
         end
 
         before do
@@ -559,6 +566,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
             expect(petition.government_response).to be_nil
 
             response_attributes = {
+              responded_on: Date.civil(2018, 6, 23),
               summary: "summmary 1",
               details: "details 1"
             }
@@ -570,6 +578,7 @@ RSpec.describe Admin::Archived::GovernmentResponseController, type: :controller,
             allow(petition).to receive(:build_government_response).and_return(government_response)
 
             response_attributes = {
+              responded_on: Date.civil(2018, 6, 23),
               summary: "summmary 2",
               details: "details 2"
             }

--- a/spec/controllers/admin/government_response_controller_spec.rb
+++ b/spec/controllers/admin/government_response_controller_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
     describe 'PATCH /update' do
       let(:government_response_attributes) do
         {
+          responded_on: Date.civil(2018, 6, 23),
           summary: 'The government agrees',
           details: 'Your petition is brilliant and we will do our utmost to make it law.'
         }
@@ -130,6 +131,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
           it 'stores the supplied government response in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -227,6 +229,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
 
         describe 'using no params to add a government response' do
           before do
+            government_response_attributes[:responded_on] = nil
             government_response_attributes[:summary] = nil
             government_response_attributes[:details] = nil
           end
@@ -305,6 +308,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
           it 'stores the supplied response on the petition in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -381,6 +385,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
           it 'stores the supplied government response in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -448,6 +453,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
 
         describe 'using no params to add a government response' do
           before do
+            government_response_attributes[:responded_on] = nil
             government_response_attributes[:summary] = nil
             government_response_attributes[:details] = nil
           end
@@ -526,6 +532,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
           it 'stores the supplied response on the petition in the db' do
             do_patch
             petition.reload
+            expect(government_response.responded_on).to eq government_response_attributes[:responded_on]
             expect(government_response.summary).to eq government_response_attributes[:summary]
             expect(government_response.details).to eq government_response_attributes[:details]
           end
@@ -577,7 +584,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
 
       context "when two moderators update the response for the first time simultaneously" do
         let(:government_response) do
-          FactoryBot.build(:government_response, summary: "", details: "", petition: petition)
+          FactoryBot.build(:government_response, responded_on: "", summary: "", details: "", petition: petition)
         end
 
         before do
@@ -591,6 +598,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
             expect(petition.government_response).to be_nil
 
             response_attributes = {
+              responded_on: Date.civil(2018, 6, 23),
               summary: "summmary 1",
               details: "details 1"
             }
@@ -602,6 +610,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
             allow(petition).to receive(:build_government_response).and_return(government_response)
 
             response_attributes = {
+              responded_on: Date.civil(2018, 6, 23),
               summary: "summmary 2",
               details: "details 2"
             }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
 
   factory :archived_government_response, class: "Archived::GovernmentResponse" do
     association :petition, factory: :archived_petition
+    responded_on { 1.year.ago.to_date }
     details "Government Response Details"
     summary "Government Response Summary"
   end
@@ -594,6 +595,7 @@ FactoryBot.define do
 
   factory :government_response do
     association :petition, factory: :awaiting_petition
+    responded_on { 1.day.ago.to_date }
     details "Government Response Details"
     summary "Government Response Summary"
   end

--- a/spec/jobs/archive_petition_job_spec.rb
+++ b/spec/jobs/archive_petition_job_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe ArchivePetitionJob, type: :job do
     end
 
     it "copies the government_response object" do
+      expect(archived_government_response.responded_on).to eq(government_response.responded_on)
       expect(archived_government_response.summary).to eq(government_response.summary)
       expect(archived_government_response.details).to eq(government_response.details)
       expect(archived_government_response.created_at).to be_usec_precise_with(government_response.created_at)

--- a/spec/models/archived/government_response_spec.rb
+++ b/spec/models/archived/government_response_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Archived::GovernmentResponse, type: :model do
     it { is_expected.to have_db_column(:petition_id).of_type(:integer) }
     it { is_expected.to have_db_column(:summary).of_type(:string).with_options(limit: 500, null: false) }
     it { is_expected.to have_db_column(:details).of_type(:text) }
+    it { is_expected.to have_db_column(:responded_on).of_type(:date) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   end

--- a/spec/models/government_response_spec.rb
+++ b/spec/models/government_response_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe GovernmentResponse, type: :model do
     expect(FactoryBot.build(:government_response)).to be_valid
   end
 
+  describe "schema" do
+    it { is_expected.to have_db_column(:petition_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:summary).of_type(:string).with_options(limit: 500, null: false) }
+    it { is_expected.to have_db_column(:details).of_type(:text) }
+    it { is_expected.to have_db_column(:responded_on).of_type(:date) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:petition).touch(true) }
   end

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
         a_hash_including(
           "government_response_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),
           "government_response" => a_hash_including(
+            "responded_on" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}\z]),
             "summary" => "Summary of what the government said",
             "details" => "Details of what the government said",
             "created_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),

--- a/spec/requests/archived_petitions_list_spec.rb
+++ b/spec/requests/archived_petitions_list_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe "API request to list archived petitions", type: :request, show_ex
           a_hash_including(
             "attributes" => a_hash_including(
               "government_response" => a_hash_including(
+                "responded_on" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}\z]),
                 "summary" => "Summary of what the government said",
                 "details" => "Details of what the government said"
               )

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
         a_hash_including(
           "government_response_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),
           "government_response" => a_hash_including(
+            "responded_on" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}\z]),
             "summary" => "Summary of what the government said",
             "details" => "Details of what the government said",
             "created_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe "API request to list petitions", type: :request, show_exceptions:
           a_hash_including(
             "attributes" => a_hash_including(
               "government_response" => a_hash_including(
+                "responded_on" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}\z]),
                 "summary" => "Summary of what the government said",
                 "details" => "Details of what the government said"
               )


### PR DESCRIPTION
Since responses have been [known to change][1] then we need to add a custom date for the response in a similar way as a debate outcome rather than relying on the timestamp when the response was created.

[1]: https://petition.parliament.uk/petitions/209433