### PR TITLE
Add the option to resend the creator email

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -1,7 +1,7 @@
 class Admin::PetitionsController < Admin::AdminController
   before_action :redirect_to_show_page, only: [:index], if: :petition_id?
   before_action :fetch_petitions, only: [:index]
-  before_action :fetch_petition, only: [:show]
+  before_action :fetch_petition, only: [:show, :resend]
 
   rescue_from ActiveRecord::RecordNotFound do
     redirect_to admin_root_url, alert: "Sorry, we couldn't find petition #{params[:id]}"
@@ -18,6 +18,11 @@ class Admin::PetitionsController < Admin::AdminController
     respond_to do |format|
       format.html
     end
+  end
+
+  def resend
+    GatherSponsorsForPetitionEmailJob.perform_later(@petition, Site.feedback_email)
+    redirect_to admin_petition_url(@petition), notice: :email_resent_to_creator
   end
 
   protected

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -90,9 +90,9 @@ class PetitionMailer < ApplicationMailer
     mail to: @signature.email, subject: subject_for(:notify_creator_of_validated_petition_being_stopped)
   end
 
-  def gather_sponsors_for_petition(petition)
+  def gather_sponsors_for_petition(petition, bcc = nil)
     @petition, @creator = petition, petition.creator
-    mail to: @creator.email, subject: subject_for(:gather_sponsors_for_petition)
+    mail to: @creator.email, bcc: bcc, subject: subject_for(:gather_sponsors_for_petition)
   end
 
   def notify_signer_of_debate_outcome(petition, signature)

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -15,6 +15,12 @@
   <%= auto_link(@petition.creator.email) %>
 </dd>
 
+<% if @petition.collecting_sponsors? %>
+  <dd>
+    <%=  button_to 'Resend email to the creator', resend_admin_petition_url(@petition), method: :post, class: 'button', data: { confirm: "Resend a copy of the email to the petition creator and forward a copy to the feedback address?" } %>
+  </dd>
+<% end %>
+
 <% if @petition.in_todo_list? %>
   <dt>Created on</dt>
   <dd><%= date_time_format(@petition.created_at) %></dd>
@@ -103,6 +109,6 @@
       <% end %>
     </small>
 
-    <%=  button_to 'Refresh', admin_petition_statistics_url(@petition), method: :patch, class: 'button' %>
+    <%=  button_to 'Refresh statistics', admin_petition_statistics_url(@petition), method: :patch, class: 'button' %>
   </div>
 <% end %>

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -47,6 +47,7 @@ en-GB:
       domain_updated: "Domain updated successfully"
       domain_deleted: "Domain removed successfully"
       domain_not_deleted: "Domain could not be removed - please contact support"
+      email_resent_to_creator: "Resent the email to the petition creator and forwarded a copy to the feedback address"
       email_sent_overnight: "Email will be sent overnight"
       enqueued_petition_statistics_update: "Updating the petition statistics - please wait a few minutes and then refresh this page"
       government_response_updated: "Updated government response successfully"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,8 @@ Rails.application.routes.draw do
       resource :moderation_delay, only: %i[new create], path: 'moderation-delay'
 
       resources :petitions, only: %i[show index] do
+        post :resend, on: :member
+
         resources :emails, controller: 'petition_emails', except: %i[index show]
         resource  :lock, only: %i[show create update destroy]
         resource  :moderation, controller: 'moderation', only: %i[update]

--- a/spec/jobs/email_job_spec.rb
+++ b/spec/jobs/email_job_spec.rb
@@ -184,6 +184,16 @@ RSpec.describe GatherSponsorsForPetitionEmailJob, type: :job do
       described_class.perform_later(petition)
     end
   end
+
+  context "when passing a BCC address" do
+    it "sends the PetitionMailer#gather_sponsors_for_petition email with a BCC address" do
+      expect(PetitionMailer).to receive(:gather_sponsors_for_petition).with(petition, Site.feedback_email).and_call_original
+
+      perform_enqueued_jobs do
+        described_class.perform_later(petition, Site.feedback_email)
+      end
+    end
+  end
 end
 
 RSpec.describe NotifyCreatorThatModerationIsDelayedJob, type: :job do

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -384,6 +384,14 @@ RSpec.describe PetitionMailer, type: :mailer do
         expect(mail).to have_body_text(%r[however we have a very large number to check])
       end
     end
+
+    context "when a BCC address is passed" do
+      subject(:mail) { described_class.gather_sponsors_for_petition(petition, Site.feedback_email) }
+
+      it "adds the BCC address to the email" do
+        expect(mail).to bcc_to("petitionscommittee@parliament.uk")
+      end
+    end
   end
 
   describe "notifying signature of debate outcome" do


### PR DESCRIPTION
Also BCC a copy to the feedback address so that it can be forwarded from their own email addresses if the main address is being filtered.