### PR TITLE
Use a historical time window for updating signature counts

### DIFF
--- a/app/jobs/petition_count_job.rb
+++ b/app/jobs/petition_count_job.rb
@@ -1,33 +1,16 @@
 class PetitionCountJob < ApplicationJob
-  class InvalidSignatureCounts < RuntimeError; end
-
-  delegate :update_signature_counts, to: :Site
   delegate :signature_count_interval, to: :Site
-  delegate :disable_signature_counts!, to: :Site
-  delegate :enable_signature_counts!, to: :Site
   delegate :disable_invalid_signature_count_check?, to: :Site
 
   queue_as :highest_priority
 
   def perform(now = current_time)
-    return if disable_invalid_signature_count_check?
+    time = signature_count_at(now.in_time_zone)
 
-    time = now.in_time_zone
-    count_at = signature_count_interval.seconds.ago(time)
-
-    if update_signature_counts
-      disable_signature_counts!
-      reschedule_job(scheduled_time(time))
-    else
-      unless petitions.empty?
-        petitions.each do |petition|
-          petition.reset_signature_count!(count_at)
-        end
-
-        send_notification(petitions)
+    unless petitions.empty?
+      petitions.each do |petition|
+        ResetPetitionSignatureCountJob.perform_later(petition, now)
       end
-
-      enable_signature_counts!
     end
   end
 
@@ -35,6 +18,10 @@ class PetitionCountJob < ApplicationJob
 
   def current_time
     Time.current.change(usec: 0).iso8601
+  end
+
+  def signature_count_at(time)
+    signature_count_interval.seconds.ago(time)
   end
 
   def petitions
@@ -47,31 +34,5 @@ class PetitionCountJob < ApplicationJob
 
   def petitions_scope
     Petition.signed_since(36.hours.ago)
-  end
-
-  def reschedule_job(time)
-    self.class.set(wait_until: time).perform_later
-  end
-
-  def scheduled_time(now)
-    signature_count_interval.seconds.since(now) + 30.seconds
-  end
-
-  def send_notification(petitions)
-    Appsignal.send_exception(exception(petitions))
-  end
-
-  def exception(petitions)
-    InvalidSignatureCounts.new(error_message(petitions))
-  end
-
-  def error_message(petitions)
-    I18n.t(
-      :"invalid_signature_counts",
-        scope:  :"petitions.errors",
-        count:  petitions.size,
-        ids:    petitions.map(&:id).inspect,
-        id:     petitions.first.id.to_s
-    )
   end
 end

--- a/app/jobs/reset_petition_signature_count_job.rb
+++ b/app/jobs/reset_petition_signature_count_job.rb
@@ -1,0 +1,28 @@
+class ResetPetitionSignatureCountJob < ApplicationJob
+  class InvalidSignatureCount < RuntimeError; end
+
+  queue_as :highest_priority
+
+  def perform(petition, time = current_time)
+    petition.reset_signature_count!(time.in_time_zone)
+    send_notification(petition)
+  end
+
+  private
+
+  def current_time
+    Time.current.change(usec: 0).iso8601
+  end
+
+  def send_notification(petition)
+    Appsignal.send_exception(exception(petition))
+  end
+
+  def exception(petition)
+    InvalidSignatureCount.new(error_message(petition))
+  end
+
+  def error_message(petition)
+    I18n.t(:"invalid_signature_count", scope: :"petitions.errors", id: petition.id.to_s)
+  end
+end

--- a/app/jobs/update_signature_counts_job.rb
+++ b/app/jobs/update_signature_counts_job.rb
@@ -12,25 +12,42 @@ class UpdateSignatureCountsJob < ApplicationJob
     retry_job(wait: signature_count_interval)
   end
 
-  def perform(now = Time.current)
+  def perform(now = current_time)
+    # Exit if updating signature counts is disabled
     return unless update_signature_counts
 
-    petitions.each do |petition|
-      last_signed_at = petition.last_signed_at
-      petition.increment_signature_count!(now)
+    time = now.in_time_zone
+    signature_count_at = signature_count_interval.seconds.ago(time)
 
+    # Exit if the signature counts have been updated since this job was scheduled
+    return unless signature_count_updated_at < signature_count_at
+
+    petitions.each do |petition|
+      # Skip this petition if it's been updated since this job was scheduled
+      next unless petition.last_signed_at < signature_count_at
+
+      last_signed_at = petition.last_signed_at
+      petition.increment_signature_count!(signature_count_at)
       ConstituencyPetitionJournal.increment_signature_counts_for(petition, last_signed_at)
       CountryPetitionJournal.increment_signature_counts_for(petition, last_signed_at)
     end
 
