### PR TITLE
Add a HTML template for feedback messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 addons:
   postgresql: "9.4"
 before_install:
-- gem install bundler
+- gem install bundler -v 1.16.2
 - |
     export PHANTOMJS_VERSION=2.1.1
     export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,4 +350,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.0
+   1.16.2

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,4 +2,8 @@ class Feedback < ActiveRecord::Base
   validates :comment, presence: true, length: { maximum: 32768 }
   validates :petition_link_or_title, length: { maximum: 255 }, allow_blank: true
   validates :email, format: { with: EMAIL_REGEX }, length: { maximum: 255 }, allow_blank: true
+
+  def petition_link?
+    petition_link_or_title =~ /\A#{Regexp.escape(Site.url)}/
+  end
 end

--- a/app/views/feedback_mailer/send_feedback.html.erb
+++ b/app/views/feedback_mailer/send_feedback.html.erb
@@ -1,0 +1,23 @@
+<h3>Comments:</h3>
+<%= simple_format(@feedback.comment) %>
+
+<hr>
+
+<p>
+  <strong>Link or title:</strong><br>
+  <% if @feedback.petition_link? %>
+    <%= link_to nil, @feedback.petition_link_or_title %>
+  <% else %>
+    <%= @feedback.petition_link_or_title %>
+  <% end %>
+</p>
+
+<p>
+  <strong>Email:</strong><br>
+  <%= mail_to(@feedback.email) %>
+</p>
+
+<p>
+  <strong>Browser:</strong><br>
+  <%= @feedback.user_agent %>
+</p>

--- a/app/views/feedback_mailer/send_feedback.text.erb
+++ b/app/views/feedback_mailer/send_feedback.text.erb
@@ -1,4 +1,13 @@
-Comments: <%= @feedback.comment %>
-Link: <%= @feedback.petition_link_or_title %>
-Email: <%= @feedback.email %>
-Browser: <%= @feedback.user_agent %>
+Comments:
+<%= word_wrap(@feedback.comment, line_width: 72) %>
+
+=======================================================================
+
+Link or title:
+<%= @feedback.petition_link_or_title %>
+
+Email:
+<%= @feedback.email %>
+
+Browser:
+<%= @feedback.user_agent %>

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -18,7 +18,7 @@ Then(/^the site owners should be notified$/) do
     Then they should see "#{@feedback.email}" in the email body
     Then they should see "#{@feedback.petition_link_or_title}" in the email body
     Then they should see "#{@feedback.comment}" in the email body
-    Then they should see "Browser: Chrome" in the email body
+    Then they should see "Chrome" in the email body
   )
 end
 

--- a/spec/mailers/previews/feedback_mailer_preview.rb
+++ b/spec/mailers/previews/feedback_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/feedback_mailer
+class FeedbackMailerPreview < ActionMailer::Preview
+  def send_feedback
+    FeedbackMailer.send_feedback(Feedback.last)
+  end
+end


### PR DESCRIPTION
An unknown PC email clients was rendering the text template on one line.