### PR TITLE
Refactor the overnight job to correct invalid signature counts

### DIFF
--- a/app/jobs/petition_count_job.rb
+++ b/app/jobs/petition_count_job.rb
@@ -1,19 +1,52 @@
 class PetitionCountJob < ApplicationJob
   class InvalidSignatureCounts < RuntimeError; end
 
-  queue_as :high_priority
+  delegate :update_signature_counts, to: :Site
+  delegate :signature_count_interval, to: :Site
+  delegate :disable_signature_counts!, to: :Site
+  delegate :enable_signature_counts!, to: :Site
 
-  def perform
-    petitions = Petition.with_invalid_signature_counts
+  queue_as :highest_priority
 
-    unless petitions.empty?
-      petitions.each(&:update_signature_count!)
+  def perform(now = Time.current)
+    if update_signature_counts
+      disable_signature_counts!
+      reschedule_job(scheduled_time(now))
+    else
+      unless petitions.empty?
+        petitions.each(&:reset_signature_count!)
+        send_notification(petitions)
+      end
 
-      Appsignal.send_exception(exception(petitions))
+      enable_signature_counts!
     end
   end
 
   private
+
+  def petitions
+    @petitions ||= fetch_petitions
+  end
+
+  def fetch_petitions
+    petitions_scope.reject(&:valid_signature_count?)
+  end
+
+  def petitions_scope
+    Petition.signed_since(36.hours.ago)
+  end
+
+  def reschedule_job(time)
+    self.class.set(wait_until: time).perform_later
+  end
+
+  def scheduled_time(now)
+    signature_count_interval.seconds.since(now) + 30.seconds
+  end
+
+  def send_notification(petitions)
+    Appsignal.send_exception(exception(petitions))
+  end
 
   def exception(petitions)
     InvalidSignatureCounts.new(error_message(petitions))

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -336,10 +336,6 @@ class Petition < ActiveRecord::Base
       end
     end
 
-    def with_invalid_signature_counts
-      where(id: Signature.petition_ids_with_invalid_signature_counts).to_a
-    end
-
     def popular_in_constituency(constituency_id, count = 50)
       popular_in(constituency_id, count).for_state(OPEN_STATE)
     end
@@ -515,6 +511,11 @@ class Petition < ActiveRecord::Base
     if update_all([updates, now: time]) > 0
       self.reload
     end
+  end
+
+  def valid_signature_count?
+    count, count_at = signatures.validated_count(nil, last_signed_at)
+    signature_count == count && last_signed_at == count_at
   end
 
   def will_reach_threshold_for_moderation?

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -167,13 +167,6 @@ class Signature < ActiveRecord::Base
       validated(since: timestamp).distinct.pluck(:petition_id)
     end
 
-    def petition_ids_with_invalid_signature_counts
-      validated.joins(:petition).
-        group([arel_table[:petition_id], Petition.arel_table[:signature_count]]).
-        having(arel_table[Arel.star].count.not_eq(Petition.arel_table[:signature_count])).
-        pluck(:petition_id)
-    end
-
     def search(query, options = {})
       query = query.to_s
       page = [options[:page].to_i, 1].max
@@ -275,8 +268,8 @@ class Signature < ActiveRecord::Base
       scope
     end
 
-    def validated_count(timestamp = nil)
-      validated(since: timestamp).pluck(count_star, max_validated_at).first
+    def validated_count(timestamp = nil, upto = nil)
+      validated(since: timestamp, upto: upto).pluck(count_star, max_validated_at).first
     end
 
     def validated_count_by_location_code(timestamp = nil, upto = nil)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -107,6 +107,14 @@ class Site < ActiveRecord::Base
       instance.touch(*names)
     end
 
+    def disable_signature_counts!
+      instance.update!(update_signature_counts: false)
+    end
+
+    def enable_signature_counts!
+      instance.update!(update_signature_counts: true)
+    end
+
     def last_checked_at!(timestamp = Time.current)
       instance.update_all(last_petition_created_at: timestamp)
     end

--- a/spec/jobs/petition_count_job_spec.rb
+++ b/spec/jobs/petition_count_job_spec.rb
@@ -6,55 +6,90 @@ RSpec.describe PetitionCountJob, type: :job do
 
     it "doesn't update the signature count" do
       expect{
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      }.not_to change{ petition.reload.signature_count }
+        described_class.perform_now
+      }.not_to change { petition.reload.signature_count }
     end
 
     it "doesn't change the updated_at timestamp" do
       expect{
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      }.not_to change{ petition.reload.updated_at }
+        described_class.perform_now
+      }.not_to change { petition.reload.updated_at }
     end
 
     it "doesn't notify AppSignal" do
       expect(Appsignal).not_to receive(:send_exception)
 
