### PR TITLE
Add the ability to override the petition status

### DIFF
--- a/app/assets/stylesheets/petitions/admin/_list.scss
+++ b/app/assets/stylesheets/petitions/admin/_list.scss
@@ -171,14 +171,20 @@
     }
 
     code {
-      font-family: monospace;
-      font-size: 14px;
-      line-height: 20px;
-      color: $black;
-      background-color: $highlight-colour;
-      border: 1px solid $border-colour;
-      border-radius: 3px;
+      vertical-align: 0px;
       padding: 3px 7px;
     }
+  }
+
+  code {
+    background-color: $highlight-colour;
+    border: 1px solid $border-colour;
+    border-radius: 3px;
+    color: $black;
+    font-family: monospace;
+    font-size: 14px;
+    line-height: 20px;
+    padding: 3px;
+    vertical-align: 1px;
   }
 }

--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -3,24 +3,27 @@ class Admin::ParliamentsController < Admin::AdminController
   before_action :fetch_parliament
 
   def show
+    respond_to do |format|
+      format.html
+    end
   end
 
   def update
     if @parliament.update(parliament_params)
       if send_emails?
         @parliament.send_emails!
-        redirect_to admin_root_url, notice: :creators_emailed
+        redirect_to admin_parliament_url(tab: params[:tab]), notice: :creators_emailed
       elsif schedule_closure?
         @parliament.schedule_closure!
-        redirect_to admin_root_url, notice: :closure_scheduled
+        redirect_to admin_parliament_url(tab: params[:tab]), notice: :closure_scheduled
       elsif archive_petitions?
         @parliament.start_archiving!
-        redirect_to admin_root_url, notice: :petitions_archiving
+        redirect_to admin_parliament_url(tab: params[:tab]), notice: :petitions_archiving
       elsif archive_parliament?
         @parliament.archive!
-        redirect_to admin_root_url, notice: :parliament_archived
+        redirect_to admin_parliament_url(tab: params[:tab]), notice: :parliament_archived
       else
-        redirect_to admin_root_url, notice: :parliament_updated
+        redirect_to admin_parliament_url(tab: params[:tab]), notice: :parliament_updated
       end
     else
       render :show
@@ -40,7 +43,10 @@ class Admin::ParliamentsController < Admin::AdminController
       :dissolved_heading, :dissolved_message,
       :dissolution_at, :dissolution_faq_url,
       :notification_cutoff_at, :registration_closed_at,
-      :election_date, :show_dissolution_notification
+      :election_date, :show_dissolution_notification,
+      :government_response_heading, :government_response_description,
+      :government_response_status, :parliamentary_debate_heading,
+      :parliamentary_debate_description, :parliamentary_debate_status
     )
   end
 

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -36,12 +36,20 @@ class Parliament < ActiveRecord::Base
       instance.opened?(now)
     end
 
+    def closed?(now = Time.current)
+      instance.closed?(now)
+    end
+
     def dissolution_at
       instance.dissolution_at
     end
 
     def dissolution_at?
       instance.dissolution_at?
+    end
+
+    def dissolving?(now = Time.current)
+      instance.dissolving?(now)
     end
 
     def registration_closed_at
@@ -92,6 +100,34 @@ class Parliament < ActiveRecord::Base
       instance.registration_closed?
     end
 
+    def government_response_heading
+      instance.government_response_heading
+    end
+
+    def government_response_description
+      instance.government_response_description.to_s % { count: Site.formatted_threshold_for_response }
+    rescue KeyError => e
+      instance.government_response_description
+    end
+
+    def government_response_status
+      instance.government_response_status
+    end
+
+    def parliamentary_debate_heading
+      instance.parliamentary_debate_heading
+    end
+
+    def parliamentary_debate_description
+      instance.parliamentary_debate_description.to_s % { count: Site.formatted_threshold_for_debate }
+    rescue KeyError => e
+      instance.parliamentary_debate_description
+    end
+
+    def parliamentary_debate_status
+      instance.parliamentary_debate_status
+    end
+
     def reload
       Thread.current[:__parliament__] = nil
     end
@@ -122,6 +158,10 @@ class Parliament < ActiveRecord::Base
     opening_at? && opening_at <= now
   end
 
+  def closed?(now = Time.current)
+    dissolved?(now) || !opened?(now)
+  end
+
   def period
     if opening_at? && dissolution_at?
       "#{opening_at.year}–#{dissolution_at.year}"
@@ -130,6 +170,10 @@ class Parliament < ActiveRecord::Base
 
   def period?
     period.present?
+  end
+
+  def dissolving?(now = Time.current)
+    dissolution_at? && dissolution_at > now
   end
 
   def dissolved?(now = Time.current)