-    signature_count_updated_at!(now)
-    reschedule_job(scheduled_time(now))
+    signature_count_updated_at!(signature_count_at)
+    reschedule_job(scheduled_time(time))
   end
 
   private
 
+  def current_time
+    Time.current.change(usec: 0).iso8601
+  end
+
   def log_exception(exception)
     logger.info(log_message(exception))
+  end
+
+  def log_message(exception)
+    "#{exception.class.name} while running #{self.class.name}"
   end
 
   def petition_ids
@@ -42,7 +59,7 @@ class UpdateSignatureCountsJob < ApplicationJob
   end
 
   def reschedule_job(time)
-    self.class.set(wait_until: time).perform_later
+    self.class.set(wait_until: time).perform_later(time.iso8601)
   end
 
   def scheduled_time(now)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -440,8 +440,7 @@ class Petition < ActiveRecord::Base
     if Site.update_signature_counts
       raise RuntimeError, "Resetting signature counts while updates are running is unsafe"
     else
-      update_columns(signature_count: 0, last_signed_at: created_at)
-      increment_signature_count!(time)
+      update_signature_count!(time)
       ConstituencyPetitionJournal.reset_signature_counts_for(self)
       CountryPetitionJournal.reset_signature_counts_for(self)
     end
@@ -449,20 +448,20 @@ class Petition < ActiveRecord::Base
 
   def update_signature_count!(time = Time.current)
     sql = "signature_count = ?, last_signed_at = ?, updated_at = ?"
-    count, counted_at = signatures.validated_count
+    count = signatures.validated_count(nil, time)
 
-    if update_all([sql, count, counted_at, time]) > 0
+    if update_all([sql, count, time, time]) > 0
       self.reload
     end
   end
 
   def increment_signature_count!(time = Time.current)
     sql = "signature_count = signature_count + ?, last_signed_at = ?, updated_at = ?"
-    count, counted_at = signatures.validated_count(last_signed_at)
+    count = signatures.validated_count(last_signed_at, time)
 
     return true if count.zero?
 
-    if update_all([sql, count, counted_at, time]) > 0
+    if update_all([sql, count, time, time]) > 0
       self.reload
 
       updates = []
@@ -516,8 +515,7 @@ class Petition < ActiveRecord::Base
   end
 
   def valid_signature_count?
-    count, count_at = signatures.validated_count(nil, last_signed_at)
-    signature_count == count && last_signed_at == count_at
+    signature_count == signatures.validated_count(nil, last_signed_at)
   end
 
   def will_reach_threshold_for_moderation?

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -437,13 +437,11 @@ class Petition < ActiveRecord::Base
   end
 
   def reset_signature_count!(time = Time.current)
-    if Site.update_signature_counts
-      raise RuntimeError, "Resetting signature counts while updates are running is unsafe"
-    else
-      update_signature_count!(time)
-      ConstituencyPetitionJournal.reset_signature_counts_for(self)
-      CountryPetitionJournal.reset_signature_counts_for(self)
-    end
+    update_column(:signature_count_reset_at, time)
+    update_signature_count!(time)
+    ConstituencyPetitionJournal.reset_signature_counts_for(self)
+    CountryPetitionJournal.reset_signature_counts_for(self)
+    update_column(:signature_count_reset_at, nil)
   end
 
   def update_signature_count!(time = Time.current)

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -355,15 +355,15 @@ class Signature < ActiveRecord::Base
       scope
     end
 
-    def validated_count(timestamp = nil, upto = nil)
-      validated(since: timestamp, upto: upto).pluck(count_star.to_sql, max_validated_at).first
+    def validated_count(timestamp, upto)
+      validated(since: timestamp, upto: upto).pluck(count_star.to_sql).first
     end
 
-    def validated_count_by_location_code(timestamp = nil, upto = nil)
+    def validated_count_by_location_code(timestamp, upto)
       validated(since: timestamp, upto: upto).group(:location_code).pluck(:location_code, count_star.to_sql)
     end
 
-    def validated_count_by_constituency_id(timestamp = nil, upto = nil)
+    def validated_count_by_constituency_id(timestamp, upto)
       validated(since: timestamp, upto: upto).group(:constituency_id).pluck(:constituency_id, count_star.to_sql)
     end
 

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -5,9 +5,7 @@ en-GB:
         one: "Please fix the following error:"
         other: "Please fix the following errors:"
 
