### PR TITLE
Only update journals if the main signature count is updated

### DIFF
--- a/app/lib/quiet_logger.rb
+++ b/app/lib/quiet_logger.rb
@@ -1,0 +1,27 @@
+class QuietLogger
+  attr_reader :app, :options, :paths
+
+  def initialize(app, options = {})
+    @app = app
+    @options = options
+    @paths = Array(options[:paths])
+  end
+
+  def call(env)
+    if silence_request?(env)
+      logger.silence { app.call(env) }
+    else
+      app.call(env)
+    end
+  end
+
+  private
+
+    def silence_request?(env)
+      paths.any? { |path| path === env['PATH_INFO'] }
+    end
+
+    def logger
+      Rails.logger
+    end
+end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -473,9 +473,9 @@ class Petition < ActiveRecord::Base
     sql = "signature_count = signature_count + ?, last_signed_at = ?, updated_at = ?"
     count = signatures.validated_count(last_signed_at, time)
 
-    return true if count.zero?
+    return false if count.zero?
 
-    if update_all([sql, count, time, time]) > 0
+    if result = update_all([sql, count, time, time]) > 0
       self.reload
 
       updates = []
@@ -505,7 +505,7 @@ class Petition < ActiveRecord::Base
       end
     end
 
-    true
+    result
   end
 
   def decrement_signature_count!(time = Time.current)

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,5 +53,10 @@ module Epets
     # to remove the CloudFront ip address from X-Forwarded-For
     config.middleware.insert_before ActionDispatch::RemoteIp, "CloudFrontRemoteIp"
     config.middleware.delete "ActionDispatch::RemoteIp"
+
+    # Don't log certain requests that spam the log files
+    config.middleware.insert_before Rails::Rack::Logger, "QuietLogger", paths: [
+      %r[\A/petitions/\d+/count.json\z], %q[/admin/status.json], %q[/ping]
+    ]
   end
 end

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -11,6 +11,7 @@ default: &defaults
 
   # Actions that should not be monitored by AppSignal
   ignore_actions:
+    - Admin::UserSessionsController#status
     - PetitionsController#count
     - PingController#ping
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # Disable logging of asset requests
+  config.assets.quiet = true
+
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true

--- a/spec/jobs/update_signature_counts_job_spec.rb
+++ b/spec/jobs/update_signature_counts_job_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
       context "with an open petition" do
         let(:petition) { FactoryBot.create(:open_petition) }
-        let(:attributes) { { petition: petition, location_code: "AA", constituency_id: "9999" } }
+        let(:attributes) { { petition: petition, location_code: location.code, constituency_id: "9999" } }
         let(:signatures) { FactoryBot.create_list(:pending_signature, 5, attributes) }
 
         before do
@@ -100,7 +100,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
 
       context "with a pending petition" do
         let(:petition) { FactoryBot.create(:pending_petition) }
-        let(:attributes) { { petition: petition, location_code: "AA", constituency_id: "9999" } }
+        let(:attributes) { { petition: petition, location_code: location.code, constituency_id: "9999" } }
         let(:signatures) { FactoryBot.create_list(:pending_signature, 5, attributes) }
 
         before do
@@ -138,6 +138,106 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
           }.to change {
             constituency_journal.reload.signature_count
           }.by(5)
+        end
+      end
+
+      context "with a pending petition that's had its creator validated after the current time window" do
+        let(:petition) { FactoryBot.create(:pending_petition, creator_attributes: { location_code: location.code, constituency_id: "9999" }) }
+
+        before do
+          # A new petition won't have been counted yet so we need
+          # to reset last_signed_at back to nil after the FIXME above.
+          petition.update_columns(last_signed_at: nil)
+
+          # Ensure that the signature falls within the expected window
+          travel_to (1.second.ago) do
+            petition.validate_creator!
+          end
+        end
+
+        it "doesn't update the siganture count" do
+          expect {
+            described_class.perform_now(current_time.iso8601)
+          }.not_to change {
+            petition.reload.signature_count
+          }.from(0)
+        end
+
+        it "doesn't update the country journal signature_count" do
+          expect {
+            described_class.perform_now(current_time.iso8601)
+          }.not_to change {
+            country_journal.reload.signature_count
+          }.from(0)
+        end
+
+        it "doesn't update the constituency journal signature_count" do
+          expect {
+            described_class.perform_now(current_time.iso8601)
+          }.not_to change {
+            constituency_journal.reload.signature_count
+          }.from(0)
+        end
+
+        context "and when the next time window occurs" do
+          let(:next_time) { current_time + interval.seconds }
+
+          it "updates the siganture count" do
+            expect {
+              described_class.perform_now(next_time.iso8601)
+            }.to change {
+              petition.reload.signature_count
+            }.from(0).to(1)
+          end
+
+          it "updates the country journal signature_count" do
+            expect {
+              described_class.perform_now(next_time.iso8601)
+            }.to change {
+              country_journal.reload.signature_count
+            }.from(0).to(1)
+          end
+
+          it "updates the constituency journal signature_count" do
+            expect {
+              described_class.perform_now(next_time.iso8601)
+            }.to change {
+              constituency_journal.reload.signature_count
+            }.from(0).to(1)
+          end
+        end
+
+        context "and when the next time window occurs after that" do
+          let(:next_time) { current_time + interval.seconds }
+          let(:third_time) { next_time + interval.seconds }
+
+          before do
+            described_class.perform_now(next_time.iso8601)
+          end
+
+          it "doesn't update the siganture count" do
+            expect {
+              described_class.perform_now(third_time.iso8601)
+            }.not_to change {
+              petition.reload.signature_count
+            }.from(1)
+          end
+
+          it "doesn't update the constituency journal signature_count" do
+            expect {
+              described_class.perform_now(third_time.iso8601)
+            }.not_to change {
+              constituency_journal.reload.signature_count
+            }.from(1)
+          end
+
+          it "doesn't update the country journal signature_count" do
+            expect {
+              described_class.perform_now(third_time.iso8601)
+            }.not_to change {
+              country_journal.reload.signature_count
+            }.from(1)
+          end
         end
       end
 


### PR DESCRIPTION
There's a subtle race condition when a petition is created and the first sponsor visits the new signature form. This action validates the creator signature but because the batch counting job runs a few seconds behind it means that the creator signature can be seen by the journal increment methods until that first signature is counted and last_signed_at set on the petition.