### PR TITLE
Increase count auto-refresh period to 10 minutes

### DIFF
--- a/app/assets/javascripts/auto-updater.js.erb
+++ b/app/assets/javascripts/auto-updater.js.erb
@@ -8,7 +8,7 @@
   var JSON_URL = window.location.pathname + '/count.json',
       THRESHOLD_RESPONSE = <%= Site.threshold_for_response %>,
       THRESHOLD_DEBATE = <%= Site.threshold_for_debate %>,
-      TIMEOUT = 10000;
+      TIMEOUT = 600000;
 
   function add_commas(n) {
         return n.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ",");


### PR DESCRIPTION
Given petitions are being updated less frequently, there's no need to poll for a count update every ten seconds. This should substantially reduce load generated by people leaving the petition page open.