### PR TITLE
Update holiday messaging

### DIFF
--- a/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
@@ -6,6 +6,14 @@
 
 <p><%= Site.threshold_for_moderation %> people need to click the link and confirm their support for us to publish your petition.</p>
 
+<% if christmas_period? %>
+<p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
+<% elsif easter_period? %>
+<p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
+<% else %>
+<p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.</p>
+<% end %>
+
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
@@ -6,6 +6,14 @@ Forward the email below to your potential supporters.
 
 <%= Site.threshold_for_moderation %> people need to click the link and confirm their support for us to publish your petition.
 
+<% if christmas_period? %>
+Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+<% elsif easter_period? %>
+Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
+<% else %>
+Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.
+<% end %>
+
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
 <%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.html.erb
@@ -5,9 +5,9 @@
 <p><%= @sponsor.name %> supported your petition – “<%= @petition.action %>”.</p>
 
 <% if christmas_period? %>
-<p><%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Christmas period it may take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
+<p><%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
 <% elsif easter_period? %>
-<p><%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Easter period it may take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
+<p><%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
 <% else %>
 <p><%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.</p>
 <% end %>

--- a/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
+++ b/app/views/sponsor_mailer/sponsor_signed_email_on_threshold.text.erb
@@ -5,9 +5,9 @@ Your petition is nearly ready to go.
 <%= @sponsor.name %> supported your petition – "<%= @petition.action %>".
 
 <% if christmas_period? %>
-<%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Christmas period it may take us a little longer than usual. We’ll check your petition as quickly as we can.
+<%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
 <% elsif christmas_period? %>
-<%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Easter period it may take us a little longer than usual. We’ll check your petition as quickly as we can.
+<%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
 <% else %>
 <%= @sponsor_count %> people have supported your petition so far. We’re checking your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.
 <% end %>

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -334,6 +334,30 @@ RSpec.describe PetitionMailer, type: :mailer do
     it "includes the petition additional details" do
       expect(mail).to have_body_text(%r[To promote organic vegetables])
     end
+
+    it "includes information about moderation" do
+      expect(mail).to have_body_text(%r[Once you’ve gained the required number of supporters])
+    end
+
+    context "during Christmas" do
+      before do
+        allow(Holiday).to receive(:christmas?).and_return(true)
+      end
+
+      it "includes information about delayed moderation" do
+        expect(mail).to have_body_text(%r[but over the Christmas period it will take us a little longer])
+      end
+    end
+
+    context "during Easter" do
+      before do
+        allow(Holiday).to receive(:easter?).and_return(true)
+      end
+
+      it "includes information about delayed moderation" do
+        expect(mail).to have_body_text(%r[but over the Easter period it will take us a little longer])
+      end
+    end
   end
 
   describe "notifying signature of debate outcome" do

--- a/spec/mailers/sponsor_mailer_spec.rb
+++ b/spec/mailers/sponsor_mailer_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe SponsorMailer, type: :mailer do
       it_behaves_like "a sponsor signed on threshold email"
 
       it "doesn't include the moderation delay message" do
-        expect(mail).not_to have_body_text(%r[over the Christmas period it may take us a little longer than usual])
+        expect(mail).not_to have_body_text(%r[over the Christmas period it will take us a little longer than usual])
       end
     end
 
@@ -143,7 +143,7 @@ RSpec.describe SponsorMailer, type: :mailer do
       it_behaves_like "a sponsor signed on threshold email"
 
       it "includes the moderation delay message" do
-        expect(mail).to have_body_text(%r[over the Christmas period it may take us a little longer than usual])
+        expect(mail).to have_body_text(%r[over the Christmas period it will take us a little longer than usual])
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe SponsorMailer, type: :mailer do
       it_behaves_like "a sponsor signed on threshold email"
 
       it "doesn't include the moderation delay message" do
-        expect(mail).not_to have_body_text(%r[over the Christmas period it may take us a little longer than usual])
+        expect(mail).not_to have_body_text(%r[over the Christmas period it will take us a little longer than usual])
       end
     end
 
@@ -167,7 +167,7 @@ RSpec.describe SponsorMailer, type: :mailer do
       it_behaves_like "a sponsor signed on threshold email"
 
       it "doesn't include the moderation delay message" do
-        expect(mail).not_to have_body_text(%r[over the Easter period it may take us a little longer than usual])
+        expect(mail).not_to have_body_text(%r[over the Easter period it will take us a little longer than usual])
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe SponsorMailer, type: :mailer do
       it_behaves_like "a sponsor signed on threshold email"
 
       it "includes the moderation delay message" do
-        expect(mail).to have_body_text(%r[over the Easter period it may take us a little longer than usual])
+        expect(mail).to have_body_text(%r[over the Easter period it will take us a little longer than usual])
       end
     end
 
@@ -191,7 +191,7 @@ RSpec.describe SponsorMailer, type: :mailer do
       it_behaves_like "a sponsor signed on threshold email"
 
       it "doesn't include the moderation delay message" do
-        expect(mail).not_to have_body_text(%r[over the Easter period it may take us a little longer than usual])
+        expect(mail).not_to have_body_text(%r[over the Easter period it will take us a little longer than usual])
       end
     end
   end


### PR DESCRIPTION
Use the word 'will' instead of 'may' as no moderation will take place over the Christmas week. Also add the messaging to the initial email that creators get to inform them about delayed moderation.