### PR TITLE
Improve signature workflow for moderators

### DIFF
--- a/app/controllers/admin/signatures_controller.rb
+++ b/app/controllers/admin/signatures_controller.rb
@@ -13,7 +13,7 @@ class Admin::SignaturesController < Admin::AdminController
 
   def bulk_validate
     begin
-      scope.validate!(selected_ids)
+      scope.validate!(selected_ids, force: true)
       redirect_to index_url(q: params[:q]), notice: :signatures_validated
     rescue StandardError => e
       Appsignal.send_exception e
@@ -23,7 +23,7 @@ class Admin::SignaturesController < Admin::AdminController
 
   def validate
     begin
-      @signature.validate!
+      @signature.validate!(force: true)
       redirect_to index_url(q: params[:q]), notice: :signature_validated
     rescue StandardError => e
       Appsignal.send_exception e

--- a/app/views/admin/signatures/_signature.html.erb
+++ b/app/views/admin/signatures/_signature.html.erb
@@ -27,15 +27,18 @@
   <% else %>
     <td class="signature-creator">No</td>
     <td class="signature-actions">
-      <% if signature.subscribed? %>
-        <%= button_to 'Unsubscribe', [:unsubscribe, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button unsubscribe-action', data: { confirm: 'Unsubscribe signature?' } %>
-      <% elsif signature.validated? %>
-        <%= button_to 'Subscribe', [:subscribe, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button subscribe-action', data: { confirm: 'Subscribe signature?' } %>
+      <% if signature.validated? %>
+        <% if signature.subscribed? %>
+          <%= button_to 'Unsubscribe', [:unsubscribe, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button unsubscribe-action', data: { confirm: 'Unsubscribe signature?' } %>
+        <% else %>
+          <%= button_to 'Subscribe', [:subscribe, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button subscribe-action', data: { confirm: 'Subscribe signature?' } %>
+        <% end %>
       <% end %>
-      <% if signature.pending? %>
-        <%= button_to 'Validate', [:validate, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button validate-action', data: { confirm: 'Validate signature?' } %>
-      <% elsif signature.validated? %>
+      <% unless signature.fraudulent? || signature.invalidated? %>
         <%= button_to 'Invalidate', [:invalidate, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button invalidate-action', data: { confirm: 'Invalidate signature?' } %>
+      <% end %>
+      <% unless signature.validated? %>
+        <%= button_to 'Validate', [:validate, :admin, @petition, signature, q: params[:q]].compact, method: :post, class: 'button validate-action', data: { confirm: 'Validate signature?' } %>
       <% end %>
       <%= button_to 'Delete', [:admin, @petition, signature, q: params[:q]].compact, method: :delete, class: 'button-warning delete-action', data: { confirm: 'Delete signature?' } %>
     </td>

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -137,8 +137,8 @@ Then(/^I should see the email address is validated$/) do
 end
 
 Then(/^I should see the email address is invalidated$/) do
-  expect(page).not_to have_button "Validate"
   expect(page).not_to have_button "Invalidate"
+  expect(page).to have_button "Validate"
   expect(page).to have_button "Delete"
 end
 


### PR DESCRIPTION
Allow pending signatures to be invalidated and fraudulent/invalidated signatures to be validated to make life easier for moderators managing signatures with bulk operations.