### PR TITLE
Advise petition creators that there will be a delay to moderation 

### DIFF
--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -32,7 +32,7 @@ class Admin::SitesController < Admin::AdminController
       :threshold_for_response, :threshold_for_debate, :feedback_email,
       :moderate_url, :login_timeout, :disable_constituency_api,
       :signature_count_interval, :update_signature_counts,
-      :disable_trending_petitions
+      :disable_trending_petitions, :threshold_for_moderation_delay
     )
   end
 end

--- a/app/helpers/moderation_helper.rb
+++ b/app/helpers/moderation_helper.rb
@@ -1,0 +1,5 @@
+module ModerationHelper
+  def moderation_delay?
+    Petition.in_moderation.count >= Site.threshold_for_moderation_delay
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,7 @@ class ApplicationMailer < ActionMailer::Base
   default_url_options[:protocol] = Site.email_protocol
   default from: ->(email){ Site.email_from }
 
-  helper :date_time, :rejection, :auto_link, :markdown
+  helper :date_time, :rejection, :auto_link, :markdown, :moderation
 
   layout 'default_mail'
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -129,22 +129,23 @@ class Site < ActiveRecord::Base
 
     def defaults
       {
-        title:                      default_title,
-        url:                        default_url,
-        moderate_url:               default_moderate_url,
-        email_from:                 default_email_from,
-        feedback_email:             default_feedback_email,
-        username:                   default_username,
-        password:                   default_password,
-        enabled:                    default_enabled,
-        protected:                  default_protected,
-        login_timeout:              default_login_timeout,
-        petition_duration:          default_petition_duration,
-        minimum_number_of_sponsors: default_minimum_number_of_sponsors,
-        maximum_number_of_sponsors: default_maximum_number_of_sponsors,
-        threshold_for_moderation:   default_threshold_for_moderation,
-        threshold_for_response:     default_threshold_for_response,
-        threshold_for_debate:       default_threshold_for_debate
+        title:                          default_title,
+        url:                            default_url,
+        moderate_url:                   default_moderate_url,
+        email_from:                     default_email_from,
+        feedback_email:                 default_feedback_email,
+        username:                       default_username,
+        password:                       default_password,
+        enabled:                        default_enabled,
+        protected:                      default_protected,
+        login_timeout:                  default_login_timeout,
+        petition_duration:              default_petition_duration,
+        minimum_number_of_sponsors:     default_minimum_number_of_sponsors,
+        maximum_number_of_sponsors:     default_maximum_number_of_sponsors,
+        threshold_for_moderation:       default_threshold_for_moderation,
+        threshold_for_moderation_delay: default_threshold_for_moderation_delay,
+        threshold_for_response:         default_threshold_for_response,
+        threshold_for_debate:           default_threshold_for_debate
       }
     end
 
@@ -244,6 +245,10 @@ class Site < ActiveRecord::Base
 
     def default_threshold_for_moderation
       ENV.fetch('THRESHOLD_FOR_MODERATION', '5').to_i
+    end
+
+    def default_threshold_for_moderation_delay
+      ENV.fetch('THRESHOLD_FOR_MODERATION_DELAY', '500').to_i
     end
 
     def default_threshold_for_response
@@ -386,6 +391,7 @@ class Site < ActiveRecord::Base
   validates :minimum_number_of_sponsors, presence: true, numericality: { only_integer: true }
   validates :maximum_number_of_sponsors, presence: true, numericality: { only_integer: true }
   validates :threshold_for_moderation, presence: true, numericality: { only_integer: true }
+  validates :threshold_for_moderation_delay, presence: true, numericality: { only_integer: true }
   validates :threshold_for_response, presence: true, numericality: { only_integer: true }
   validates :threshold_for_debate, presence: true, numericality: { only_integer: true }
   validates :username, presence: true, length: { maximum: 30 }, if: :protected?

--- a/app/views/admin/sites/_moderation.html.erb
+++ b/app/views/admin/sites/_moderation.html.erb
@@ -6,6 +6,12 @@
   <%= form.text_field :threshold_for_moderation, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
 <% end %>
 
