### PR TITLE
Only load creator for page title for sponsors

### DIFF
--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -51,7 +51,7 @@ module PageTitleHelper
         if petition?
           opts[:petition] = petition.action
 
-          unless petition.is_a?(Archived::Petition)
+          if controller == 'sponsors'
             opts[:creator] = petition.creator.name
           end
         end


### PR DESCRIPTION
We're seeing lots of this query:

```
SELECT  "signatures".*
FROM "signatures"
WHERE "signatures"."petition_id" = $1
  AND "signatures"."creator" = ?
LIMIT 1
```

The page creator is only needed to build the page title for sponsor pages
but we're loading it for showing petitions also.

We're also not caching the page title so we're seeing this query every
time someone looks as the petition page.

Where the creator is being used: https://github.com/alphagov/e-petitions/blob/master/config/locales/page_titles.en-GB.yml#L33-L34