--- a/app/views/admin/parliaments/_debate.html.erb
+++ b/app/views/admin/parliaments/_debate.html.erb
@@ -1,0 +1,22 @@
+<%= hidden_field_tag :tab, "debate" %>
+
+<p>Petitions waiting for a debate outcome before a new Petitions Committee is formed should show:</p>
+
+<%= form_row for: [form.object, :parliamentary_debate_heading] do %>
+  <%= form.label :parliamentary_debate_heading, 'Heading', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :parliamentary_debate_heading %>
+  <%= form.text_field :parliamentary_debate_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :parliamentary_debate_description] do %>
+  <%= form.label :parliamentary_debate_description, 'Description', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :parliamentary_debate_description %>
+  <%= form.text_area :parliamentary_debate_description, tabindex: increment, rows: 5, class: 'form-control' %>
+  <small class="form-hint">Use <code>%{count}</code> for the number of required signatures</small>
+<% end %>
+
+<%= form_row for: [form.object, :parliamentary_debate_status] do %>
+  <%= form.label :parliamentary_debate_status, 'Status', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :parliamentary_debate_status %>
+  <%= form.text_field :parliamentary_debate_status, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>

--- a/app/views/admin/parliaments/_details.html.erb
+++ b/app/views/admin/parliaments/_details.html.erb
@@ -1,0 +1,11 @@
+<%= form_row for: [form.object, :government] do %>
+  <%= form.label :government, 'Government', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :government %>
+  <%= form.text_field :government, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :opening_at] do %>
+  <%= form.label :opening_at, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :opening_at %>
+  <%= form.datetime_select :opening_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>

--- a/app/views/admin/parliaments/_dissolution.html.erb
+++ b/app/views/admin/parliaments/_dissolution.html.erb
@@ -1,0 +1,39 @@
+<%= hidden_field_tag :tab, "dissolution" %>
+
+<%= form_row for: [form.object, :dissolution_at] do %>
+  <%= form.label :dissolution_at, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :dissolution_at %>
+  <%= form.datetime_select :dissolution_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>
+
+<%= form_row for: [form.object, :dissolution_faq_url] do %>
+  <%= form.label :dissolution_faq_url, 'Dissolution FAQ URL', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :dissolution_faq_url %>
+  <%= form.text_field :dissolution_faq_url, tabindex: increment, maxlength: 500, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :show_dissolution_notification], class: 'inline' do %>
+  <%= form.label :show_dissolution_notification, "Show dissolution notification?", class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :show_dissolution_notification %>
+  <div class="multiple-choice">
+    <%= form.radio_button :show_dissolution_notification, true %>
+    <%= form.label :show_dissolution_notification_true, "Yes", for: "parliament_show_dissolution_notification_true" %>
+  </div>
+  <div class="multiple-choice">
+    <%= form.radio_button :show_dissolution_notification, false %>
+    <%= form.label :show_dissolution_notification_false, "No", for: "parliament_show_dissolution_notification_false" %>
+  </div>
+<% end %>
+
+<%= form_row for: [form.object, :dissolution_heading] do %>
+  <%= form.label :dissolution_heading, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :dissolution_heading %>
+  <%= form.text_field :dissolution_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :dissolution_message] do %>
+  <%= form.label :dissolution_message, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :dissolution_message %>
+  <%= form.text_area :dissolution_message, tabindex: increment, rows: 5, data: { max_length: 500 }, class: 'form-control' %>
+  <p class="character-count">500 characters max</p>
+<% end %>

--- a/app/views/admin/parliaments/_dissolved.html.erb
+++ b/app/views/admin/parliaments/_dissolved.html.erb
@@ -1,0 +1,20 @@
+<%= hidden_field_tag :tab, "dissolved" %>
+
+<%= form_row for: [form.object, :notification_cutoff_at] do %>
+  <%= form.label :notification_cutoff_at, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :notification_cutoff_at %>
+  <%= form.datetime_select :notification_cutoff_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>
+
+<%= form_row for: [form.object, :dissolved_heading] do %>
+  <%= form.label :dissolved_heading, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :dissolved_heading %>
+  <%= form.text_field :dissolved_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :dissolved_message] do %>
+  <%= form.label :dissolved_message, class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :dissolved_message %>
+  <%= form.text_area :dissolved_message, tabindex: increment, rows: 5, data: { max_length: 500 }, class: 'form-control' %>
+  <p class="character-count">500 characters max</p>
+<% end %>

