### PR TITLE
Respond correctly to non-HTML requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'dotenv-rails', :require => 'dotenv/rails-now'
 gem 'rails', '4.2.10'
 
 gem 'rake'
-gem 'pg'
+gem 'pg', '< 0.21'
 gem 'authlogic'
 gem 'will_paginate'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
-    pg (0.21.0)
+    pg (0.20.0)
     phantomjs (2.1.1.0)
     pickle (0.5.4)
       cucumber (>= 0.8, < 3.0)
@@ -331,7 +331,7 @@ DEPENDENCIES
   net-http-persistent
   nokogiri
   paperclip
-  pg
+  pg (< 0.21)
   pickle
   poltergeist
   pry

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -69,6 +69,12 @@ class PetitionsController < ApplicationController
     end
   end
 
+  def gathering_support
+    respond_to do |format|
+      format.html
+    end
+  end
+
   def moderation_info
     respond_to do |format|
       format.html

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -11,6 +11,7 @@ default: &defaults
 
   # Actions that should not be monitored by AppSignal
   ignore_actions:
+    - PetitionsController#count
     - PingController#ping
 
   # Exceptions that should not be recorded by AppSignal

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
   # Turn on lograge, to give us more parseable logs
   config.lograge.enabled = true
   config.lograge.ignore_actions = %w[
+    PetitionsController#count
     PingController#ping
     Admin::UserSessionsController#status
     Admin::LocksController#show

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -217,6 +217,14 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     it_behaves_like 'a route that only supports html formats'
   end
 
+  context 'the petitions/gathering-support url' do
+    let(:url) { "/petitions/#{petition.id}/gathering-support" }
+    let(:petition) { FactoryBot.create(:validated_petition) }
+    let(:params) { {} }
+
+    it_behaves_like 'a route that only supports html formats'
+  end
+
   context 'the petitions/moderation-info url' do
     let(:url) { "/petitions/#{petition.id}/moderation-info" }
     let(:petition) { FactoryBot.create(:sponsored_petition) }


### PR DESCRIPTION
The /petitions/:id/gathering-support route used an implicit action so didn't respond correctly to non-HTML requests (e.g. application/json).