### PR TITLE
Lock paperclip to 5.x branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'connection_pool'
 gem 'lograge'
 gem 'logstash-logger'
 gem 'jbuilder'
-gem 'paperclip'
+gem 'paperclip', '~> 5.3'
 gem 'maxminddb'
 gem 'redcarpet'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       connection_pool (~> 2.2)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    paperclip (6.1.0)
+    paperclip (5.3.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
       mime-types
@@ -336,7 +336,7 @@ DEPENDENCIES
   maxminddb
   net-http-persistent
   nokogiri
-  paperclip
+  paperclip (~> 5.3)
   pg (< 0.21)
   pickle
   poltergeist


### PR DESCRIPTION
Paperclip 6.0+ requires AWS SDK v3.x so restrict until we're ready.