--- a/app/views/admin/parliaments/_election.html.erb
+++ b/app/views/admin/parliaments/_election.html.erb
@@ -1,0 +1,13 @@
+<%= hidden_field_tag :tab, "election" %>
+
+<%= form_row for: [form.object, :election_date] do %>
+  <%= form.label :election_date, 'Date', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :election_date %>
+  <%= form.date_select :election_date, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>
+
+<%= form_row for: [form.object, :registration_closed_at] do %>
+  <%= form.label :registration_closed_at, 'Voter registration closes at', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :registration_closed_at %>
+  <%= form.datetime_select :registration_closed_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
+<% end %>

--- a/app/views/admin/parliaments/_form.html.erb
+++ b/app/views/admin/parliaments/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_for @parliament, url: admin_parliament_url do |form| %>
+  <%= render tab, form: form %>
+  <%= form.submit 'Save', class: 'button' %>
+  <% if @parliament.dissolved? %>
+    <% if @parliament.can_archive_petitions? %>
+      <%= form.submit 'Archive petitions', name: 'archive_petitions', class: 'button-secondary', data: { confirm: 'Copy current petitions to archive?' } %>
+    <% elsif @parliament.can_archive? %>
+      <%= form.submit 'Archive parliament', name: 'archive_parliament', class: 'button-secondary', data: { confirm: 'Archive this parliament and create a new one?' } %>
+    <% end %>
+  <% elsif @parliament.dissolving? %>
+    <% if @parliament.dissolution_announced? %>
+      <%= form.submit 'Schedule closure', name: 'schedule_closure', class: 'button-secondary', data: { confirm: 'Schedule early closure of petitions?' } %>
+    <% else %>
+      <%= form.submit 'Send dissolution emails', name: 'send_emails', class: 'button-secondary', data: { confirm: 'Email everyone about dissolution?' } %>
+    <% end %>
+  <% end %>
+  <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>
+<% end %>
+
+<%= javascript_include_tag 'character-counter' %>

--- a/app/views/admin/parliaments/_response.html.erb
+++ b/app/views/admin/parliaments/_response.html.erb
@@ -1,0 +1,22 @@
+<%= hidden_field_tag :tab, "response" %>
+
+<p>Petitions waiting for a government response before a new Petitions Committee is formed should show:</p>
+
+<%= form_row for: [form.object, :government_response_heading] do %>
+  <%= form.label :government_response_heading, 'Heading', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :government_response_heading %>
+  <%= form.text_field :government_response_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>
+
+<%= form_row for: [form.object, :government_response_description] do %>
+  <%= form.label :government_response_description, 'Description', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :government_response_description %>
+  <%= form.text_area :government_response_description, tabindex: increment, rows: 5, class: 'form-control' %>
+  <small class="form-hint">Use <code>%{count}</code> for the number of required signatures</small>
+<% end %>
+
+<%= form_row for: [form.object, :government_response_status] do %>
+  <%= form.label :government_response_status, 'Status', class: 'form-label' %>
+  <%= error_messages_for_field @parliament, :government_response_status %>
+  <%= form.text_field :government_response_status, tabindex: increment, maxlength: 100, class: 'form-control' %>
+<% end %>

--- a/app/views/admin/parliaments/show.html.erb
+++ b/app/views/admin/parliaments/show.html.erb
@@ -1,115 +1,23 @@
 <h1>Edit Parliament</h1>
 
 <div class="grid-row">
+  <div class="grid-column">
+    <%= render "admin/shared/parliament_tabs" %>
+  </div>
+
   <div class="column-two-thirds extra-gutter">
