### PR TITLE
Gracefully handle when signatures have never been counted

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -398,6 +398,10 @@ class Signature < ActiveRecord::Base
       where(id: id).where(validated_at.not_eq(nil)).exists?
     end
 
+    def earliest_validation
+      validated.order(validated_at: :asc).limit(1).pluck(:validated_at).first
+    end
+
     private
 
     def ip_search?(query)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -398,6 +398,10 @@ class Site < ActiveRecord::Base
     time.end_of_day + petition_duration.months
   end
 
+  def signature_count_updated_at
+    super || Signature.earliest_validation
+  end
+
   validates :title, presence: true, length: { maximum: 50 }
   validates :url, presence: true, length: { maximum: 50 }
   validates :moderate_url, presence: true, length: { maximum: 50 }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -995,4 +995,21 @@ RSpec.describe Site, type: :model do
       expect(site.closed_at_for_opening).to eq(3.months.from_now.end_of_day)
     end
   end
+
+  describe "#signature_count_updated_at" do
+    context "when the count has never been updated" do
+      subject :site do
+        described_class.create!(signature_count_updated_at: nil)
+      end
+
+      before do
+        FactoryBot.create(:validated_signature, validated_at: 2.weeks.ago)
+        FactoryBot.create(:validated_signature, validated_at: 4.weeks.ago)
+      end
+
+      it "returns the earliest validated signature timestamp" do
+        expect(site.signature_count_updated_at).to be_within(1.minute).of(4.weeks.ago)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a new developer boots the app for the first time the counts have never been updated so the job fails. Fix this by defaulting to the earliest validated signature and if there are no validated signatures then just record the current time window and exit.