### PR TITLE
Restore scheduled updating of petition statistics

### DIFF
--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -10,7 +10,7 @@ class Admin::SitesController < Admin::AdminController
 
   def update
     if @site.update(site_params)
-      redirect_to edit_admin_site_url, notice: :site_updated
+      redirect_to edit_admin_site_url(tab: params[:tab]), notice: :site_updated
     else
       respond_to do |format|
         format.html { render :edit }
@@ -33,7 +33,7 @@ class Admin::SitesController < Admin::AdminController
       :moderate_url, :login_timeout, :disable_constituency_api,
       :signature_count_interval, :update_signature_counts,
       :disable_trending_petitions, :threshold_for_moderation_delay,
-      :disable_invalid_signature_count_check
+      :disable_invalid_signature_count_check, :disable_daily_update_statistics_job
     )
   end
 end

--- a/app/jobs/enqueue_petition_statistics_updates_job.rb
+++ b/app/jobs/enqueue_petition_statistics_updates_job.rb
@@ -1,7 +1,11 @@
 class EnqueuePetitionStatisticsUpdatesJob < ApplicationJob
   queue_as :low_priority
 
+  delegate :disable_daily_update_statistics_job?, to: :Site
+
   def perform(timestamp)
+    return if disable_daily_update_statistics_job?
+
     Petition.signed_since(timestamp.in_time_zone).find_each do |petition|
       UpdatePetitionStatisticsJob.perform_later(petition)
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -8,7 +8,13 @@ class Site < ActiveRecord::Base
   include ActiveSupport::NumberHelper
 
   FALSE_VALUES = [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF'].to_set
-  FEATURE_FLAGS = %w[disable_constituency_api disable_trending_petitions disable_invalid_signature_count_check]
+
+  FEATURE_FLAGS = %w[
+    disable_constituency_api
+    disable_trending_petitions
+    disable_invalid_signature_count_check
+    disable_daily_update_statistics_job
+  ]
 
   class << self
     def table_exists?

--- a/app/views/admin/sites/_features.html.erb
+++ b/app/views/admin/sites/_features.html.erb
@@ -27,6 +27,19 @@
   </div>
 <% end %>
 
+<%= form_row for: [form.object, :disable_daily_update_statistics_job], class: "inline" do %>
+  <%= form.label :disable_daily_update_statistics_job, "Disable updating of duplicate email statistics?", class: "form-label" %>
+  <%= error_messages_for_field @site, :disable_daily_update_statistics_job %>
+  <div class="multiple-choice">
+    <%= form.radio_button :disable_daily_update_statistics_job, true %>
+    <%= form.label :disable_daily_update_statistics_job, "Yes", for: "site_disable_daily_update_statistics_job_true" %>
+  </div>
+  <div class="multiple-choice">
+    <%= form.radio_button :disable_daily_update_statistics_job, false %>
+    <%= form.label :disable_daily_update_statistics_job, "No", for: "site_disable_daily_update_statistics_job_false" %>
+  </div>
+<% end %>
+
 <%= form_row for: [form.object, :disable_invalid_signature_count_check], class: "inline" do %>
   <%= form.label :disable_invalid_signature_count_check, "Disable overnight check on invalid signature counts?", class: "form-label" %>
   <%= error_messages_for_field @site, :disable_invalid_signature_count_check %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -41,6 +41,10 @@ every :day, at: '2.30am' do
   rake "epets:petitions:count", output: nil
 end
 
+every :day, at: '3.30am' do
+	rake "epets:petitions:update_statistics", output: nil
+end
+
 every :day, at: '7.00am' do
   rake "epets:petitions:close", output: nil
 end

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -25,8 +25,8 @@ namespace :epets do
 
     desc "Add a task to the queue to update petition statistics"
     task :update_statistics => :environment do
-      Task.run("epets:petitions:update_statistics", 30.minutes) do
-        EnqueuePetitionStatisticsUpdatesJob.perform_later(60.minutes.ago.iso8601)
+      Task.run("epets:petitions:update_statistics", 12.hours) do
+        EnqueuePetitionStatisticsUpdatesJob.perform_later(24.hours.ago.iso8601)
       end
     end
 


### PR DESCRIPTION
Rather than hourly, run them overnight so that they don't drift for days without updates - moderators can refresh if a newer one is needed.