-      perform_enqueued_jobs {
-        described_class.perform_later
-      }
+      described_class.perform_now
     end
   end
 
   context "when there are petitions with invalid signature counts" do
-    let!(:petition) { FactoryBot.create(:open_petition, signature_count: 100) }
     let(:exception_class) { PetitionCountJob::InvalidSignatureCounts }
 
-    it "updates the signature count" do
-      expect{
+    let!(:petition) do
+      FactoryBot.create(:open_petition,
+        created_at: 2.days.ago,
+        last_signed_at: Time.current,
+        signature_count: 100
+      )
+    end
+
+    context "and signature count updating is enabled" do
+      before do
+        Site.enable_signature_counts!
+      end
+
+      it "disables the signature count updating" do
+        expect {
+          described_class.perform_now
+        }.to change { Site.update_signature_counts }.from(true).to(false)
+      end
+
+      it "reschedules the job" do
+        expect {
+          described_class.perform_now
+        }.to have_enqueued_job(PetitionCountJob)
+      end
+    end
+
+    context "and signature count updating is disabled" do
+      before do
+        Site.disable_signature_counts!
+      end
+
+      it "updates the signature count" do
+        expect {
+          described_class.perform_now
+        }.to change { petition.reload.signature_count }.from(100).to(1)
+      end
+
+      it "updates the updated_at timestamp" do
+        expect {
+          perform_enqueued_jobs {
+            described_class.perform_later
+          }
+        }.to change { petition.reload.updated_at }.to(be_within(1.second).of(Time.current))
+      end
+
+      it "notifies AppSignal" do
+        expect(Appsignal).to receive(:send_exception).with(an_instance_of(exception_class))
+
         perform_enqueued_jobs {
           described_class.perform_later
         }
-      }.to change{ petition.reload.signature_count }.from(100).to(1)
-    end
+      end
 
-    it "updates the updated_at timestamp" do
-      expect{
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      }.to change{ petition.reload.updated_at }.to(be_within(1.second).of(Time.current))
-    end
+      it "enables the signature count updating" do
+        expect {
+          described_class.perform_now
+        }.to change { Site.update_signature_counts }.from(false).to(true)
+      end
 
-    it "notifies AppSignal" do
-      expect(Appsignal).to receive(:send_exception).with(an_instance_of(exception_class))
-
-      perform_enqueued_jobs {
-        described_class.perform_later
-      }
+      it "schedules the update signature count job" do
+        expect {
+          described_class.perform_now
+        }.to have_enqueued_job(UpdateSignatureCountsJob)
+      end
     end
   end
 end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1500,26 +1500,6 @@ RSpec.describe Petition, type: :model do
     end
   end
 
-  describe ".with_invalid_signature_counts" do
-    let!(:petition) { FactoryBot.create(:open_petition, attributes) }
-
-    context "when there are no petitions with invalid signature counts" do
-      let(:attributes) { { created_at: 2.days.ago, updated_at: 2.days.ago } }
-
-      it "doesn't return any petitions" do
-        expect(described_class.with_invalid_signature_counts).to eq([])
-      end
-    end
-
-    context "when there are petitions with invalid signature counts" do
-      let(:attributes) { { created_at: 2.days.ago, updated_at: 2.days.ago, signature_count: 100 } }
-
-      it "returns the petitions" do
-        expect(described_class.with_invalid_signature_counts).to eq([petition])
-      end
-    end
-  end
-
   describe ".unarchived" do
     let!(:archived_petition) { FactoryBot.create(:closed_petition, archived_at: 1.hour.ago) }
     let!(:unarchived_petition) { FactoryBot.create(:closed_petition, archived_at: nil) }

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -931,28 +931,6 @@ RSpec.describe Signature, type: :model do
     end
   end
 
-  describe ".petition_ids_with_invalid_signature_counts" do
-    subject do
-      described_class.petition_ids_with_invalid_signature_counts
-    end
-
-    context "when there are no petitions with invalid signature counts" do
-      let!(:petition) { FactoryBot.create(:open_petition) }
-
-      it "returns an empty array" do
-        expect(subject).to eq([])
-      end
-    end
-
-    context "when there are petitions with invalid signature counts" do
-      let!(:petition) { FactoryBot.create(:open_petition, signature_count: 100) }
-
-      it "returns an array of ids" do
-        expect(described_class.petition_ids_with_invalid_signature_counts).to eq([petition.id])
-      end
-    end
-  end
-
   describe ".fraudulent_domains" do
     subject do
       described_class.fraudulent_domains


### PR DESCRIPTION
Now that we have a single job to update signature counts we can refactor our overnight check for invalid signature counts to take advantage of the ability to stop counting, reset the count to a particular time and then restart counting.