-      invalid_signature_counts:
-        one: "There was 1 petition with id: %{id} that had an invalid signature count"
-        other: "There were %{count} petitions with ids: %{ids} that had invalid signature counts"
+      invalid_signature_count: "Petition %{id} had an invalid signature count"
 
     page_titles:
       all: "All petitions"

--- a/db/migrate/20190419065717_add_reset_signature_count_at_to_petitions.rb
+++ b/db/migrate/20190419065717_add_reset_signature_count_at_to_petitions.rb
@@ -1,0 +1,5 @@
+class AddResetSignatureCountAtToPetitions < ActiveRecord::Migration
+  def change
+    add_column :petitions, :signature_count_reset_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -946,7 +946,8 @@ CREATE TABLE public.petitions (
     tags integer[] DEFAULT '{}'::integer[] NOT NULL,
     locked_at timestamp without time zone,
     locked_by_id integer,
-    moderation_lag integer
+    moderation_lag integer,
+    signature_count_reset_at timestamp without time zone
 );
 
 
@@ -3037,4 +3038,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190414083111');
 INSERT INTO schema_migrations (version) VALUES ('20190414234613');
 
 INSERT INTO schema_migrations (version) VALUES ('20190415015616');
+
+INSERT INTO schema_migrations (version) VALUES ('20190419065717');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -243,7 +243,7 @@ FactoryBot.define do
       unless evaluator.sponsors_signed.nil?
         evaluator.sponsor_count.times do
           if evaluator.sponsors_signed
-            FactoryBot.create(:sponsor, :validated, petition: petition)
+            FactoryBot.create(:sponsor, :validated, petition: petition, validated_at: 10.seconds.ago)
           else
             FactoryBot.create(:sponsor, :pending, petition: petition)
           end

--- a/spec/jobs/petition_count_job_spec.rb
+++ b/spec/jobs/petition_count_job_spec.rb
@@ -21,27 +21,15 @@ RSpec.describe PetitionCountJob, type: :job do
   context "when there are no petitions with invalid signature counts" do
     let!(:petition) { FactoryBot.create(:open_petition) }
 
-    it "doesn't update the signature count" do
+    it "doesn't enqueue a ResetPetitionSignatureCountJob job" do
       expect {
         described_class.perform_now
-      }.not_to change { petition.reload.signature_count }
-    end
-
-    it "doesn't change the updated_at timestamp" do
-      expect {
-        described_class.perform_now
-      }.not_to change { petition.reload.updated_at }
-    end
-
-    it "doesn't notify AppSignal" do
-      expect(Appsignal).not_to receive(:send_exception)
-
-      described_class.perform_now
+      }.not_to have_enqueued_job(ResetPetitionSignatureCountJob)
     end
   end
 
   context "when there are petitions with invalid signature counts" do
-    let(:exception_class) { PetitionCountJob::InvalidSignatureCounts }
+    let(:current_time) { "2019-04-19T12:57:00Z" }
 
     let!(:petition) do
       FactoryBot.create(:open_petition,
@@ -57,16 +45,10 @@ RSpec.describe PetitionCountJob, type: :job do
         Site.enable_signature_counts!
       end
 
-      it "disables the signature count updating" do
+      it "enqueues a ResetPetitionSignatureCountJob job" do
         expect {
-          described_class.perform_now
-        }.to change { Site.update_signature_counts }.from(true).to(false)
-      end
-
-      it "reschedules the job" do
-        expect {
-          described_class.perform_now
-        }.to have_enqueued_job(PetitionCountJob)
+          described_class.perform_now(current_time)
+        }.to have_enqueued_job(ResetPetitionSignatureCountJob).with(petition, current_time).on_queue("highest_priority")
       end
     end
 
@@ -75,38 +57,10 @@ RSpec.describe PetitionCountJob, type: :job do
         Site.disable_signature_counts!
       end
 
-      it "updates the signature count" do
+      it "enqueues a ResetPetitionSignatureCountJob job" do
         expect {
-          described_class.perform_now
-        }.to change { petition.reload.signature_count }.from(100).to(1)
-      end
-
-      it "updates the updated_at timestamp" do
-        expect {
-          perform_enqueued_jobs {
-            described_class.perform_later
-          }
-        }.to change { petition.reload.updated_at }.to(be_within(1.second).of(30.seconds.ago))
-      end
-
-      it "notifies AppSignal" do
-        expect(Appsignal).to receive(:send_exception).with(an_instance_of(exception_class))
-
-        perform_enqueued_jobs {
-          described_class.perform_later
-        }
-      end
-
-      it "enables the signature count updating" do
-        expect {
-          described_class.perform_now
-        }.to change { Site.update_signature_counts }.from(false).to(true)
-      end
-
-      it "schedules the update signature count job" do
-        expect {
-          described_class.perform_now
-        }.to have_enqueued_job(UpdateSignatureCountsJob)
+          described_class.perform_now(current_time)
+        }.to have_enqueued_job(ResetPetitionSignatureCountJob).with(petition, current_time).on_queue("highest_priority")
       end
     end
   end