-    <%= form_for @parliament, url: admin_parliament_url do |form| %>
-      <h2>Voter registration closes at</h2>
-
-      <%= form_row for: [form.object, :registration_closed_at] do %>
-        <%= error_messages_for_field @parliament, :registration_closed_at %>
-        <%= form.datetime_select :registration_closed_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
-      <% end %>
-
-      <h2>Election date</h2>
-
-      <%= form_row for: [form.object, :election_date] do %>
-        <%= error_messages_for_field @parliament, :election_date %>
-        <%= form.date_select :election_date, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
-      <% end %>
-
-      <h2>Government</h2>
-
-      <%= form_row for: [form.object, :government] do %>
-        <%= error_messages_for_field @parliament, :government %>
-        <%= form.text_field :government, tabindex: increment, maxlength: 100, class: 'form-control' %>
-      <% end %>
-
-      <%= form_row for: [form.object, :opening_at] do %>
-        <%= form.label :opening_at, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :opening_at %>
-        <%= form.datetime_select :opening_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
-      <% end %>
-
-      <h2>Dissolution</h2>
-
-      <%= form_row for: [form.object, :dissolution_at] do %>
-        <%= form.label :dissolution_at, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :dissolution_at %>
-        <%= form.datetime_select :dissolution_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
-      <% end %>
-
-      <%= form_row for: [form.object, :dissolution_heading] do %>
-        <%= form.label :dissolution_heading, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :dissolution_heading %>
-        <%= form.text_field :dissolution_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
-      <% end %>
-
-      <%= form_row for: [form.object, :dissolution_message] do %>
-        <%= form.label :dissolution_message, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :dissolution_message %>
-        <%= form.text_area :dissolution_message, tabindex: increment, rows: 5, data: { max_length: 500 }, class: 'form-control' %>
-        <p class="character-count">500 characters max</p>
-      <% end %>
-
-      <%= form_row for: [form.object, :dissolution_faq_url] do %>
-        <%= form.label :dissolution_faq_url, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :dissolution_faq_url %>
-        <%= form.text_field :dissolution_faq_url, tabindex: increment, maxlength: 500, class: 'form-control' %>
-      <% end %>
-
-      <%= form_row for: [form.object, :show_dissolution_notification], class: 'inline' do %>
-        <%= form.label :show_dissolution_notification, "Show dissolution notification?", class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :show_dissolution_notification %>
-        <div class="multiple-choice">
-          <%= form.radio_button :show_dissolution_notification, true %>
-          <%= form.label :show_dissolution_notification_true, "Yes", for: "parliament_show_dissolution_notification_true" %>
-        </div>
-        <div class="multiple-choice">
-          <%= form.radio_button :show_dissolution_notification, false %>
-          <%= form.label :show_dissolution_notification_false, "No", for: "parliament_show_dissolution_notification_false" %>
-        </div>
-      <% end %>
-
-      <h2>Dissolved</h2>
-
-      <%= form_row for: [form.object, :notification_cutoff_at] do %>
-        <%= form.label :notification_cutoff_at, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :notification_cutoff_at %>
-        <%= form.datetime_select :notification_cutoff_at, { include_blank: true }, tabindex: increment, class: 'form-control auto-width' %>
-      <% end %>
-
-      <%= form_row for: [form.object, :dissolved_heading] do %>
-        <%= form.label :dissolved_heading, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :dissolved_heading %>
-        <%= form.text_field :dissolved_heading, tabindex: increment, maxlength: 100, class: 'form-control' %>
-      <% end %>
-
-      <%= form_row for: [form.object, :dissolved_message] do %>
-        <%= form.label :dissolved_message, class: 'form-label' %>
-        <%= error_messages_for_field @parliament, :dissolved_message %>
-        <%= form.text_area :dissolved_message, tabindex: increment, rows: 5, data: { max_length: 500 }, class: 'form-control' %>
-        <p class="character-count">500 characters max</p>
-      <% end %>
-
-      <%= form.submit 'Save', class: 'button' %>
-      <% if @parliament.dissolution_at? %>
-        <% if @parliament.dissolved? %>
-          <% if @parliament.can_archive_petitions? %>
-            <%= form.submit 'Archive petitions', name: 'archive_petitions', class: 'button-secondary', data: { confirm: 'Copy current petitions to archive?' } %>
-          <% elsif @parliament.can_archive? %>
-            <%= form.submit 'Archive parliament', name: 'archive_parliament', class: 'button-secondary', data: { confirm: 'Archive this parliament and create a new one?' } %>
-          <% end %>
-        <% else %>
-          <% if @parliament.dissolution_announced? %>
-            <%= form.submit 'Schedule closure', name: 'schedule_closure', class: 'button-secondary', data: { confirm: 'Schedule early closure of petitions?' } %>
-          <% else %>
-            <%= form.submit 'Send dissolution emails', name: 'send_emails', class: 'button-secondary', data: { confirm: 'Email everyone about dissolution?' } %>
-          <% end %>
-        <% end %>
-      <% end %>
-      <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>
+    <% if params[:tab] == "dissolution" %>
+      <%= render "form", tab: "dissolution" %>
+    <% elsif params[:tab] == "election" %>
+      <%= render "form", tab: "election" %>
+    <% elsif params[:tab] == "dissolved" %>
+      <%= render "form", tab: "dissolved" %>
+    <% elsif params[:tab] == "response" %>
+      <%= render "form", tab: "response" %>
+    <% elsif params[:tab] == "debate" %>
+      <%= render "form", tab: "debate" %>
+    <% else %>
+      <%= render "form", tab: "details" %>
     <% end %>
   </div>
 </div>
-
-<%= javascript_include_tag 'character-counter' %>

