### PR TITLE
Disable daily threshold reminder

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,10 +21,6 @@
 
 env :PATH, ENV['PATH']
 
-every :weekday, at: '6.30am' do
-  rake "epets:threshold_email_reminder", output: nil
-end
-
 every :day, at: '1.15am' do
   rake "epets:countries:fetch", output: nil
 end


### PR DESCRIPTION
Nobody is reading it and now it fails on SES with too many recipients.