### PR TITLE
Add a dormant state for petitions

### DIFF
--- a/app/assets/stylesheets/petitions/admin/_list.scss
+++ b/app/assets/stylesheets/petitions/admin/_list.scss
@@ -26,6 +26,16 @@
     background-color: $mellow-red-25;
   }
 
+  .petition-list-petition-state-dormant {
+    td {
+      color: $grey-2;
+
+      a {
+        color: $grey-2;
+      }
+    }
+  }
+
   th:last-child, td:last-child {
     padding-right: 0;
   }

--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -4,7 +4,7 @@ class Admin::ModerationController < Admin::AdminController
   def update
     if @petition.moderate(moderation_params)
       send_notifications
-      redirect_to [:admin, @petition]
+      redirect_to [:admin, @petition], notice: :petition_updated
     else
       render 'admin/petitions/show'
     end

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -23,7 +23,7 @@ class SponsorsController < SignaturesController
   def retrieve_petition
     @petition = Petition.not_hidden.find(petition_id)
 
-    if @petition.flagged? || @petition.stopped?
+    if @petition.flagged? || @petition.dormant? || @petition.stopped?
       raise ActiveRecord::RecordNotFound, "Unable to find Petition with id: #{petition_id}"
     end
 
@@ -36,7 +36,7 @@ class SponsorsController < SignaturesController
     @signature = Signature.sponsors.find(signature_id)
     @petition = @signature.petition
 
-    if @petition.flagged? || @petition.hidden? || @petition.stopped?
+    if @petition.flagged? || @petition.dormant? || @petition.hidden? || @petition.stopped?
       raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
   end

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -10,10 +10,20 @@
       <%= f.radio_button :moderation, 'reject' %>
       <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>
     </div>
-    <% unless f.object.flagged? %>
+    <% if f.object.flagged? || f.object.dormant? %>
+      <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'restore' %>
+        <%= f.label :moderation_restore, "Restore", for: "petition_moderation_restore" %>
+      </div>
+    <% else %>
       <div class="multiple-choice">
         <%= f.radio_button :moderation, 'flag' %>
         <%= f.label :moderation_flag, "Flag", for: "petition_moderation_flag" %>
+      </div>
+
+      <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'dormant' %>
+        <%= f.label :moderation_dormant, "Dormant", for: "petition_moderation_dormant" %>
       </div>
     <% end %>
   <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,9 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = 'public, max-age=3600'
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+  }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -48,7 +48,8 @@ en-GB:
         petition:
           attributes:
             moderation:
-              blank: "You must choose to approve, reject or flag"
+              blank: "You must choose to approve, reject, flag or mark as dormant"
+              invalid: "You must choose to approve, reject or restore the petition to the sponsored state"
             creator_signature:
               blank: "%{attribute} must be completed"
             state:

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -110,5 +110,25 @@ Feature: Moderator respond to petition
     And the creator should not receive a notification email
     And the creator should not receive a rejection notification email
     But the petition will still show up in the back-end reporting
-    And the petition can no longer be flagged
-    And I go to the Admin home page
+    When I revisit the petition
+    Then the petition can no longer be flagged
+    And the petition can no longer be marked as dormant
+    But it can still be approved
+    And it can still be rejected
+    And it can be restored to a sponsored state
+
+  @javascript
+  Scenario: Moderator marks a petition as dormant
+    Given I am logged in as a moderator
+    When I look at the next petition on my list
+    And I mark the petition as dormant
+    Then the petition is not available for searching or viewing
+    And the creator should not receive a notification email
+    And the creator should not receive a rejection notification email
+    But the petition will still show up in the back-end reporting
+    When I revisit the petition
+    Then the petition can no longer be flagged
+    And the petition can no longer be marked as dormant
+    But it can still be approved
+    And it can still be rejected
+    And it can be restored to a sponsored state

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -42,6 +42,11 @@ When(/^I flag the petition$/) do
   click_button "Save without emailing"
 end
 
+When(/^I mark the petition as dormant$/) do
+  choose "Dormant"
+  click_button "Save without emailing"
+end
+
 Then /^the petition is still available for searching or viewing$/ do
   step %{I search for "Rejected petitions" with "#{@petition.action}"}
   step %{I should see the petition "#{@petition.action}"}
@@ -70,8 +75,30 @@ Then /^the petition should be visible on the site for signing$/ do
 end
 
 Then(/^the petition can no longer be flagged$/) do
+  expect(page).to have_no_field('Flag', visible: false)
+end
+
+Then(/^the petition can no longer be marked as dormant$/) do
+  expect(page).to have_no_field('Dormant', visible: false)
+end
+
+When(/^I revisit the petition$/) do
   visit admin_petition_url(@petition)
