### PR TITLE
Don't show 'signatures by x' on rejected petitions

### DIFF
--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -235,6 +235,10 @@ module Archived
       state == HIDDEN_STATE
     end
 
+    def published?
+      state.in?(PUBLISHED_STATES)
+    end
+
     def duration
       if parliament.petition_duration?
         parliament.petition_duration

--- a/app/views/archived/petitions/_petition.json.jbuilder
+++ b/app/views/archived/petitions/_petition.json.jbuilder
@@ -57,7 +57,7 @@ json.attributes do
     json.debate nil
   end
 
-  if archived_petition_page?
+  if archived_petition_page? && petition.published?
     json.signatures_by_country petition.signatures_by_country
     json.signatures_by_constituency petition.signatures_by_constituency
   end

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -63,7 +63,7 @@ json.attributes do
     json.debate nil
   end
 
-  if petition_page?
+  if petition_page? && petition.published?
     json.signatures_by_country petition.signatures_by_country do |country|
       json.name country.name
       json.code country.code

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -205,6 +205,20 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
       )
     end
 
+    it "doesn't include the signatures by constituency data in rejected petitions" do
+      FactoryBot.create :constituency, :coventry_north_east
+      FactoryBot.create :constituency, :bethnal_green_and_bow
+
+      petition = \
+        FactoryBot.create :archived_petition, :rejected,
+          signatures_by_constituency: { 3427 => 123, 3320 => 456 }
+
+      get "/archived/petitions/#{petition.id}.json"
+      expect(response).to be_success
+
+      expect(attributes.keys).not_to include("signatures_by_constituency")
+    end
+
     it "includes the signatures by country data" do
       FactoryBot.create :location, name: "United Kingdom", code: "gb"
       FactoryBot.create :location, name: "France", code: "fr"
@@ -232,6 +246,20 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
           )
         )
       )
+    end
+
+    it "doesn't include the signatures by country data in rejected petitions" do
+      FactoryBot.create :location, name: "United Kingdom", code: "gb"
+      FactoryBot.create :location, name: "France", code: "fr"
+
+      petition = \
+        FactoryBot.create :archived_petition, :rejected,
+          signatures_by_country: { "gb" => 123456, "fr" => 789 }
+
+      get "/archived/petitions/#{petition.id}.json"
+      expect(response).to be_success
+
+      expect(attributes.keys).not_to include("signatures_by_country")
     end
   end
 end

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -205,6 +205,21 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       )
     end
 
+    it "doesn't include the signatures by constituency data in rejected petitions" do
+      petition = FactoryBot.create :rejected_petition
+
+      FactoryBot.create :constituency, :coventry_north_east
+      FactoryBot.create :constituency, :bethnal_green_and_bow
+
+      FactoryBot.create :constituency_petition_journal, constituency_id: 3427, signature_count: 123, petition: petition
+      FactoryBot.create :constituency_petition_journal, constituency_id: 3320, signature_count: 456, petition: petition
+
+      get "/petitions/#{petition.id}.json"
+      expect(response).to be_success
+
+      expect(attributes.keys).not_to include("signatures_by_constituency")
+    end
+
     it "includes the signatures by country data" do
       petition = FactoryBot.create :open_petition
 
@@ -233,6 +248,21 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
           )
         )
       )
+    end
+
+    it "doesn't include the signatures by country data in rejected petitions" do
+      petition = FactoryBot.create :rejected_petition
+
+      gb = FactoryBot.create :location, name: "United Kingdom", code: "gb"
+      fr = FactoryBot.create :location, name: "France", code: "fr"
+
+      FactoryBot.create :country_petition_journal, location: gb, signature_count: 123456, petition: petition
+      FactoryBot.create :country_petition_journal, location: fr, signature_count: 789, petition: petition
+
+      get "/petitions/#{petition.id}.json"
+      expect(response).to be_success
+
+      expect(attributes.keys).not_to include("signatures_by_country")
     end
   end
 end


### PR DESCRIPTION
Rejected petitions only have creator and sponsor signatures.