--- a/app/views/admin/shared/_parliament_tabs.html.erb
+++ b/app/views/admin/shared/_parliament_tabs.html.erb
@@ -1,0 +1,45 @@
+<p class="tabs">
+  <% if params[:tab] == "dissolution" %>
+    <%= link_to "Details", admin_parliament_path %> |
+   Dissolution |
+    <%= link_to "Election", admin_parliament_path(tab: 'election') %> |
+    <%= link_to "Dissolved", admin_parliament_path(tab: 'dissolved') %> |
+    <%= link_to "Government Response", admin_parliament_path(tab: 'response') %> |
+    <%= link_to "Parliamentary Debate", admin_parliament_path(tab: 'debate') %>
+  <% elsif params[:tab] == "election" %>
+    <%= link_to "Details", admin_parliament_path %> |
+    <%= link_to "Dissolution", admin_parliament_path(tab: 'dissolution') %> |
+   Election |
+    <%= link_to "Dissolved", admin_parliament_path(tab: 'dissolved') %> |
+    <%= link_to "Government Response", admin_parliament_path(tab: 'response') %> |
+    <%= link_to "Parliamentary Debate", admin_parliament_path(tab: 'debate') %>
+  <% elsif params[:tab] == "dissolved" %>
+    <%= link_to "Details", admin_parliament_path %> |
+    <%= link_to "Dissolution", admin_parliament_path(tab: 'dissolution') %> |
+    <%= link_to "Election", admin_parliament_path(tab: 'election') %> |
+    Dissolved |
+    <%= link_to "Government Response", admin_parliament_path(tab: 'response') %> |
+    <%= link_to "Parliamentary Debate", admin_parliament_path(tab: 'debate') %>
+  <% elsif params[:tab] == "response" %>
+    <%= link_to "Details", admin_parliament_path %> |
+    <%= link_to "Dissolution", admin_parliament_path(tab: 'dissolution') %> |
+    <%= link_to "Election", admin_parliament_path(tab: 'election') %> |
+    <%= link_to "Dissolved", admin_parliament_path(tab: 'dissolved') %> |
+    Government Response |
+    <%= link_to "Parliamentary Debate", admin_parliament_path(tab: 'debate') %>
+  <% elsif params[:tab] == "debate" %>
+    <%= link_to "Details", admin_parliament_path %> |
+    <%= link_to "Dissolution", admin_parliament_path(tab: 'dissolution') %> |
+    <%= link_to "Election", admin_parliament_path(tab: 'election') %> |
+    <%= link_to "Dissolved", admin_parliament_path(tab: 'dissolved') %> |
+    <%= link_to "Government Response", admin_parliament_path(tab: 'response') %> |
+    Parliamentary Debate
+  <% else %>
+    Details |
+    <%= link_to "Dissolution", admin_parliament_path(tab: 'dissolution') %> |
+    <%= link_to "Election", admin_parliament_path(tab: 'election') %> |
+    <%= link_to "Dissolved", admin_parliament_path(tab: 'dissolved') %> |
+    <%= link_to "Government Response", admin_parliament_path(tab: 'response') %> |
+    <%= link_to "Parliamentary Debate", admin_parliament_path(tab: 'debate') %>
+  <% end %>
+</p>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -57,12 +57,17 @@
       </p>
     <% end %>
 
-  <%# Waiting for a government response #%>
+  <%# Waiting for a debate date #%>
   <% elsif petition.debate_threshold_reached_at? -%>
-    <h2 id="debate-threshold-heading">Parliament will consider this for a debate</h2>
-    <p>Parliament considers all petitions that get more than <%= Site.formatted_threshold_for_debate %> signatures for a debate</p>
-    <p class="secondary"><%= waiting_for_in_words(petition.debate_threshold_reached_at) %> for a debate date</p>
-
+    <% if Parliament.closed? %>
+      <h2 id="response-threshold-heading"><%= Parliament.parliamentary_debate_heading.presence || "Parliament will consider this for a debate" %></h2>
+      <p><%= Parliament.parliamentary_debate_description.presence || "Parliament considers all petitions that get more than #{Site.formatted_threshold_for_debate} signatures for a debate" %></p>
+      <p class="secondary"><%= Parliament.parliamentary_debate_status.presence || "#{waiting_for_in_words(petition.debate_threshold_reached_at)} for a debate date" %></p>
+    <% else %>
+      <h2 id="debate-threshold-heading">Parliament will consider this for a debate</h2>
+      <p>Parliament considers all petitions that get more than <%= Site.formatted_threshold_for_debate %> signatures for a debate</p>
+      <p class="secondary"><%= waiting_for_in_words(petition.debate_threshold_reached_at) %> for a debate date</p>
+    <% end %>
   <%# Needs more signatures #%>
   <% else -%>
     <% if !@petition.closed? %>

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -22,9 +22,15 @@
 
   <%# Waiting for a government response #%>
   <% elsif petition.response_threshold_reached_at? -%>
