### PR TITLE
Add statistics about duplicate email usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :test do
   gem 'email_spec'
   gem 'launchy'
   gem 'webmock'
+  gem 'test_after_commit'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
       sprockets (>= 3.0.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    test_after_commit (1.2.2)
+      activerecord (>= 3.2, < 5.0)
     textacular (3.2.2)
       activerecord (>= 3.0, < 5.0)
     thor (0.20.3)
@@ -349,6 +351,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   slack-notifier
+  test_after_commit
   textacular
   uglifier
   webmock

--- a/app/assets/stylesheets/petitions/admin/_meta.scss
+++ b/app/assets/stylesheets/petitions/admin/_meta.scss
@@ -13,6 +13,15 @@
         }
       }
     }
+
+    .statistics-meta {
+      small {
+        @include core-14;
+        color: $grey-1;
+        display: block;
+        margin-bottom: em(6, 16);
+      }
+    }
   }
 
   .petition-meta-state, .petition-meta-signature-count {

--- a/app/controllers/admin/petition_statistics_controller.rb
+++ b/app/controllers/admin/petition_statistics_controller.rb
@@ -1,0 +1,15 @@
+class Admin::PetitionStatisticsController < Admin::AdminController
+  before_action :require_sysadmin
+  before_action :fetch_petition
+
+  def update
+    UpdatePetitionStatisticsJob.perform_later(@petition)
+    redirect_to admin_petition_url(@petition), notice: :enqueued_petition_statistics_update
+  end
+
+  private
+
+  def fetch_petition
+    @petition = Petition.moderated.find(params[:petition_id])
+  end
+end

--- a/app/jobs/enqueue_petition_statistics_updates_job.rb
+++ b/app/jobs/enqueue_petition_statistics_updates_job.rb
@@ -1,0 +1,9 @@
+class EnqueuePetitionStatisticsUpdatesJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform(timestamp)
+    Petition.signed_since(timestamp.in_time_zone).find_each do |petition|
+      UpdatePetitionStatisticsJob.perform_later(petition)
+    end
+  end
+end

--- a/app/jobs/update_petition_statistics_job.rb
+++ b/app/jobs/update_petition_statistics_job.rb
@@ -1,0 +1,7 @@
+class UpdatePetitionStatisticsJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform(petition)
+    petition.statistics.refresh!
+  end
+end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -76,6 +76,7 @@ class Petition < ActiveRecord::Base
   has_one :government_response, dependent: :destroy
   has_one :note, dependent: :destroy
   has_one :rejection, dependent: :destroy
+  has_one :statistics, dependent: :destroy
 
   has_many :signatures
   has_many :sponsors, -> { sponsors }, class_name: 'Signature'
@@ -383,6 +384,10 @@ class Petition < ActiveRecord::Base
       untagged.in_moderation
     end
 
+    def signed_since(timestamp)
+      where(arel_table[:last_signed_at].gt(timestamp))
+    end
+
     private
 
     def moderation_threshold_reached_at
@@ -427,6 +432,10 @@ class Petition < ActiveRecord::Base
     def scheduled_debate_state
       arel_table[:debate_state].eq('scheduled')
     end
+  end
+
+  def statistics
+    super || create_statistics!
   end
 
   def update_signature_count!

--- a/app/models/petition/statistics.rb
+++ b/app/models/petition/statistics.rb
@@ -1,0 +1,26 @@
+class Petition < ActiveRecord::Base
+  class Statistics < ActiveRecord::Base
+    belongs_to :petition
+
+    after_commit on: :create do
+      UpdatePetitionStatisticsJob.perform_later(petition)
+    end
+
+    def refresh!(now = Time.current)
+      update!(
+        refreshed_at: now,
+        duplicate_emails: refresh_duplicate_emails
+      )
+    end
+
+    def refreshed?
+      refreshed_at?
+    end
+
+    private
+
+      def refresh_duplicate_emails
+        petition.signatures.duplicate_emails
+      end
+  end
+end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -90,6 +90,10 @@ class Signature < ActiveRecord::Base
       where(arel_table[:id].not_eq(id).and(arel_table[:email].eq(email)))
     end
 
+    def duplicate_emails
+      unscoped.from(validated.select(:uuid).group(:uuid).having(arel_table[Arel.star].count.gt(1))).count
+    end
+
     def for_email(email)
       where(email: email.downcase)
     end

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -37,6 +37,11 @@
   <% end %>
 
   <% if current_user.is_a_sysadmin? %>
+    <% if @petition.statistics.refreshed? %>
+      <dt>Duplicate emails</dt>
+      <dd><%= number_with_delimiter(@petition.statistics.duplicate_emails) %></dd>
+    <% end %>
+
     <% if @petition.fraudulent_domains? %>
       <dt>Fraudulent domains</dt>
       <dd>
@@ -53,3 +58,17 @@
   <% end %>
 <% end %>
 </dl>
+
+<% if current_user.is_a_sysadmin? %>
+  <div class="statistics-meta">
+    <small>
+      <% if @petition.statistics.refreshed? %>
+        Statistics last updated at <time datetime="<%= @petition.statistics.refreshed_at.iso8601 %>"><%= date_time_format(@petition.statistics.refreshed_at) %></time>
+      <% else %>
+        Statistics not yet generated
+      <% end %>
+    </small>
+
+    <%=  button_to 'Refresh', admin_petition_statistics_url(@petition), method: :patch, class: 'button' %>
+  </div>
+<% end %>

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -36,6 +36,7 @@ en-GB:
       debate_date_updated: "Updated the scheduled debate date successfully"
       debate_outcome_updated: "Updated debate outcome successfully"
       email_sent_overnight: "Email will be sent overnight"
+      enqueued_petition_statistics_update: "Updating the petition statistics - please wait a few minutes and then refresh this page"
       government_response_updated: "Updated government response successfully"
       failed_tasks: "There was a problem starting the tasks - please contact support"
       invalidation_cant_be_cancelled: "Can't cancel invalidations that have completed"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
         resources :emails, controller: 'petition_emails', except: %i[index show]
         resource  :lock, only: %i[show create update destroy]
         resource  :moderation, controller: 'moderation', only: %i[update]
+        resource  :statistics, controller: 'petition_statistics', only: %i[update]
 
         scope only: %i[show update] do
           resource :debate_outcome, path: 'debate-outcome'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -48,3 +48,7 @@ end
 every :day, at: '7.15am' do
   rake "epets:petitions:debated", output: nil
 end
+
+every 60.minutes do
+  rake "epets:petitions:update_statistics", output: nil
+end

--- a/db/migrate/20181211115757_create_petition_statistics.rb
+++ b/db/migrate/20181211115757_create_petition_statistics.rb
@@ -1,0 +1,11 @@
+class CreatePetitionStatistics < ActiveRecord::Migration
+  def change
+    create_table :petition_statistics do |t|
+      t.belongs_to :petition, index: { unique: true }, foreign_key: true
+      t.timestamp :refreshed_at
+      t.integer :duplicate_emails
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -887,6 +887,39 @@ ALTER SEQUENCE public.petition_emails_id_seq OWNED BY public.petition_emails.id;
 
 
 --
+-- Name: petition_statistics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE public.petition_statistics (
+    id integer NOT NULL,
+    petition_id integer,
+    refreshed_at timestamp without time zone,
+    duplicate_emails integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: petition_statistics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.petition_statistics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: petition_statistics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.petition_statistics_id_seq OWNED BY public.petition_statistics.id;
+
+
+--
 -- Name: petitions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1350,6 +1383,13 @@ ALTER TABLE ONLY public.petition_emails ALTER COLUMN id SET DEFAULT nextval('pub
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY public.petition_statistics ALTER COLUMN id SET DEFAULT nextval('public.petition_statistics_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.petitions ALTER COLUMN id SET DEFAULT nextval('public.petitions_id_seq'::regclass);
 
 
@@ -1569,6 +1609,14 @@ ALTER TABLE ONLY public.parliaments
 
 ALTER TABLE ONLY public.petition_emails
     ADD CONSTRAINT petition_emails_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: petition_statistics_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY public.petition_statistics
+    ADD CONSTRAINT petition_statistics_pkey PRIMARY KEY (id);
 
 
 --
@@ -2041,6 +2089,13 @@ CREATE INDEX index_petition_emails_on_petition_id ON public.petition_emails USIN
 
 
 --
+-- Name: index_petition_statistics_on_petition_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_petition_statistics_on_petition_id ON public.petition_statistics USING btree (petition_id);
+
+
+--
 -- Name: index_petitions_on_action; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2376,6 +2431,14 @@ ALTER TABLE ONLY public.petition_emails
 
 
 --
+-- Name: fk_rails_a6de6b1362; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.petition_statistics
+    ADD CONSTRAINT fk_rails_a6de6b1362 FOREIGN KEY (petition_id) REFERENCES public.petitions(id);
+
+
+--
 -- Name: fk_rails_b6266f73f1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2682,4 +2745,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180623131406');
 INSERT INTO schema_migrations (version) VALUES ('20181201073159');
 
 INSERT INTO schema_migrations (version) VALUES ('20181202102751');
+
+INSERT INTO schema_migrations (version) VALUES ('20181211115757');
 

--- a/features/step_definitions/validation_steps.rb
+++ b/features/step_definitions/validation_steps.rb
@@ -1,5 +1,5 @@
 Then /^the markup should be valid$/ do
-  tags = %w[header nav main details summary section footer]
+  tags = %w[header nav main details summary section footer time]
   pattern = /\A\d+:\d+: ERROR: Tag (?:#{tags.join('|')}) invalid\z/
   filter = -> (error){ error.message =~ pattern }
 

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -23,6 +23,13 @@ namespace :epets do
       end
     end
 
+    desc "Add a task to the queue to update petition statistics"
+    task :update_statistics => :environment do
+      Task.run("epets:petitions:update_statistics", 30.minutes) do
+        EnqueuePetitionStatisticsUpdatesJob.perform_later(60.minutes.ago.iso8601)
+      end
+    end
+
     desc "Backfill moderation lag"
     task :backfill_moderation_lag => :environment do
       %w[petitions archived_petitions].each do |table_name|

--- a/spec/controllers/admin/petition_statistics_controller_spec.rb
+++ b/spec/controllers/admin/petition_statistics_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PetitionStatisticsController, type: :controller, admin: true do
+  let!(:petition) { FactoryBot.create(:open_petition) }
+
+  context "when not logged in" do
+    describe "PATCH /admin/petitions/:petition_id/statistics" do
+      before do
+        patch :update, petition_id: petition.id
+      end
+
+      it "redirects to the login page" do
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+      end
+    end
+  end
+
+  context "when logged in as a moderator" do
+    let(:moderator) { FactoryBot.create(:moderator_user) }
+    before { login_as(moderator) }
+
+    describe "PATCH /admin/petitions/:petition_id/statistics" do
+      before do
+        patch :update, petition_id: petition.id
+      end
+
+      it "redirects to the admin hub page" do
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+      end
+    end
+  end
+
+  context "when logged in as a sysadmin" do
+    let(:sysadmin) { FactoryBot.create(:sysadmin_user) }
+    before { login_as(sysadmin) }
+
+    describe "PATCH /admin/petitions/:petition_id/statistics" do
+      before do
+        patch :update, petition_id: petition.id
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
+      end
+
+      it "sets the flash notice message" do
+        expect(flash[:notice]).to eq("Updating the petition statistics - please wait a few minutes and then refresh this page")
+      end
+
+      it "enqueues a UpdatePetitionStatisticsJob" do
+        update_statistics_job = {
+          job: UpdatePetitionStatisticsJob,
+          args: [{ "_aj_globalid" => "gid://epets/Petition/#{petition.id}" }],
+          queue: "low_priority"
+        }
+
+        expect(enqueued_jobs).to eq([update_statistics_job])
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -620,6 +620,10 @@ FactoryBot.define do
     sent_by "Admin User"
   end
 
+  factory :petition_statistics, class: "Petition::Statistics" do
+    association :petition, factory: :open_petition
+  end
+
   factory :rejection do
     association :petition, factory: :validated_petition
     code "duplicate"

--- a/spec/jobs/enqueue_petition_statistics_updates_job_spec.rb
+++ b/spec/jobs/enqueue_petition_statistics_updates_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe EnqueuePetitionStatisticsUpdatesJob, type: :job do
+  let(:timestamp) { 1.hour.ago.iso8601 }
+
+  it "only enqueues jobs for petitions signed in the last hour" do
+    FactoryBot.create(:open_petition, last_signed_at: 2.hours.ago)
+    FactoryBot.create(:open_petition, last_signed_at: 30.minutes.ago)
+    FactoryBot.create(:open_petition, last_signed_at: 15.minutes.ago)
+
+    expect {
+      described_class.perform_now(timestamp)
+    }.to change {
+      enqueued_jobs.size
+    }.from(0).to(2)
+  end
+
+  it "enqueues an UpdatePetitionStatisticsJob job" do
+    petition = FactoryBot.create(:open_petition, last_signed_at: 15.minutes.ago)
+
+    update_statistics_job = {
+      job: UpdatePetitionStatisticsJob,
+      args: [{ "_aj_globalid" => "gid://epets/Petition/#{petition.id}" }],
+      queue: "low_priority"
+    }
+
+    expect {
+      described_class.perform_now(timestamp)
+    }.to change {
+      enqueued_jobs
+    }.from([]).to([update_statistics_job])
+  end
+end

--- a/spec/jobs/update_petition_statistics_job_spec.rb
+++ b/spec/jobs/update_petition_statistics_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe UpdatePetitionStatisticsJob, type: :job do
+  let(:petition) { FactoryBot.create(:open_petition) }
+  let(:statistics) { petition.statistics }
+
+  it "updates the petition statistics" do
+    expect {
+      described_class.perform_now(petition)
+    }.to change {
+      statistics.reload.refreshed_at
+    }.to(be_within(1.second).of(Time.current))
+  end
+end

--- a/spec/models/petition/statistics_spec.rb
+++ b/spec/models/petition/statistics_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe Petition::Statistics, type: :model do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:petition_statistics)).to be_valid
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:petition) }
+  end
+
+  describe "indexes" do
+    it { is_expected.to have_db_index([:petition_id]) }
+  end
+
+  describe "callbacks", with_commits: true do
+    let!(:petition) { FactoryBot.create(:open_petition) }
+
+    it "enqueues a job on create" do
+      expect {
+        petition.create_statistics!
+      }.to change {
+        enqueued_jobs.size
+      }.by(1)
+    end
+
+    it "doesn't enqueue a job on update" do
+      petition.create_statistics!
+
+      expect {
+        petition.statistics.refresh!
+      }.not_to change {
+        enqueued_jobs.size
+      }
+    end
+  end
+
+  describe "#refreshed?" do
+    context "when the statistics have never been updated" do
+      let(:statistics) { FactoryBot.build(:petition_statistics, refreshed_at: nil) }
+
+      it "returns false" do
+        expect(statistics.refreshed?).to eq(false)
+      end
+    end
+
+    context "when the statistics have been updated" do
+      let(:statistics) { FactoryBot.build(:petition_statistics, refreshed_at: 1.hour.ago) }
+
+      it "returns true" do
+        expect(statistics.refreshed?).to eq(true)
+      end
+    end
+  end
+
+  describe "#refresh!" do
+    let!(:petition) { FactoryBot.create(:open_petition) }
+    let!(:statistics) { FactoryBot.create(:petition_statistics, petition: petition, refreshed_at: nil) }
+
+    it "updates the refreshed_at timestamp" do
+      expect {
+        statistics.refresh!
+      }.to change {
+        statistics.reload.refreshed_at
+      }.from(nil).to(be_within(1.second).of(Time.current))
+    end
+
+    context "when there are no duplicate emails" do
+      it "updates the duplicate_emails count" do
+        expect {
+          statistics.refresh!
+        }.to change {
+          statistics.reload.duplicate_emails
+        }.from(nil).to(0)
+      end
+    end
+
+    context "when there are duplicate emails" do
+      let!(:alice) { FactoryBot.create(:pending_signature, petition: petition, name: "Alice", email: "aliceandbob@example.com") }
+      let!(:bob) { FactoryBot.create(:pending_signature, petition: petition, name: "Bob", email: "aliceandbob@example.com") }
+
+      it "updates the duplicate_emails count" do
+        perform_enqueued_jobs do
+          alice.validate!
+          bob.validate!
+        end
+
+        expect {
+          statistics.refresh!
+        }.to change {
+          statistics.reload.duplicate_emails
+        }.from(nil).to(1)
+      end
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -751,6 +751,20 @@ RSpec.describe Petition, type: :model do
         expect(Petition.untagged_in_moderation).not_to include(tagged_recent_petition, tagged_overdue_petition, tagged_nearly_overdue_petition)
       end
     end
+
+    describe ".signed_since" do
+      let!(:petition_1) { FactoryBot.create(:open_petition, last_signed_at: 2.hours.ago) }
+      let!(:petition_2) { FactoryBot.create(:open_petition, last_signed_at: 30.minutes.ago) }
+      let!(:petition_3) { FactoryBot.create(:open_petition, last_signed_at: 15.minutes.ago) }
+
+      it "returns petitions that have been signed since the timestamp" do
+        expect(Petition.signed_since(1.hour.ago)).to include(petition_2, petition_3)
+      end
+
+      it "doesn't return petitions that haven't been signed since the timestamp" do
+        expect(Petition.signed_since(1.hour.ago)).not_to include(petition_1)
+      end
+    end
   end
 
   it_behaves_like "a taggable model"

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -1042,6 +1042,27 @@ RSpec.describe Signature, type: :model do
     end
   end
 
+  describe ".duplicate_emails" do
+    let!(:petition) { FactoryBot.create(:open_petition) }
+
+    context "when there are no duplicate emails" do
+      it "returns zero" do
+        expect(petition.signatures.duplicate_emails).to eq(0)
+      end
+    end
+
+    context "when there are duplicate emails" do
+      before do
+        FactoryBot.create(:validated_signature, petition: petition, name: "Alice", email: "aliceandbob@example.com")
+        FactoryBot.create(:validated_signature, petition: petition, name: "Bob", email: "aliceandbob@example.com")
+      end
+
+      it "returns the number of duplicate emails" do
+        expect(petition.signatures.duplicate_emails).to eq(1)
+      end
+    end
+  end
+
   describe "#number" do
     let(:attributes) { FactoryBot.attributes_for(:petition) }
     let(:creator) { FactoryBot.create(:pending_signature, creator: true) }

--- a/spec/support/after_commits.rb
+++ b/spec/support/after_commits.rb
@@ -1,0 +1,13 @@
+TestAfterCommit.enabled = false
+
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    if example.metadata.key?(:with_commits)
+      TestAfterCommit.with_commits(example.metadata[:with_commits]) do
+        example.run
+      end
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
Because people sometimes share email addresses we allow up to two signatures using the same email address as long as the name is different and the postcode is the same. The petitions committee often receives queries about the abuse of this rule so to improve the speed of handling these add the statistics about them to the petition admin page.

Because the query takes a long time with petitions that have a large number of signatures the implementation is a little complicated and we have to cache the results and update them every hour. If a more recent number is required the sysadmin user can kick off an manual refresh of the statistics. The pattern is flexible so that we can add further statistics in the future.