-  expect(page).to have_no_field('Flag')
+end
+
+Then(/^it can still be approved$/) do
+  expect(page).to have_field('Approve', visible: false)
+end
+
+Then(/^it can still be rejected$/) do
+  expect(page).to have_field('Reject', visible: false)
+end
+
+Then(/^it can be restored to a sponsored state$/) do
+  choose "Restore"
+  click_button "Save without emailing"
+  expect(page).to have_content("Petition has been successfully updated")
+  expect(page).to have_content("Status Sponsored")
 end
 
 Then(/^the creator should receive a notification email$/) do

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -14,7 +14,7 @@ When(/^I navigate to the next page of petitions$/) do
   click_link "Next"
 end
 
-Given(/^a(n)? ?(pending|validated|sponsored|flagged|open|rejected)? petition "([^"]*)"$/) do |a_or_an, state, petition_action|
+Given(/^a(n)? ?(pending|validated|sponsored|flagged|dormant|open|rejected)? petition "([^"]*)"$/) do |a_or_an, state, petition_action|
   petition_args = {
     :action => petition_action,
     :closed_at => 1.day.from_now,
@@ -448,7 +448,7 @@ Given(/^a petition "(.*?)" exists with notes "([^"]*)"$/) do |action, notes|
   @petition = FactoryBot.create(:open_petition, action: action, admin_notes: notes)
 end
 
-Given(/^an? ?(pending|validated|sponsored|flagged|open)? petition "(.*?)" exists with tags "([^"]*)"$/) do |state, action, tags|
+Given(/^an? ?(pending|validated|sponsored|flagged|dormant|open)? petition "(.*?)" exists with tags "([^"]*)"$/) do |state, action, tags|
   tags = tags.split(",").map(&:strip)
   state ||= "open"
   tag_ids = tags.map { |tag| Tag.find_or_create_by(name: tag).id }

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -246,6 +246,39 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
           expect(email).to be_nil
         end
       end
+
+      context "when moderation param is 'dormant'" do
+        let(:email) { ActionMailer::Base.deliveries.last }
+
+        before do
+          do_patch moderation: 'dormant'
+          petition.reload
+        end
+
+        it "marks the petition as dormant" do
+          expect(petition.state).to eq(Petition::DORMANT_STATE)
+        end
+
+        it "does not set the open date" do
+          expect(petition.open_at).to be_nil
+        end
+
+        it "does not set the rejected date" do
+          expect(petition.rejected_at).to be_nil
+        end
+
+        it "does not set the moderation lag" do
+          expect(petition.moderation_lag).to be_nil
+        end
+
+        it "redirects to the admin show page for the petition page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
+        end
+
+        it "does not send an email to the petition creator" do
+          expect(email).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -89,7 +89,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -187,7 +187,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -396,7 +396,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -530,7 +530,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
@@ -727,7 +727,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
@@ -903,7 +903,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
+    %w[pending validated sponsored flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[flagged hidden stopped].each do |state|
+    %w[flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -140,7 +140,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[flagged hidden stopped].each do |state|
+    %w[flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -266,7 +266,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[flagged hidden stopped].each do |state|
+    %w[flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -515,7 +515,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[flagged hidden stopped].each do |state|
+    %w[flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -635,7 +635,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[flagged hidden stopped].each do |state|
+    %w[flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
@@ -1032,7 +1032,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[flagged hidden stopped].each do |state|
+    %w[flagged dormant hidden stopped].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition, sponsor: true) }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -336,6 +336,10 @@ FactoryBot.define do
     state  Petition::FLAGGED_STATE
   end
 
+  factory :dormant_petition, :parent => :petition do
+    state  Petition::DORMANT_STATE
+  end
+
   factory :open_petition, :parent => :sponsored_petition do
     state  Petition::OPEN_STATE
     open_at { Time.current }

--- a/spec/models/dissolution_notification_spec.rb
+++ b/spec/models/dissolution_notification_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DissolutionNotification, type: :model do
       expect(subject.petitions).not_to include(petition)
     end
 
-    %w[pending validated sponsored flagged rejected hidden closed].each do |state|
+    %w[pending validated sponsored flagged dormant rejected hidden closed].each do |state|
       it "doesn't include #{state} petitions" do
         petition = FactoryBot.create(:"#{state}_petition")
         FactoryBot.create(:validated_signature, email: email, petition: petition)
@@ -114,7 +114,7 @@ RSpec.describe DissolutionNotification, type: :model do
       expect(subject.created_petitions).not_to include(petition)
     end
 
-    %w[pending validated sponsored flagged rejected hidden closed].each do |state|
+    %w[pending validated sponsored flagged dormant rejected hidden closed].each do |state|
       it "doesn't include #{state} petitions that I created" do
         petition = FactoryBot.create(:"#{state}_petition", creator_email: email)
 


### PR DESCRIPTION
Rather than have petitions sitting in the moderation queue, allow marking them as 'dormant' in a similar manner to 'flagged' with the exception that they don't appear in the queue. Also add the ability to move a petition back to the sponsored state from 'flagged' or 'dormant' states.