-    <h2 id="response-threshold-heading">Government will respond</h2>
-    <p>Government responds to all petitions that get more than <%= Site.formatted_threshold_for_response %> signatures</p>
-    <p class="secondary"><%= waiting_for_in_words(petition.response_threshold_reached_at) %> for a government response</p>
+    <% if Parliament.closed? %>
+      <h2 id="response-threshold-heading"><%= Parliament.government_response_heading.presence || "Government will respond" %></h2>
+      <p><%= Parliament.government_response_description.presence || "Government responds to all petitions that get more than #{Site.formatted_threshold_for_response} signatures" %></p>
+      <p class="secondary"><%= Parliament.government_response_status.presence || "#{waiting_for_in_words(petition.response_threshold_reached_at)} for a government response" %></p>
+    <% else %>
+      <h2 id="response-threshold-heading">Government will respond</h2>
+      <p>Government responds to all petitions that get more than <%= Site.formatted_threshold_for_response %> signatures</p>
+      <p class="secondary"><%= waiting_for_in_words(petition.response_threshold_reached_at) %> for a government response</p>
+    <% end %>
 
   <%# Needs more signatures #%>
   <% else -%>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_debate.html.erb
@@ -1,6 +1,10 @@
 <h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
-<p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
-<% if petition.scheduled_debate_date? %>
-  <p><%= scheduled_for_debate_in_words(petition.scheduled_debate_date) %></p>
+<% if Parliament.closed? %>
+  <%= Parliament.parliamentary_debate_status.presence || waiting_for_in_words(petition.debate_threshold_reached_at) %>
+<% else %>
+  <p><%= waiting_for_in_words(petition.debate_threshold_reached_at) %></p>
+  <% if petition.scheduled_debate_date? %>
+    <p><%= scheduled_for_debate_in_words(petition.scheduled_debate_date) %></p>
+  <% end %>
 <% end %>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_awaiting_response.html.erb
@@ -1,3 +1,7 @@
 <h3><%= link_to petition.action, petition_result_path(petition) %></h3>
 <p><%= signature_count(:default, petition.signature_count) %></p>
-<p><%= waiting_for_in_words(petition.response_threshold_reached_at) %></p>
+<% if Parliament.closed? %>
+  <%= Parliament.government_response_status.presence || waiting_for_in_words(petition.response_threshold_reached_at) %>
+<% else %>
+  <p><%= waiting_for_in_words(petition.response_threshold_reached_at) %></p>
+<% end %>

--- a/db/migrate/20191107140359_add_petition_status_columns_to_parliament.rb
+++ b/db/migrate/20191107140359_add_petition_status_columns_to_parliament.rb
@@ -1,0 +1,38 @@
+class AddPetitionStatusColumnsToParliament < ActiveRecord::Migration
+  class Parliament < ActiveRecord::Base
+    class << self
+      def current
+        where(archived_at: nil).order(created_at: :asc).first!
+      end
+    end
+  end
+
+  def up
+    add_column :parliaments, :government_response_heading, :string
+    add_column :parliaments, :government_response_description, :text
+    add_column :parliaments, :government_response_status, :string
+    add_column :parliaments, :parliamentary_debate_heading, :string
+    add_column :parliaments, :parliamentary_debate_description, :text
+    add_column :parliaments, :parliamentary_debate_status, :string
+
+    Parliament.current.tap do |parliament|
+      parliament.update(
+        government_response_heading: "Government will respond",
+        government_response_description: "Government responds to all petitions that get more than %{count} signatures",
+        government_response_status: "Waiting for a new Petitions Committee after the General Election",
+        parliamentary_debate_heading: "This petition will be considered for debate",
+        parliamentary_debate_description: "All petitions that have more than %{count} signatures will be considered for debate in the new Parliament",
+        parliamentary_debate_status: "Waiting for a new Petitions Committee after the General Election"
+      )
+    end
+  end
+
+  def down
+    remove_column :parliaments, :government_response_heading
+    remove_column :parliaments, :government_response_description
+    remove_column :parliaments, :government_response_status
+    remove_column :parliaments, :parliamentary_debate_heading
+    remove_column :parliaments, :parliamentary_debate_description
+    remove_column :parliaments, :parliamentary_debate_status
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -871,7 +871,13 @@ CREATE TABLE public.parliaments (
     petition_duration integer DEFAULT 6,
     archiving_started_at timestamp without time zone,
     election_date date,
-    show_dissolution_notification boolean DEFAULT false NOT NULL
+    show_dissolution_notification boolean DEFAULT false NOT NULL,
+    government_response_heading character varying,
+    government_response_description text,
+    government_response_status character varying,
+    parliamentary_debate_heading character varying,
+    parliamentary_debate_description text,
+    parliamentary_debate_status character varying
 );
 
 
