### PR TITLE
Don't output blank rejections in the JSON

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -648,10 +648,6 @@ class Petition < ActiveRecord::Base
     update(state: FLAGGED_STATE)
   end
 
-  def rejection(*args)
-    super || build_rejection
-  end
-
   def close!(time = deadline)
     if open?
       update!(state: CLOSED_STATE, closed_at: time)

--- a/app/views/admin/petitions/_reject.html.erb
+++ b/app/views/admin/petitions/_reject.html.erb
@@ -17,7 +17,7 @@
     });
   <% end -%>
 
-  <%= f.fields_for :rejection, f.object.rejection do |r| %>
+  <%= f.fields_for :rejection, f.object.rejection || f.object.build_rejection do |r| %>
     <%= form_row for: [r.object, :code] do %>
       <%= r.label :code, 'Rejection reason', class: 'form-label' %>
       <%= error_messages_for_field r.object, :code %>

--- a/spec/fixtures/rejection_reasons.yml
+++ b/spec/fixtures/rejection_reasons.yml
@@ -1,4 +1,5 @@
 duplicate:
+  created_at: "2015-07-20T10:00:01Z"
   code: "duplicate"
   title: "Duplicate petition"
   hidden: false
@@ -8,6 +9,7 @@ duplicate:
     You are more likely to get action on this issue if you sign and share a single petition.
 
 irrelevant:
+  created_at: "2015-07-20T10:00:02Z"
   code: "irrelevant"
   title: "Not the Government/Parliament’s responsibility"
   hidden: false
@@ -15,6 +17,7 @@ irrelevant:
     It’s about something that the UK Government or Parliament is not responsible for.
 
 no-action:
+  created_at: "2015-07-20T10:00:03Z"
   code: "no-action"
   title: "Action unclear"
   hidden: false
@@ -22,6 +25,7 @@ no-action:
     It’s not clear what the petition is asking the UK Government or Parliament to do.
 
 honours:
+  created_at: "2015-07-20T10:00:04Z"
   code: "honours"
   title: "Honours or appointments"
   hidden: false
@@ -29,6 +33,7 @@ honours:
     It’s about honours or appointments.
 
 fake-name:
+  created_at: "2015-07-20T10:00:05Z"
   code: "fake-name"
   title: "Fake name"
   hidden: false
@@ -42,6 +47,7 @@ fake-name:
     We are rejecting your petition for that reason, but if you resubmit your petition using your full name, we’ll be able to approve it.
 
 foi:
+  created_at: "2015-07-20T10:00:06Z"
   code: "foi"
   title: "FOI request"
   hidden: false
@@ -49,6 +55,7 @@ foi:
     It’s an FOI request.
 
 libellous:
+  created_at: "2015-07-20T10:00:07Z"
   code: "libellous"
   title: "Confidential, libellous, false, defamatory or references a court case"
   hidden: true
@@ -56,6 +63,7 @@ libellous:
     It included confidential, libellous, false or defamatory information, or a reference to a case which is active in the UK courts.
 
 offensive:
+  created_at: "2015-07-20T10:00:08Z"
   code: "offensive"
   title: "Offensive, joke, nonsense or advert"
   hidden: true

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2051,10 +2051,10 @@ RSpec.describe Petition, type: :model do
           p1 = described_class.find(petition.id)
           p2 = described_class.find(petition.id)
 
-          expect(p1.rejection).not_to be_persisted
+          expect(p1.rejection).to be_nil
           expect(p1.association(:rejection)).to be_loaded
 
-          expect(p2.rejection).not_to be_persisted
+          expect(p2.rejection).to be_nil
           expect(p2.association(:rejection)).to be_loaded
 
           p1.reject(code: "duplicate")

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
       )
     end
 
+    it "doesn't include the rejection section for non-rejected petitions" do
+      petition = FactoryBot.create :archived_petition
+
+      get "/archived/petitions/#{petition.id}.json"
+      expect(response).to be_successful
+
+      expect(attributes).to match(
+        a_hash_including(
+          "rejected_at" => nil,
+          "rejection" => nil
+        )
+      )
+    end
+
     it "includes the rejection section for rejected petitions" do
       petition = \
         FactoryBot.create :archived_petition, :rejected,

--- a/spec/requests/archived_petitions_list_spec.rb
+++ b/spec/requests/archived_petitions_list_spec.rb
@@ -145,6 +145,24 @@ RSpec.describe "API request to list archived petitions", type: :request, show_ex
       )
     end
 
+    it "doesn't include the rejection section for non-rejected petitions" do
+      petition = FactoryBot.create :archived_petition
+
+      get "/archived/petitions.json"
+      expect(response).to be_successful
+
+      expect(data).to match(
+        a_collection_containing_exactly(
+          a_hash_including(
+            "attributes" => a_hash_including(
+              "rejected_at" => nil,
+              "rejection" => nil
+            )
+          )
+        )
+      )
+    end
+
     it "includes the rejection section for rejected petitions" do
       petition = \
         FactoryBot.create :archived_petition, :rejected,

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       )
     end
 
+    it "doesn't include the rejection section for non-rejected petitions" do
+      petition = FactoryBot.create :open_petition
+
+      get "/petitions/#{petition.id}.json"
+      expect(response).to be_successful
+
+      expect(attributes).to match(
+        a_hash_including(
+          "rejected_at" => nil,
+          "rejection" => nil
+        )
+      )
+    end
+
     it "includes the rejection section for rejected petitions" do
       petition = \
         FactoryBot.create :rejected_petition,

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -169,6 +169,24 @@ RSpec.describe "API request to list petitions", type: :request, show_exceptions:
       end
     end
 
+    it "doesn't include the rejection section for non-rejected petitions" do
+      petition = FactoryBot.create :open_petition
+
+      get "/petitions.json"
+      expect(response).to be_successful
+
+      expect(data).to match(
+        a_collection_containing_exactly(
+          a_hash_including(
+            "attributes" => a_hash_including(
+              "rejected_at" => nil,
+              "rejection" => nil
+            )
+          )
+        )
+      )
+    end
+
     it "includes the rejection section for rejected petitions" do
       petition = \
         FactoryBot.create :rejected_petition,


### PR DESCRIPTION
By implicitly creating a rejection in 525705ca3 we started outputting blank rejection objects in the JSON which is obviously a bad thing.