--- a/spec/jobs/reset_petition_signature_count_job_spec.rb
+++ b/spec/jobs/reset_petition_signature_count_job_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ResetPetitionSignatureCountJob, type: :job do
+  let(:current_time) { "2019-04-19T12:57:00Z" }
+  let(:exception_class) { ResetPetitionSignatureCountJob::InvalidSignatureCount }
+
+  let!(:petition) do
+    FactoryBot.create(:open_petition,
+      created_at: "2019-04-17T12:57:00Z",
+      last_signed_at: "2019-04-19T12:56:00Z",
+      signature_count: 100,
+      creator_attributes: { validated_at: "2019-04-18T12:57:00Z" }
+    )
+  end
+
+  before do
+    allow(Appsignal).to receive(:send_exception)
+  end
+
+  it "updates the signature count" do
+    expect {
+      described_class.perform_now(petition, current_time)
+    }.to change { petition.reload.signature_count }.from(100).to(1)
+  end
+
+  it "updates the last_signed_at timestamp" do
+    expect {
+      described_class.perform_now(petition, current_time)
+    }.to change { petition.reload.last_signed_at }.to(current_time.in_time_zone)
+  end
+
+  it "updates the updated_at timestamp" do
+    expect {
+      described_class.perform_now(petition, current_time)
+    }.to change { petition.reload.updated_at }.to(current_time.in_time_zone)
+  end
+
+  it "notifies AppSignal" do
+    described_class.perform_now(petition, current_time)
+    expect(Appsignal).to have_received(:send_exception).with(an_instance_of(exception_class))
+  end
+end

--- a/spec/jobs/update_signature_counts_job_spec.rb
+++ b/spec/jobs/update_signature_counts_job_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
   let(:scheduled_time) { interval.seconds.since(current_time) }
 
   before do
+    Site.signature_count_updated_at!(current_time - 60.seconds)
     allow(Site).to receive(:signature_count_interval).and_return(interval)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INLINE_UPDATES").and_return("false")
   end
 
   context "when signature count updating is disabled" do
@@ -16,7 +19,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
     it "doesn't update Site#signature_count_updated_at" do
       expect {
-        described_class.perform_now(current_time)
+        described_class.perform_now(current_time.iso8601)
       }.not_to change {
         Site.signature_count_updated_at
       }
@@ -24,7 +27,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
     it "doesn't reschedule another job" do
       expect {
-        described_class.perform_now(current_time)
+        described_class.perform_now(current_time.iso8601)
       }.not_to have_enqueued_job(described_class)
     end
   end
@@ -36,15 +39,15 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
     it "updates Site#signature_count_updated_at" do
       expect {
-        described_class.perform_now(current_time)
+        described_class.perform_now(current_time.iso8601)
       }.to change {
         Site.signature_count_updated_at
-      }.to(current_time)
+      }.to(current_time - 30.seconds)
     end
 
     it "reschedules another job" do
       expect {
-        described_class.perform_now(current_time)
+        described_class.perform_now(current_time.iso8601)
       }.to have_enqueued_job(described_class).on_queue("highest_priority").at(scheduled_time)
     end
 
@@ -56,21 +59,23 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
       before do
         # FIXME: reset the signature count to ensure it's valid because
         # the factories don't leave the petition in a consistent state.
-        petition.update_signature_count!
+        petition.update_signature_count!(current_time - 60.seconds)
       end
 
       context "with an open petition" do
         let(:petition) { FactoryBot.create(:open_petition) }
+        let(:attributes) { { petition: petition, location_code: "AA", constituency_id: "9999" } }
+        let(:signatures) { FactoryBot.create_list(:pending_signature, 5, attributes) }
 
         before do
-          5.times do
-            FactoryBot.create(:validated_signature, petition: petition, location_code: "AA", constituency_id: "9999")
+          signatures.each do |signature|
+            signature.validate!(current_time - 45.seconds)
           end
         end
 
         it "updates the signature count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             petition.reload.signature_count
           }.by(5)
@@ -78,7 +83,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
         it "updates the country journal signature_count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             country_journal.reload.signature_count
           }.by(5)
@@ -86,7 +91,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
         it "updates the constituency journal signature_count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             constituency_journal.reload.signature_count
           }.by(5)