@@ -3202,4 +3208,6 @@ INSERT INTO schema_migrations (version) VALUES ('20191030172734');
 INSERT INTO schema_migrations (version) VALUES ('20191101104438');
 
 INSERT INTO schema_migrations (version) VALUES ('20191104165726');
+
+INSERT INTO schema_migrations (version) VALUES ('20191107140359');
 

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -148,9 +148,37 @@ Given(/^a petition "([^"]*)" has been closed early because of parliament dissolv
     dissolved_heading: "Parliament has been dissolved",
     dissolved_message: "All petitions have been closed",
     dissolution_faq_url: "https://parliament.example.com/parliament-is-closing",
-    show_dissolution_notification: true
+    show_dissolution_notification: true,
+    government_response_heading: "Government will respond",
+    government_response_description: "Government responds to all petitions that get more than %{count} signatures",
+    government_response_status: "Waiting for a new Petitions Committee after the General Election",
+    parliamentary_debate_heading: "This petition will be considered for debate",
+    parliamentary_debate_description: "All petitions that have more than %{count} signatures will be considered for debate in the new Parliament",
+    parliamentary_debate_status: "Waiting for a new Petitions Committee after the General Election"
 
   @petition = FactoryBot.create(:closed_petition, action: petition_action, open_at: open_at, closed_at: closed_at)
+end
+
+Given(/^the petition "([^"]*)" has been closed early because of parliament dissolving$/) do |petition_action|
+  open_at = 3.months.ago
+  closed_at = 1.month.ago
+
+  Parliament.instance.update! dissolution_at: closed_at,
+    dissolution_heading: "Parliament is dissolving",
+    dissolution_message: "This means all petitions will close in 2 weeks",
+    dissolved_heading: "Parliament has been dissolved",
+    dissolved_message: "All petitions have been closed",
+    dissolution_faq_url: "https://parliament.example.com/parliament-is-closing",
+    show_dissolution_notification: true,
+    government_response_heading: "Government will respond",
+    government_response_description: "Government responds to all petitions that get more than %{count} signatures",
+    government_response_status: "Waiting for a new Petitions Committee after the General Election",
+    parliamentary_debate_heading: "This petition will be considered for debate",
+    parliamentary_debate_description: "All petitions that have more than %{count} signatures will be considered for debate in the new Parliament",
+    parliamentary_debate_status: "Waiting for a new Petitions Committee after the General Election"
+
+  @petition = Petition.find_by!(action: petition_action)
+  @petition.update(state: "closed", open_at: open_at, closed_at: closed_at)
 end
 
 Given(/^the petition has closed$/) do

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -72,6 +72,22 @@ Feature: Suzie views a petition
     When I view the petition
     Then I should see "This petition closed early because of a General Election"
 
+  Scenario: Suzie sees a special message when viewing a petition closed early due to parliament being dissolved and awaiting a government response
+    Given a petition "Spend more money on Defence" exists and passed the threshold for a response 14 days ago
+    And the petition "Spend more money on Defence" has been closed early because of parliament dissolving
+    When I view the petition
+    Then I should see "Government will respond"
+    Then I should see "Government responds to all petitions that get more than 10,000 signatures"
+    Then I should see "Waiting for a new Petitions Committee after the General Election"
+
+  Scenario: Suzie sees a special message when viewing a petition closed early due to parliament being dissolved and awaiting a debate
+    Given a petition "Spend more money on Defence" passed the threshold for a debate 14 days ago and has no debate date set
+    And the petition "Spend more money on Defence" has been closed early because of parliament dissolving
+    When I view the petition
+    Then I should see "This petition will be considered for debate"
+    Then I should see "All petitions that have more than 100,000 signatures will be considered for debate in the new Parliament"
+    Then I should see "Waiting for a new Petitions Committee after the General Election"
+
   Scenario: Suzie does not see the creator when viewing a closed petition
     Given a petition "Spend more money on Defence" has been closed
     When I view the petition

--- a/spec/controllers/admin/parliaments_controller_spec.rb
+++ b/spec/controllers/admin/parliaments_controller_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -143,8 +143,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             { job: NotifyPetitionsThatParliamentIsDissolvingJob, args: [], queue: "high_priority" }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -168,8 +168,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -238,8 +238,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -267,8 +267,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -328,8 +328,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -357,8 +357,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -424,8 +424,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do
@@ -453,8 +453,8 @@ RSpec.describe Admin::ParliamentsController, type: :controller, admin: true do
             }
           end
 
