### PR TITLE
Pass token as a query param

### DIFF
--- a/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -42,4 +42,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -42,4 +42,4 @@
 
 <hr>
 <p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
-<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, @signature.unsubscribe_token) %></small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>


### PR DESCRIPTION
Passing the token as a positional param results in it being used as a format and not a query param