### PR TITLE
Clear up signature signed tokens

### DIFF
--- a/app/assets/stylesheets/petitions/_tables.scss
+++ b/app/assets/stylesheets/petitions/_tables.scss
@@ -1,0 +1,34 @@
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin: 0 0 em(9, 16) 0;
+  width: 100%;
+
+  th,
+  td {
+    @include core-16;
+    padding: em(9, 16) 0 em(9, 16) em(20, 16);
+
+    text-align: left;
+    color: $black;
+    border-bottom: 1px solid $border-colour;
+
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+
+  th {
+    font-weight: 700;
+    // Right align headings for numeric content
+    &.numeric {
+      text-align: right;
+    }
+  }
+
+  // Use tabular numbers for numeric table cells
+  td.numeric {
+    @include core-16($tabular-numbers: true);
+    text-align: right;
+  }
+}

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -31,6 +31,7 @@
 @import "petitions/footer";
 @import "petitions/forms";
 @import "petitions/search-inline";
+@import "petitions/tables";
 @import "petitions/tumble"; // Animation on signature confirm page
 
 @import "petitions/views/shared";

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,6 +1,7 @@
 class SignaturesController < ApplicationController
   before_action :retrieve_petition, only: [:new, :confirm, :create, :thank_you]
   before_action :retrieve_signature, only: [:verify, :unsubscribe, :signed]
+  before_action :expire_signed_tokens, only: [:verify]
   before_action :verify_token, only: [:verify]
   before_action :verify_signed_token, only: [:signed]
   before_action :verify_unsubscribe_token, only: [:unsubscribe]
@@ -99,11 +100,15 @@ class SignaturesController < ApplicationController
   end
 
   def session_signed_token
-    signed_tokens[signature_id.to_s]
+    signed_tokens.delete(signature_id.to_s)
   end
 
   def signed_token_hash
     { signature_id.to_s => @signature.signed_token }
+  end
+
+  def expire_signed_tokens
+    signed_tokens.delete_if { |id, token| Signature.validated?(id) }
   end
 
   def store_signed_token_in_session

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -265,6 +265,10 @@ class Signature < ActiveRecord::Base
       end
     end
 
+    def validated?(id)
+      where(id: id).where(validated_at.not_eq(nil)).exists?
+    end
+
     private
 
     def ip_search?(query)

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -92,7 +92,7 @@
   <ul class="list-bullet">
     <li>information about how your personal data is processed</li>
     <li>a copy of that personal data - this copy will be provided in a structured, commonly used and machine-readable format</li>
-    <li>that anything inaccurate in your personal data is corrected immediately </li>
+    <li>that anything inaccurate in your personal data is corrected immediately</li>
   </ul>
 
   <p>You can also:</p>
@@ -155,7 +155,7 @@
   SK9 5AF
   </p>
 </section>
-  
+
 <section id="cookies" aria-labelledby="cookies-heading">
   <h2 id="cookies-heading">Cookies</h2>
 

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -617,8 +617,14 @@ RSpec.describe SponsorsController, type: :controller do
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
+        let(:other_petition) { FactoryBot.create(:open_petition) }
+        let(:other_signature) { FactoryBot.create(:validated_signature, petition: other_petition) }
 
         before do
+          session[:signed_tokens] = {
+            other_signature.id.to_s => other_signature.signed_token
+          }
+
           get :verify, id: signature.id, token: signature.perishable_token
         end
 
@@ -636,6 +642,10 @@ RSpec.describe SponsorsController, type: :controller do
 
         it "records the constituency id on the signature" do
           expect(assigns[:signature].constituency_id).to eq("3415")
+        end
+
+        it "deletes old signed tokens" do
+          expect(session[:signed_tokens]).not_to have_key(other_signature.id.to_s)
         end
 
         it "saves the signed token in the session" do
@@ -800,6 +810,10 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "renders the sponsors/signed template" do
             expect(response).to render_template("sponsors/signed")
+          end
+
+          it "deletes the signed token from the session" do
+            expect(session[:signed_tokens]).to be_empty
           end
 
           context "and the signature has already seen the confirmation page" do


### PR DESCRIPTION
Some people sign a lot of petitions in a single browser session so remove tokens for signatures that have previously been validated and use it once on the signed page. This changes the behaviour on refreshing the signed page to redirect to the petition page but that's probably a better behaviour anyway.
