### PR TITLE
Reduce confusion when people share their signed page

### DIFF
--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -12,7 +12,8 @@ class SponsorsController < SignaturesController
       @signature.validate!
     end
 
-    redirect_to signed_sponsor_url(@signature, token: @signature.perishable_token)
+    store_signed_token_in_session
+    redirect_to signed_sponsor_url(@signature)
   end
 
   private
@@ -60,8 +61,8 @@ class SponsorsController < SignaturesController
     thank_you_petition_sponsors_url(@petition, token: @petition.sponsor_token)
   end
 
-  def verify_url
-    verify_sponsor_url(@signature, token: @signature.perishable_token)
+  def signed_token_failure_url
+    moderation_info_petition_url(@petition)
   end
 
   def redirect_to_petition_page_if_moderated

--- a/app/models/concerns/perishable_token_generator.rb
+++ b/app/models/concerns/perishable_token_generator.rb
@@ -1,16 +1,11 @@
 module PerishableTokenGenerator
-
   extend ActiveSupport::Concern
 
   class_methods do
     def has_perishable_token(called: 'perishable_token')
-      setter_method_name = :"set_#{called}"
-      before_create setter_method_name
-
-      define_method setter_method_name do
-        self.send(:"#{called}=", Authlogic::Random.friendly_token)
+      before_create do
+        write_attribute(called, Authlogic::Random.friendly_token)
       end
-      private setter_method_name
     end
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -5,6 +5,7 @@ class Signature < ActiveRecord::Base
   include PerishableTokenGenerator
 
   has_perishable_token
+  has_perishable_token called: 'signed_token'
   has_perishable_token called: 'unsubscribe_token'
 
   PENDING_STATE = 'pending'

--- a/db/migrate/20181202102751_add_signed_token_to_signature.rb
+++ b/db/migrate/20181202102751_add_signed_token_to_signature.rb
@@ -1,0 +1,5 @@
+class AddSignedTokenToSignature < ActiveRecord::Migration
+  def change
+    add_column :signatures, :signed_token, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1056,7 +1056,8 @@ CREATE TABLE public.signatures (
     archived_at timestamp without time zone,
     email_count integer DEFAULT 0 NOT NULL,
     sponsor boolean DEFAULT false NOT NULL,
-    creator boolean DEFAULT false NOT NULL
+    creator boolean DEFAULT false NOT NULL,
+    signed_token character varying
 );
 
 
@@ -2679,4 +2680,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180510131346');
 INSERT INTO schema_migrations (version) VALUES ('20180623131406');
 
 INSERT INTO schema_migrations (version) VALUES ('20181201073159');
+
+INSERT INTO schema_migrations (version) VALUES ('20181202102751');
 

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -116,7 +116,7 @@ Feature: Suzie signs a petition
     When Suzie has already signed the petition and validated her email
     And Suzie shares the signatory confirmation link with Eric
     And I click the shared link
-    Then I view the petition
+    Then I should see "Sign this petition"
 
   Scenario: Suzie cannot start a new signature when the petition has closed
     Given the petition has closed

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -33,8 +33,13 @@ RSpec.describe Signature, type: :model do
     end
 
     it "generates unsubscription token" do
-      s = FactoryBot.create(:signature, :unsubscribe_token=> nil)
+      s = FactoryBot.create(:signature, :unsubscribe_token => nil)
       expect(s.unsubscribe_token).not_to be_nil
+    end
+
+    it "generates signed token" do
+      s = FactoryBot.create(:signature, :signed_token => nil)
+      expect(s.signed_token).not_to be_nil
     end
   end
 

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -260,12 +260,12 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   context 'the sponsors/sponsored url' do
     let(:url) { "/sponsors/#{signature.id}/sponsored" }
     let(:petition) { FactoryBot.create(:pending_petition) }
-    let(:signature) { FactoryBot.create(:sponsor, :validated, :just_signed, petition: petition) }
-    let(:params) {
-      {
-        'token' => signature.perishable_token
-      }
-    }
+    let(:signature) { FactoryBot.create(:sponsor, :pending, petition: petition) }
+    let(:params) { {} }
+
+    before do
+      get "/sponsors/#{signature.id}/verify?token=#{signature.perishable_token}"
+    end
 
     it_behaves_like 'a route that only supports html formats'
   end
@@ -289,14 +289,11 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   context 'the signatures/signed url' do
     let(:url) { "/signatures/#{signature.id}/signed" }
     let(:petition) { FactoryBot.create(:open_petition) }
-    let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
-    let(:params) {
-      {
-        'token' => signature.perishable_token
-      }
-    }
+    let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+    let(:params) { {} }
+
     before do
-      allow(Constituency).to receive(:find_by_postcode).and_return(nil)
+      get "/signatures/#{signature.id}/verify?token=#{signature.perishable_token}"
     end
 
     it_behaves_like 'a route that only supports html formats'

--- a/spec/requests/missing_tokens_spec.rb
+++ b/spec/requests/missing_tokens_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "missing a 'token'", type: :request, show_exceptions: true do
       get "/signatures/#{signature.id}/signed"
     end
 
-    it "returns 404 Not Found" do
-      expect(response).to have_http_status(:not_found)
+    it "redirects to the petition page" do
+      expect(response).to redirect_to("/petitions/#{petition.id}")
     end
   end
 


### PR DESCRIPTION
Although we embed sharing links in the page people often share the last page in the signing process (`/signatures/:id/signed?token=123456`) which thanks them for signing a petition. When someone else clicks this link they also see the same page thanking them for signing the petition which has led to some confusion and emails from people saying they just wanted to look at the petition before signing it.

To fix this we're adding a hidden token which gets set in the session when the person follows the verification link and removing the token from the url. This means that when someone shares that url and someone else clicks it they don't have the hidden token in the session and we can redirect to the petition page or then moderation info page if the petition isn't published yet.