### PR TITLE
Extract rate limiting out to a concern for sharing

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -144,10 +144,6 @@ class SignaturesController < ApplicationController
     unless @petition.visible?
       raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
-
-    if @signature.invalidated? || @signature.fraudulent?
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
-    end
   end
 
   def build_signature(attributes)

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -38,10 +38,6 @@ class SponsorsController < SignaturesController
     if @petition.flagged? || @petition.hidden? || @petition.stopped?
       raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
-
-    if @signature.invalidated? || @signature.fraudulent?
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
-    end
   end
 
   def build_signature(attributes)

--- a/app/jobs/concerns/rate_limiting.rb
+++ b/app/jobs/concerns/rate_limiting.rb
@@ -1,0 +1,33 @@
+module RateLimiting
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from(ActiveJob::DeserializationError) do |exception|
+      Appsignal.send_exception exception
+    end
+  end
+
+  def perform(signature)
+    if rate_limit.exceeded?(signature)
+      signature.fraudulent!
+    end
+
+    mailer.send(email, signature).deliver_now
+
+    updates, params = [], {}
+    updates << "email_count = COALESCE(email_count, 0) + 1"
+
+    if constituency = signature.constituency
+      updates << "constituency_id = :constituency_id"
+      params[:constituency_id] = constituency.external_id
+    end
+
+    signature.update_all([updates.join(", "), params])
+  end
+
+  private
+
+  def rate_limit
+    @rate_limit ||= RateLimit.first_or_create!
+  end
+end

--- a/app/jobs/email_confirmation_for_signer_email_job.rb
+++ b/app/jobs/email_confirmation_for_signer_email_job.rb
@@ -2,31 +2,5 @@ class EmailConfirmationForSignerEmailJob < EmailJob
   self.mailer = PetitionMailer
   self.email = :email_confirmation_for_signer
 
-  rescue_from(ActiveJob::DeserializationError) do |exception|
-    Appsignal.send_exception exception
-  end
-
-  def perform(signature)
-    if rate_limit.exceeded?(signature)
-      signature.fraudulent!
-    else
-      mailer.send(email, signature).deliver_now
-
-      updates, params = [], {}
-      updates << "email_count = COALESCE(email_count, 0) + 1"
-
-      if constituency = signature.constituency
-        updates << "constituency_id = :constituency_id"
-        params[:constituency_id] = constituency.external_id
-      end
-
-      signature.update_all([updates.join(", "), params])
-    end
-  end
-
-  private
-
-  def rate_limit
-    @rate_limit ||= RateLimit.first_or_create!
-  end
+  include RateLimiting
 end

--- a/app/jobs/petition_and_email_confirmation_for_sponsor_email_job.rb
+++ b/app/jobs/petition_and_email_confirmation_for_sponsor_email_job.rb
@@ -1,4 +1,6 @@
 class PetitionAndEmailConfirmationForSponsorEmailJob < EmailJob
   self.mailer = SponsorMailer
   self.email = :petition_and_email_confirmation_for_sponsor
+
+  include RateLimiting
 end

--- a/app/jobs/sponsor_signed_email_below_threshold_email_job.rb
+++ b/app/jobs/sponsor_signed_email_below_threshold_email_job.rb
@@ -1,4 +1,10 @@
 class SponsorSignedEmailBelowThresholdEmailJob < EmailJob
   self.mailer = SponsorMailer
   self.email = :sponsor_signed_email_below_threshold
+
+  def perform(signature)
+    if signature.validated?
+      super
+    end
+  end
 end

--- a/app/jobs/sponsor_signed_email_on_threshold_email_job.rb
+++ b/app/jobs/sponsor_signed_email_on_threshold_email_job.rb
@@ -1,4 +1,10 @@
 class SponsorSignedEmailOnThresholdEmailJob < EmailJob
   self.mailer = SponsorMailer
   self.email = :sponsor_signed_email_on_threshold
+
+  def perform(signature)
+    if signature.validated?
+      super
+    end
+  end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -531,6 +531,10 @@ class Signature < ActiveRecord::Base
     update_column(:uuid, generate_uuid)
   end
 
+  def number
+    super || petition.signature_count + 1
+  end
+
   def email_threshold_reached?
     email_count >= 5
   end

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -183,7 +183,13 @@ Feature: Suzie signs a petition
     Then I should be on the new signature page
     When I say I am happy with my email address
     Then I am told to check my inbox to complete signing
-    And "womboid@wimbledon.com" should have no emails
+    And "womboid@wimbledon.com" should receive 1 email
+    And I confirm my email address
+    Then I should see "We've added your signature to the petition"
+    And I should see "2 signatures"
+    When I follow "Do something!"
+    Then I should be on the petition page
+    And I should see "1 signature"
 
   Scenario: Suzie can validate her signature when IP address is rate limited but the domain is allowed
     Given the burst rate limit is 1 per minute

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -454,10 +454,10 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :verify, id: signature.id, token: signature.perishable_token
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -465,10 +465,10 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :verify, id: signature.id, token: signature.perishable_token
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -643,10 +643,10 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :signed, id: signature.id
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -654,10 +654,10 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :signed, id: signature.id
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -819,10 +819,10 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :unsubscribe, id: signature.id, token: signature.unsubscribe_token
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -830,10 +830,10 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :unsubscribe, id: signature.id, token: signature.unsubscribe_token
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -559,10 +559,10 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition, sponsor: true) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :verify, id: signature.id, token: signature.perishable_token
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -570,10 +570,10 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition, sponsor: true) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :verify, id: signature.id, token: signature.perishable_token
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -932,10 +932,10 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition, sponsor: true) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :signed, id: signature.id
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 
@@ -943,10 +943,10 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition, sponsor: true) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
+      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
         expect {
           get :signed, id: signature.id
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Previously rate limiting wasn't applied to sponsor emails which isn't a big concern since you can only have 20 sponsors but applying the block list to the sponsors will reduce the moderation load on the team.