+<%= form_row for: [form.object, :threshold_for_moderation_delay] do %>
+  <%= form.label :threshold_for_moderation_delay, "Threshold for moderation delay", class: "form-label" %>
+  <%= error_messages_for_field @site, :threshold_for_moderation_delay %>
+  <%= form.text_field :threshold_for_moderation_delay, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
+<% end %>
+
 <%= form_row for: [form.object, :minimum_number_of_sponsors] do %>
   <%= form.label :minimum_number_of_sponsors, class: "form-label" %>
   <%= error_messages_for_field @site, :minimum_number_of_sponsors %>

--- a/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
@@ -11,7 +11,7 @@
 <% elsif easter_period? %>
 <p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
 <% else %>
-<p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.</p>
+<p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less, however we have a very large number to check at the moment so it is likely to take longer. Thank you for your patience.</p>
 <% end %>
 
 <p>Thanks,<br />

--- a/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.html.erb
@@ -10,8 +10,10 @@
 <p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
 <% elsif easter_period? %>
 <p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.</p>
-<% else %>
+<% elsif moderation_delay? %>
 <p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less, however we have a very large number to check at the moment so it is likely to take longer. Thank you for your patience.</p>
+<% else %>
+<p>Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.</p>
 <% end %>
 
 <p>Thanks,<br />

--- a/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
@@ -11,7 +11,7 @@ Once you’ve gained the required number of supporters, we’ll check your petit
 <% elsif easter_period? %>
 Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
 <% else %>
-Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.
+Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less, however we have a very large number to check at the moment so it is likely to take longer. Thank you for your patience.
 <% end %>
 
 Thanks,

--- a/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
+++ b/app/views/petition_mailer/gather_sponsors_for_petition.text.erb
@@ -10,8 +10,10 @@ Forward the email below to your potential supporters.
 Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
 <% elsif easter_period? %>
 Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
-<% else %>
+<% elsif moderation_delay? %>
 Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less, however we have a very large number to check at the moment so it is likely to take longer. Thank you for your patience.
+<% else %>
+Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does, we’ll publish it. This usually takes a week or less.
 <% end %>
 
 Thanks,

--- a/db/migrate/20190326144123_add_threshold_for_moderation_delay_to_sites.rb
+++ b/db/migrate/20190326144123_add_threshold_for_moderation_delay_to_sites.rb
@@ -1,0 +1,5 @@
+class AddThresholdForModerationDelayToSites < ActiveRecord::Migration
+  def change
+    add_column :sites, :threshold_for_moderation_delay, :integer, default: 500, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1135,7 +1135,8 @@ CREATE TABLE public.sites (
     feature_flags jsonb DEFAULT '{}'::jsonb NOT NULL,
     signature_count_updated_at timestamp without time zone,
     signature_count_interval integer DEFAULT 60 NOT NULL,
-    update_signature_counts boolean DEFAULT false NOT NULL
+    update_signature_counts boolean DEFAULT false NOT NULL,
+    threshold_for_moderation_delay integer DEFAULT 500 NOT NULL
 );
 
 
@@ -2778,4 +2779,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190325204926');
 INSERT INTO schema_migrations (version) VALUES ('20190325205128');
 
 INSERT INTO schema_migrations (version) VALUES ('20190325205137');
+
+INSERT INTO schema_migrations (version) VALUES ('20190326144123');
 