@@ -95,24 +100,27 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
       context "with a pending petition" do
         let(:petition) { FactoryBot.create(:pending_petition) }
+        let(:attributes) { { petition: petition, location_code: "AA", constituency_id: "9999" } }
+        let(:signatures) { FactoryBot.create_list(:pending_signature, 5, attributes) }
 
         before do
-          5.times do
-            FactoryBot.create(:validated_signature, petition: petition, location_code: "AA", constituency_id: "9999")
+          signatures.each do |signature|
+            signature.validate!(current_time - 45.seconds)
           end
         end
 
         it "updates the signature count" do
+          # This changes by 6 because the creator is validated by the first signature
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             petition.reload.signature_count
-          }.by(5)
+          }.by(6)
         end
 
         it "updates the country journal signature_count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             country_journal.reload.signature_count
           }.by(5)
@@ -120,7 +128,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
         it "updates the constituency journal signature_count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             constituency_journal.reload.signature_count
           }.by(5)
@@ -129,16 +137,18 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
       context "with a validated petition" do
         let(:petition) { FactoryBot.create(:validated_petition) }
+        let(:attributes) { { petition: petition, location_code: "AA", constituency_id: "9999" } }
+        let(:signatures) { FactoryBot.create_list(:pending_signature, 5, attributes) }
 
         before do
-          5.times do
-            FactoryBot.create(:validated_signature, petition: petition, location_code: "AA", constituency_id: "9999")
+          signatures.each do |signature|
+            signature.validate!(current_time - 45.seconds)
           end
         end
 
         it "updates the signature count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             petition.reload.signature_count
           }.by(5)
@@ -146,7 +156,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
         it "updates the country journal signature_count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             country_journal.reload.signature_count
           }.by(5)
@@ -154,7 +164,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
         it "updates the constituency journal signature_count" do
           expect {
-            described_class.perform_now(current_time)
+            described_class.perform_now(current_time.iso8601)
           }.to change {
             constituency_journal.reload.signature_count
           }.by(5)

--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -203,9 +203,14 @@ RSpec.describe CountryPetitionJournal, type: :model do
     let!(:petition_2) { FactoryBot.create(:petition, creator_attributes: {location_code: location_code_1}) }
 
     before do
-      described_class.for(petition_1, location_code_1).update_attribute(:signature_count, 20)
-      described_class.for(petition_1, location_code_2).update_attribute(:signature_count, 10)
-      described_class.for(petition_2, location_code_2).update_attribute(:signature_count, 1)
+      # We do this so last_signed_at is not nil
+      petition_1.update_signature_count!
+      petition_2.update_signature_count!
+
+      described_class.for(petition_1, location_code_1).update_columns(signature_count: 20, last_signed_at: 5.minutes.ago)
+      described_class.for(petition_1, location_code_2).update_columns(signature_count: 10, last_signed_at: nil)
+      described_class.for(petition_2, location_code_1).update_columns(signature_count: 1, last_signed_at: 5.minutes.ago)
+      described_class.for(petition_2, location_code_2).update_columns(signature_count: 1, last_signed_at: nil)
     end
 
     context 'when there are no signatures' do
@@ -222,10 +227,10 @@ RSpec.describe CountryPetitionJournal, type: :model do
 
     context 'when there are signatures' do
       before do
-        4.times { FactoryBot.create(:validated_signature, petition: petition_1, location_code: location_code_1) }
+        4.times { FactoryBot.create(:validated_signature, petition: petition_1, location_code: location_code_1, validated_at: 1.minute.ago) }
         2.times { FactoryBot.create(:pending_signature, petition: petition_1, location_code: location_code_1) }
-        3.times { FactoryBot.create(:validated_signature, petition: petition_1, location_code: location_code_2) }
-        2.times { FactoryBot.create(:validated_signature, petition: petition_2, location_code: location_code_1) }
+        3.times { FactoryBot.create(:validated_signature, petition: petition_1, location_code: location_code_2, validated_at: 1.minute.ago) }
+        2.times { FactoryBot.create(:validated_signature, petition: petition_2, location_code: location_code_1, validated_at: 1.minute.ago) }
         5.times { FactoryBot.create(:pending_signature, petition: petition_2, location_code: location_code_2) }
       end
 


### PR DESCRIPTION
Since the timestamps are coming from ruby they're subject to drift meaning that some signatures will be inserted with a validated_at timestamp in an out of order fashion. By setting the window to look at the previous window hopefully any such signatures will have all been committed by then and if they haven't it's likely the database is in flames anyway and we'll need to re-sync the counts.