### PR TITLE
Use correct archived petition urls in search results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -20,4 +20,12 @@ module SearchHelper
     noun = petitions.search? ? 'result' : 'petition'
     "#{number_with_delimiter(total_entries)} #{noun.pluralize(total_entries)}"
   end
+
+  def petition_result_path(petition, options = {})
+    if petition.is_a?(Archived::Petition)
+      archived_petition_path(petition, options)
+    else
+      petition_path(petition, options)
+    end
+  end
 end

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_all.html.erb
@@ -1,4 +1,4 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <% case petition.state %>
 <% when "open" %>
   <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
@@ -1,4 +1,4 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
 <p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
 <% if petition.scheduled_debate_date? %>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_response.html.erb
@@ -1,3 +1,3 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
 <p><%= waiting_for_in_words(petition.response_threshold_reached_at) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_closed.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_closed.html.erb
@@ -1,2 +1,2 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_debated.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_debated.html.erb
@@ -1,4 +1,4 @@
-<h3><%= link_to petition.action, petition_path(petition, anchor: 'debate-threshold') %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition, anchor: 'debate-threshold') %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
 <% if debate_outcome = petition.debate_outcome %>
 <p>Debated <%= short_date_format(debate_outcome.debated_on) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_not_debated.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_not_debated.html.erb
@@ -1,2 +1,2 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_open.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_open.html.erb
@@ -1,2 +1,2 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_published.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_published.html.erb
@@ -1,2 +1,2 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_rejected.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_rejected.html.erb
@@ -1,1 +1,1 @@
-<h3><%= link_to petition.action, petition_path(petition) %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition) %></h3>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
@@ -1,4 +1,4 @@
-<h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></h3>
+<h3><%= link_to petition.action, petition_result_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></h3>
 <p>Government responded – <%= short_date_format(petition.government_response.responded_on) %></p>
 <p><%= petition.government_response.summary %></p>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -120,4 +120,34 @@ RSpec.describe SearchHelper, type: :helper do
       end
     end
   end
+
+  describe "#petition_result_path" do
+    let(:petition) { FactoryBot.create(:petition) }
+
+    subject { helper.petition_result_path(petition) }
+
+    it "generates the correct url" do
+      expect(subject).to eq("/petitions/#{petition.id}")
+    end
+
+    context "with an archived petition" do
+      let(:petition) { FactoryBot.create(:archived_petition) }
+
+      it "generates the correct url" do
+        expect(subject).to eq("/archived/petitions/#{petition.id}")
+      end
+    end
+
+    context "with options" do
+      let(:options) do
+        { reveal_response: "yes", anchor: 'response-threshold' }
+      end
+
+      subject { helper.petition_result_path(petition, options) }
+
+      it "generates the correct url" do
+        expect(subject).to eq("/petitions/#{petition.id}?reveal_response=yes#response-threshold")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This was missed because they redirect to the correct url but they lose the reveal response param when redirecting on responded petitions.