### PR TITLE
Ensure signed tokens exist during rollout

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -374,6 +374,10 @@ class Signature < ActiveRecord::Base
           attributes[:constituency_id] = new_constituency_id
         end
 
+        unless signed_token?
+          attributes[:signed_token] = Authlogic::Random.friendly_token
+        end
+
         update_columns(attributes)
       end
     end
@@ -447,6 +451,10 @@ class Signature < ActiveRecord::Base
     end
   end
 
+  def signed_token
+    super || generate_and_save_signed_token
+  end
+
   def get_email_sent_at_for(timestamp)
     self[column_name_for(timestamp)]
   end
@@ -486,6 +494,20 @@ class Signature < ActiveRecord::Base
 
   def generate_uuid
     Digest::UUID.uuid_v5(Digest::UUID::URL_NAMESPACE, "mailto:#{email}")
+  end
+
+  def generate_and_save_signed_token
+    token = Authlogic::Random.friendly_token
+
+    retry_lock do
+      if signed_token?
+        token = read_attribute(:signed_token)
+      else
+        update_column(:signed_token, token)
+      end
+    end
+
+    token
   end
 
   def column_name_for(timestamp)


### PR DESCRIPTION
Until all existing pengin signatures have been verified it's possible that signed_token may be nil so generate it dynamically if it's not been set. This ensures that anyone following the verify link sees the signed page and any existing sharing of a signed link with a token in the url gets redirected to the petition page.