--- a/spec/helpers/moderation_helper_spec.rb
+++ b/spec/helpers/moderation_helper_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe ModerationHelper, type: :helper do
+  describe "#moderation_delay?" do
+    let(:scope) { double(Petition) }
+
+    before do
+      allow(Petition).to receive(:in_moderation).and_return(scope)
+      allow(scope).to receive(:count).and_return(moderation_queue)
+    end
+
+    context "when there are less than 500 petitions in the moderation queue" do
+      let(:moderation_queue) { 499 }
+
+      it "returns false" do
+        expect(helper.moderation_delay?).to eq(false)
+      end
+    end
+
+    context "when there are 500 petitions in the moderation queue" do
+      let(:moderation_queue) { 500 }
+
+      it "returns true" do
+        expect(helper.moderation_delay?).to eq(true)
+      end
+    end
+
+    context "when there are more than 500 petitions in the moderation queue" do
+      let(:moderation_queue) { 501 }
+
+      it "returns true" do
+        expect(helper.moderation_delay?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -358,6 +358,32 @@ RSpec.describe PetitionMailer, type: :mailer do
         expect(mail).to have_body_text(%r[but over the Easter period it will take us a little longer])
       end
     end
+
+    context "when there's isn't a moderation delay" do
+      let(:scope) { double(Petition) }
+
+      before do
+        allow(Petition).to receive(:in_moderation).and_return(scope)
+        allow(scope).to receive(:count).and_return(499)
+      end
+
+      it "doesn't include information about delayed moderation" do
+        expect(mail).not_to have_body_text(%r[however we have a very large number to check])
+      end
+    end
+
+    context "when there's a moderation delay" do
+      let(:scope) { double(Petition) }
+
+      before do
+        allow(Petition).to receive(:in_moderation).and_return(scope)
+        allow(scope).to receive(:count).and_return(500)
+      end
+
+      it "includes information about delayed moderation" do
+        expect(mail).to have_body_text(%r[however we have a very large number to check])
+      end
+    end
   end
 
   describe "notifying signature of debate outcome" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Site, type: :model do
     it { is_expected.to have_db_column(:minimum_number_of_sponsors).of_type(:integer).with_options(null: false, default: 5) }
     it { is_expected.to have_db_column(:maximum_number_of_sponsors).of_type(:integer).with_options(null: false, default: 20) }
     it { is_expected.to have_db_column(:threshold_for_moderation).of_type(:integer).with_options(null: false, default: 5) }
+    it { is_expected.to have_db_column(:threshold_for_moderation_delay).of_type(:integer).with_options(null: false, default: 500) }
     it { is_expected.to have_db_column(:threshold_for_response).of_type(:integer).with_options(null: false, default: 10000) }
     it { is_expected.to have_db_column(:threshold_for_debate).of_type(:integer).with_options(null: false, default: 100000) }
     it { is_expected.to have_db_column(:last_checked_at).of_type(:datetime).with_options(null: true, default: nil) }
@@ -46,6 +47,7 @@ RSpec.describe Site, type: :model do
     it { is_expected.to validate_presence_of(:minimum_number_of_sponsors) }
     it { is_expected.to validate_presence_of(:maximum_number_of_sponsors) }
     it { is_expected.to validate_presence_of(:threshold_for_moderation) }
+    it { is_expected.to validate_presence_of(:threshold_for_moderation_delay) }
     it { is_expected.to validate_presence_of(:threshold_for_response) }
     it { is_expected.to validate_presence_of(:threshold_for_debate) }
     it { is_expected.to validate_presence_of(:login_timeout) }
@@ -56,8 +58,8 @@ RSpec.describe Site, type: :model do
     it { is_expected.to validate_length_of(:feedback_email).is_at_most(100) }
 
     %w[
-      petition_duration minimum_number_of_sponsors maximum_number_of_sponsors
-      threshold_for_moderation threshold_for_response threshold_for_debate login_timeout
+      petition_duration minimum_number_of_sponsors maximum_number_of_sponsors threshold_for_moderation
+      threshold_for_moderation_delay threshold_for_response threshold_for_debate login_timeout
     ].each do |attribute|
       describe attribute do
         let(:errors) { subject.errors[attribute] }
@@ -474,6 +476,18 @@ RSpec.describe Site, type: :model do
       it "can be overridden with the THRESHOLD_FOR_MODERATION environment variable" do
         allow(ENV).to receive(:fetch).with("THRESHOLD_FOR_MODERATION", '5').and_return("10")
         expect(defaults[:threshold_for_moderation]).to eq(10)
+      end
+    end
+
+    describe "for threshold_for_moderation_delay" do
+      it "defaults to 500" do
+        allow(ENV).to receive(:fetch).with("THRESHOLD_FOR_MODERATION_DELAY", '500').and_return("500")
+        expect(defaults[:threshold_for_moderation_delay]).to eq(500)
+      end
+
+      it "can be overridden with the THRESHOLD_FOR_MODERATION_DELAY environment variable" do
+        allow(ENV).to receive(:fetch).with("THRESHOLD_FOR_MODERATION_DELAY", '500').and_return("100")
+        expect(defaults[:threshold_for_moderation_delay]).to eq(100)
       end
     end
 


### PR DESCRIPTION
There's a lot post Article 50 petition - so this is to advise of the delay.

Will have to revert once the backlog passes.

Possibly something to add to admin at some point - adhoc processing delay like we have for Holidays, but not for now.