### PR TITLE
Add a postcode length validation

### DIFF
--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -171,6 +171,7 @@ class PetitionCreator
     errors.add(:email, :blank) unless email.present?
     errors.add(:location_code, :blank) unless location_code.present?
     errors.add(:uk_citizenship, :accepted) unless uk_citizenship == "1"
+    errors.add(:postcode, :too_long, count: 255) if postcode.length > 255
 
     if email.present?
       email_validator.validate(self)

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -33,6 +33,7 @@ class Signature < ActiveRecord::Base
   validates :email, presence: true, email: { allow_blank: true }, on: :create
   validates :location_code, presence: true
   validates :postcode, presence: true, postcode: true, if: :united_kingdom?
+  validates :postcode, length: { maximum: 255 }, allow_blank: true
   validates :uk_citizenship, acceptance: true, unless: :persisted?, allow_nil: false
   validates :constituency_id, length: { maximum: 255 }
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -273,25 +273,35 @@ RSpec.describe Signature, type: :model do
         expect(FactoryBot.build(:signature, :postcode => 'SW1A 1AA')).to be_valid
         expect(FactoryBot.build(:signature, :postcode => '')).not_to be_valid
       end
+
       it "does not require a postcode for non-UK addresses" do
         expect(FactoryBot.build(:signature, :location_code => "GB", :postcode => '')).not_to be_valid
         expect(FactoryBot.build(:signature, :location_code => "US", :postcode => '')).to be_valid
       end
+
       it "checks the format of postcode" do
         s = FactoryBot.build(:signature, :postcode => 'SW1A1AA')
         expect(s).to have_valid(:postcode)
       end
+
       it "recognises special postcodes" do
         expect(FactoryBot.build(:signature, :postcode => 'BFPO 1234')).to have_valid(:postcode)
         expect(FactoryBot.build(:signature, :postcode => 'XM4 5HQ')).to have_valid(:postcode)
         expect(FactoryBot.build(:signature, :postcode => 'GIR 0AA')).to have_valid(:postcode)
       end
+
       it "does not allow prefix of postcode only" do
         s = FactoryBot.build(:signature, :postcode => 'N1')
         expect(s).not_to have_valid(:postcode)
       end
+
       it "does not allow unrecognised postcodes" do
         s = FactoryBot.build(:signature, :postcode => '90210')
+        expect(s).not_to have_valid(:postcode)
+      end
+
+      it "does not allow postcodes longer than 255 characters for non-UK addresses" do
+        s = FactoryBot.build(:signature, :location_code => "US", :postcode => "1" * 256)
         expect(s).not_to have_valid(:postcode)
       end
     end


### PR DESCRIPTION
To prevent hard 500 errors when people are signing from outside the UK, add a length validation to the signature forms.