### PR TITLE
Remove the committee email address from the email help

### DIFF
--- a/app/views/signatures/thank_you.html.erb
+++ b/app/views/signatures/thank_you.html.erb
@@ -23,11 +23,8 @@
     </ul>
 
     <p>
-      If you still don’t receive a confirmation email, send us an email and we can manually confirm your address for you.
+      If you still don’t receive a confirmation email, please <%= link_to 'contact us', feedback_path %>.
     </p>
 
-    <p>
-      <strong>petitionscommittee@parliament.uk</strong>
-    </p>
   </div>
 </details>


### PR DESCRIPTION
Due to overloading the committee, we're keen to see if removing the email address and routing through the feedback from helps.

The committee will then contact the requester asking them to reply in order to validate the address.

It's a trial to see if that changes the contact rates etc...