-          it "redirects to the admin dashboard page" do
-            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+          it "redirects back to the edit page" do
+            expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/parliament")
           end
 
           it "sets the flash notice message" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -692,6 +692,13 @@ FactoryBot.define do
       dissolved_heading "Parliament is dissolved"
       dissolved_message "All petitions are now closed"
       dissolution_at { 2.weeks.ago }
+
+      government_response_heading { "Government will respond" }
+      government_response_description { "Government responds to all petitions that get more than %{count} signatures" }
+      government_response_status { "Waiting for a new Petitions Committee after the General Election" }
+      parliamentary_debate_heading { "This petition will be considered for debate" }
+      parliamentary_debate_description { "All petitions that have more than %{count} signatures will be considered for debate in the new Parliament" }
+      parliamentary_debate_status { "Waiting for a new Petitions Committee after the General Election" }
     end
 
     trait :coalition do

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -188,6 +188,11 @@ RSpec.describe Parliament, type: :model do
       expect(Parliament.opened?).to eq(true)
     end
 
+    it "delegates closed? to the instance" do
+      expect(parliament).to receive(:closed?).and_return(false)
+      expect(Parliament.closed?).to eq(false)
+    end
+
     it "delegates dissolution_at to the instance" do
       expect(parliament).to receive(:dissolution_at).and_return(now)
       expect(Parliament.dissolution_at).to eq(now)
@@ -236,6 +241,11 @@ RSpec.describe Parliament, type: :model do
     it "delegates dissolution_announced? to the instance" do
       expect(parliament).to receive(:dissolution_announced?).and_return(true)
       expect(Parliament.dissolution_announced?).to eq(true)
+    end
+
+    it "delegates dissolving? to the instance" do
+      expect(parliament).to receive(:dissolving?).and_return(true)
+      expect(Parliament.dissolving?).to eq(true)
     end
 
     it "delegates dissolved? to the instance" do
@@ -436,6 +446,50 @@ RSpec.describe Parliament, type: :model do
     end
   end
 
+  describe "#closed?" do
+    context "when Parliament is open" do
+      context "and has not been dissolved" do
+        subject :parliament do
+          FactoryBot.build(:parliament, opening_at: 2.years.ago, dissolution_at: nil)
+        end
+
+        it "return false" do
+          expect(parliament.closed?).to eq(false)
+        end
+      end
+
+      context "and is dissolving" do
+        subject :parliament do
+          FactoryBot.build(:parliament, opening_at: 2.years.ago, dissolution_at: 1.day.from_now)
+        end
+
+        it "return false" do
+          expect(parliament.closed?).to eq(false)
+        end
+      end
+
+      context "and has been dissolved" do
+        subject :parliament do
+          FactoryBot.build(:parliament, opening_at: 2.years.ago, dissolution_at: 1.day.ago)
+        end
+
+        it "return true" do
+          expect(parliament.closed?).to eq(true)
+        end
+      end
+    end
+
+    context "whem Parliament has not been opened" do
+      subject :parliament do
+        FactoryBot.build(:parliament, opening_at: nil, dissolution_at: nil)
+      end
+
+      it "return true" do
+        expect(parliament.closed?).to eq(true)
+      end
+    end
+  end
+
   describe "#dissolution_announced?" do
     context "when dissolution_at is nil" do
       subject :parliament do
@@ -470,6 +524,38 @@ RSpec.describe Parliament, type: :model do
         it "returns true" do
           expect(parliament.dissolution_announced?).to eq(true)
         end
+      end
+    end
+  end
+
+  describe "#dissolving?" do
+    context "when dissolution_at is nil" do
+      subject :parliament do
+        FactoryBot.create(:parliament)
+      end
+
+      it "returns false" do
+        expect(parliament.dissolving?).to eq(false)
+      end
+    end
+
+    context "when dissolution_at is in the future" do
+      subject :parliament do
+        FactoryBot.create(:parliament, :dissolving)
+      end
+
+      it "returns true" do
+        expect(parliament.dissolving?).to eq(true)
+      end
+    end
+
+    context "when dissolution_at is in the past" do
+      subject :parliament do
+        FactoryBot.create(:parliament, :dissolved)
+      end
+
+      it "returns false" do
+        expect(parliament.dissolving?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
When Parliament is dissolved the messages about government responses and debate outcomes aren't correct so allow overriding of the default messages with a custom message when Parliament is closed.