### PR TITLE
Autocorrect a select number of high-traffic domains

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -198,6 +198,6 @@ class SignaturesController < ApplicationController
   end
 
   def signature_attributes
-    %i[name email email_confirmation postcode location_code uk_citizenship notify_by_email]
+    %i[name email email_confirmation postcode location_code uk_citizenship notify_by_email autocorrect_domain]
   end
 end

--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -1,3 +1,4 @@
+require 'domain_autocorrect'
 require 'postcode_sanitizer'
 
 class PetitionCreator
@@ -107,6 +108,10 @@ class PetitionCreator
     petition_creator_params[:email].to_s.strip
   end
 
+  def email=(value)
+    petition_creator_params[:email] = value
+  end
+
   def postcode
     PostcodeSanitizer.call(petition_creator_params[:postcode])
   end
@@ -169,6 +174,10 @@ class PetitionCreator
   end
 
   def validate_creator
+    if stage == "creator"
+      self.email = DomainAutocorrect.call(email)
+    end
+
     errors.add(:name, :invalid) if name =~ /\A[-=+@]/
     errors.add(:name, :blank) unless name.present?
     errors.add(:name, :too_long, count: 255) if action.length > 255

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/digest/uuid'
+require 'domain_autocorrect'
 require 'postcode_sanitizer'
 require 'ipaddr'
 
@@ -46,6 +47,10 @@ class Signature < ActiveRecord::Base
   end
 
   attr_readonly :sponsor, :creator
+
+  before_validation if: :autocorrect_domain do
+    self.email = DomainAutocorrect.call(email)
+  end
 
   before_create if: :email? do
     self.uuid = generate_uuid
@@ -468,6 +473,11 @@ class Signature < ActiveRecord::Base
   end
 
   attr_accessor :uk_citizenship
+  attr_reader :autocorrect_domain
+
+  def autocorrect_domain=(value)
+    @autocorrect_domain = value.present?
+  end
 
   def find_duplicate
     begin

--- a/app/views/petitions/create/_creator_stage.html.erb
+++ b/app/views/petitions/create/_creator_stage.html.erb
@@ -3,6 +3,7 @@
 <%= form.hidden_field :action %>
 <%= form.hidden_field :background %>
 <%= form.hidden_field :additional_details %>
+<%= form.hidden_field :autocorrect_domain, value: "1" %>
 
 <h1 class="page-title">Sign your petition</h1>
 <h2 class="page-subtitle"><%= petition.action %></h2>

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -1,3 +1,5 @@
+<%= form.hidden_field :autocorrect_domain, value: "1" %>
+
 <%= form_row for: [signature, :uk_citizenship], class: "uk-citizen" do %>
   <span class="form-label">
     Only British citizens or UK residents have the right to sign

--- a/features/arnold_searches_from_home_page.feature
+++ b/features/arnold_searches_from_home_page.feature
@@ -1,4 +1,3 @@
-@search
 Feature: Arnold searches from the home page
   In order to reduce the likelihood of a duplicate petition being made
   As a petition moderator

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -2,7 +2,6 @@ Feature: As Charlie
   In order to have an issue discussed in parliament
   I want to be able to create a petition and verify my email address.
 
-@search
 Scenario: Charlie has to search for a petition before creating one
   Given the following petitions exist:
     | action                         | state    | signature_count | open_at    |
@@ -41,7 +40,6 @@ Scenario: Charlie starts to create a petition when parliament is dissolved
   When I am on the help page
   Then I should see the Parliament dissolved warning message
 
-@search
 Scenario: Charlie cannot craft an xss attack when searching for petitions
   Given I am on the home page
   When I follow "Start a petition" within ".//main"
@@ -158,3 +156,28 @@ Scenario: Charlie tries to submit an invalid petition
 
   Then a petition should exist with action: "The wombats of wimbledon rock.", state: "pending"
   Then there should be a "pending" signature with email "womboid@wimbledon.com" and name "Mr. Wibbledon"
+
+Scenario: Charlie creates a petition with a typo in his email
+  Given I start a new petition
+  And I fill in the petition details
+  And I press "Preview petition"
+  And I press "This looks good"
+  And I fill in my details with email "charlie@hotmial.com"
+  And I press "Continue"
+  Then my email is autocorrected to "charlie@hotmail.com"
+  When I press "Yes – this is my email address"
+  Then a petition should exist with action: "The wombats of wimbledon rock.", state: "pending"
+  And a signature should exist with email: "charlie@hotmail.com", state: "pending"
+
+Scenario: Charlie creates a petition when his email is autocorrected wrongly
+  Given I start a new petition
+  And I fill in the petition details
+  And I press "Preview petition"
+  And I press "This looks good"
+  And I fill in my details with email "charlie@hotmial.com"
+  And I press "Continue"
+  Then my email is autocorrected to "charlie@hotmail.com"
+  When I fill in "Email" with "charlie@hotmial.com"
+  And I press "Yes – this is my email address"
+  Then a petition should exist with action: "The wombats of wimbledon rock.", state: "pending"
+  And a signature should exist with email: "charlie@hotmial.com", state: "pending"

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -92,6 +92,10 @@ Then(/^I am asked to review my email address$/) do
   expect(page).to have_field('Email')
 end
 
+Then(/^my email is autocorrected to "([^"]+)"/) do |email|
+  expect(page).to have_field('Email', with: email)
+end
+
 When(/^I change my email address to "(.*?)"$/) do |email_address|
   fill_in 'Email', with: email_address
 end

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -1,4 +1,3 @@
-@search
 Feature: Suzy Singer searches by free text
   In order to find interesting petitions to sign for a particular area of government
   As Suzy the signer

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -75,7 +75,6 @@ Feature: Suzie signs a petition
   Scenario: Suzie receives a duplicate signature email if she changes to her original email but she has already signed and validated
     When I have already signed the petition with an uppercase email
     And I decide to sign the petition
-    And I fill in my details
     And I fill in my details with email "womboidian@wimbledon.com"
     And I try to sign
     When I change my email address to "womboid@wimbledon.com"
@@ -254,3 +253,28 @@ Feature: Suzie signs a petition
     Then I should be on the petition page
     And I should see "2 signatures"
     And the signature "womboid@wimbledon.com" is marked as validated
+
+  Scenario: Suzie signs a petition with a typo in her email
+    Given I am on the new signature page
+    When I fill in my details with email "suzie@gmial.com"
+    And I try to sign
+    Then my email is autocorrected to "suzie@gmail.com"
+    When I say I am happy with my email address
+    Then a signature should exist with email: "suzie@gmail.com", state: "pending"
+    And "suzie@gmail.com" should receive 1 email
+    When I confirm my email address
+    Then I should see "We've added your signature to the petition"
+    And a signature should exist with email: "suzie@gmail.com", state: "validated"
+
+  Scenario: Suzie signs a petition when her email is autocorrected wrongly
+    Given I am on the new signature page
+    When I fill in my details with email "suzie@gmial.com"
+    And I try to sign
+    Then my email is autocorrected to "suzie@gmail.com"
+    When I fill in "Email" with "suzie@gmial.com"
+    And I say I am happy with my email address
+    Then a signature should exist with email: "suzie@gmial.com", state: "pending"
+    And "suzie@gmial.com" should receive 1 email
+    When I confirm my email address
+    Then I should see "We've added your signature to the petition"
+    And a signature should exist with email: "suzie@gmial.com", state: "validated"

--- a/lib/domain_autocorrect.rb
+++ b/lib/domain_autocorrect.rb
@@ -1,0 +1,36 @@
+require 'active_support/core_ext/object/blank'
+
+class DomainAutocorrect
+  RULES = {
+    /\A([^@]+)@(a(?:i|o|p)l\.(?:com|con|co\.uk))\z/ => 'aol.com',
+    /\A([^@]+)@(b(?:r|t|y)?i?n(?:g|t|y)?e(?:r|t)?(?:m|n)e(?:r|t)\.(?:com|con|co\.uk|co))\z/ => 'btinternet.com',
+    /\A([^@]+)@((?:f|g)\.?(?:a|m|n)(?:a|i|m|n|s)(?:a|i|l|o|u)(?:i|k|l){0,2}\.(?:cim|clm|comm|com\.uk|com\.com|com|con|vom|cm|co\.uk|co|om|uk))\z/ => 'gmail.com',
+    /\A([^@]+)@(goog?le?m(?:a|i|s)(?:a|i)l\.(?:com|con|co\.uk))\z/ => 'googlemail.com',
+    /\A([^@]+)@(h(?:i|o)(?:r|t)?(?:m|n)(?:a|i|s)?(?:a|i|u)?(?:k|l){0,2}\.(?:cim|com|con|cm|co))\z/ => 'hotmail.com',
+    /\A([^@]+)@(h(?:i|o)(?:r|t)?(?:m|n)(?:a|i|s)?(?:a|i|u)?(?:k|l){0,2}\.?(?:com|con|co)?\.?(?:ik|uk|uj|ul|um|un|yk))\z/ => 'hotmail.co.uk',
+    /\A([^@]+)@(i?(?:c|v)l?oul?d\.(?:com|con|co\.uk))\z/ => 'icloud.com',
+    /\A([^@]+)@(live\.(?:com|con|co))\z/ => 'live.com',
+    /\A([^@]+)@(live\.co\.(?:ik|uk|um|un))\z/ => 'live.co.uk',
+    /\A([^@]+)@(mac\.(?:com|con))\z/ => 'mac.com',
+    /\A([^@]+)@(me\.(?:com|con))\z/ => 'me.com',
+    /\A([^@]+)@(msn\.(?:com|con))\z/ => 'msn.com',
+    /\A([^@]+)@(ntlworl?d\.(?:com|con))\z/ => 'ntlworld.com',
+    /\A([^@]+)@(out?l?(?:i|o)o+k\.co(?:m|n|\.uk))\z/ => 'outlook.com',
+    /\A([^@]+)@(sky\.co(?:m|n))\z/ => 'sky.com',
+    /\A([^@]+)@(talktalk\.(?:com|net))\z/ => 'talktalk.net',
+    /\A([^@]+)@((?:u|t|y)(?:a|s)?hoo?\.?(?:co)?n?\.?(?:i|u|y)(?:j|k|l|m|n))\z/ => 'yahoo.co.uk',
+    /\A([^@]+)@(yahoo\.co(?:m|n)?)\z/ => 'yahoo.com'
+  }
+
+  def self.call(email)
+    return email if email.blank?
+
+    RULES.each do |pattern, domain|
+      if data = pattern.match(email)
+        return "#{data[1]}@#{domain}"
+      end
+    end
+
+    email
+  end
+end

--- a/spec/lib/domain_autocorrect_spec.rb
+++ b/spec/lib/domain_autocorrect_spec.rb
@@ -1,0 +1,426 @@
+require 'spec_helper'
+require 'domain_autocorrect'
+
+RSpec.describe DomainAutocorrect do
+  describe ".call" do
+    it "returns nil if the argument is nil" do
+      expect(
+        described_class.call(nil)
+      ).to eq(nil)
+    end
+
+    it "returns '' if the argument is ''" do
+      expect(
+        described_class.call("")
+      ).to eq("")
+    end
+
+    context "with typos for the domain 'aol.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@aol.com")
+        ).to eq("bob.jones@aol.com")
+      end
+
+      %w[ail.com aol.co.uk aol.con apl.com].each do |domain|
+        it "autocorrects '#{domain}' to 'aol.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@aol.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'btinternet.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@btinternet.com")
+        ).to eq("bob.jones@btinternet.com")
+      end
+
+      %w[
+        binternet.com
+        brinternet.com
+        btinernet.com
+        btingernet.com
+        btintenet.com
+        btintermet.com
+        btinterner.com
+        btinternet.co
+        btinternet.co.uk
+        btinternet.con
+        btintetnet.com
+        btinyernet.com
+        btnternet.com
+        byinternet.com
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'btinternet.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@btinternet.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'gmail.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@gmail.com")
+        ).to eq("bob.jones@gmail.com")
+      end
+
+      %w[
+        gmail.com
+        fmail.com
+        g.mail.com
+        gail.com
+        gamail.com
+        gamil.com
+        gmai.com
+        gmaik.com
+        gmail.cim
+        gmail.clm
+        gmail.cm
+        gmail.co
+        gmail.co.uk
+        gmail.com.com
+        gmail.com.uk
+        gmail.comm
+        gmail.con
+        gmail.om
+        gmail.uk
+        gmail.vom
+        gmaill.com
+        gmal.com
+        gmaol.com
+        gmaul.com
+        gmial.com
+        gmil.com
+        gmsil.com
+        gnail.com
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'gmail.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@gmail.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'googlemail.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@googlemail.com")
+        ).to eq("bob.jones@googlemail.com")
+      end
+
+      %w[
+        googlemail.co.uk
+        googlemail.con
+        googlemial.com
+        googlemsil.com
+        googlmail.com
+        goolemail.com
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'googlemail.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@googlemail.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'hotmail.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@hotmail.com")
+        ).to eq("bob.jones@hotmail.com")
+      end
+
+      %w[
+        hitmail.com
+        homail.com
+        hormail.com
+        hotmai.com
+        hotmail.cim
+        hotmail.cm
+        hotmail.co
+        hotmail.con
+        hotmaill.com
+        hotmal.com
+        hotmil.com
+        hotmial.com
+        hotmsil.com
+        hotnail.com
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'hotmail.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@hotmail.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'hotmail.co.uk'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@hotmail.co.uk")
+        ).to eq("bob.jones@hotmail.co.uk")
+      end
+
+      %w[
+        hitmail.co.uk
+        homail.co.uk
+        hormail.co.uk
+        hotmai.co.uk
+        hotmaik.co.uk
+        hotmail.co.ik
+        hotmail.co.uj
+        hotmail.co.ul
+        hotmail.co.um
+        hotmail.co.un
+        hotmail.co.yk
+        hotmail.com.uk
+        hotmail.conuk
+        hotmail.couk
+        hotmail.uk
+        hotmailco.uk
+        hotmal.co.uk
+        hotmaul.co.uk
+        hotmil.co.uk
+        hotmial.co.uk
+        hotmsil.co.uk
+        hotnail.co.uk
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'hotmail.co.uk'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@hotmail.co.uk")
+        end
+      end
+    end
+
+    context "with typos for the domain 'icloud.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@icloud.com")
+        ).to eq("bob.jones@icloud.com")
+      end
+
+      %w[
+        cloud.com
+        icloud.co.uk
+        icloud.con
+        icoud.com
+        icould.com
+        ivloud.com
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'icloud.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@icloud.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'live.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@live.com")
+        ).to eq("bob.jones@live.com")
+      end
+
+      %w[live.co live.con].each do |domain|
+        it "autocorrects '#{domain}' to 'live.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@live.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'live.co.uk'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@live.co.uk")
+        ).to eq("bob.jones@live.co.uk")
+      end
+
+      %w[live.co.ik live.co.um live.co.un].each do |domain|
+        it "autocorrects '#{domain}' to 'live.co.uk'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@live.co.uk")
+        end
+      end
+    end
+
+    context "with typos for the domain 'mac.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@mac.com")
+        ).to eq("bob.jones@mac.com")
+      end
+
+      %w[mac.con].each do |domain|
+        it "autocorrects '#{domain}' to 'mac.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@mac.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'me.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@me.com")
+        ).to eq("bob.jones@me.com")
+      end
+
+      %w[me.con].each do |domain|
+        it "autocorrects '#{domain}' to 'me.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@me.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'msn.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@msn.com")
+        ).to eq("bob.jones@msn.com")
+      end
+
+      %w[msn.con].each do |domain|
+        it "autocorrects '#{domain}' to 'msn.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@msn.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'ntlworld.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@ntlworld.com")
+        ).to eq("bob.jones@ntlworld.com")
+      end
+
+      %w[ntlword.com ntlworld.con].each do |domain|
+        it "autocorrects '#{domain}' to 'ntlworld.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@ntlworld.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'outlook.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@outlook.com")
+        ).to eq("bob.jones@outlook.com")
+      end
+
+      %w[
+        oulook.com
+        outliok.com
+        outlook.co.uk
+        outlook.con
+        outloook.com
+        outook.com
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'outlook.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@outlook.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'sky.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@sky.com")
+        ).to eq("bob.jones@sky.com")
+      end
+
+      %w[sky.con].each do |domain|
+        it "autocorrects '#{domain}' to 'sky.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@sky.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'talktalk.net'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@talktalk.net")
+        ).to eq("bob.jones@talktalk.net")
+      end
+
+      %w[talktalk.com].each do |domain|
+        it "autocorrects '#{domain}' to 'talktalk.net'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@talktalk.net")
+        end
+      end
+    end
+
+    context "with typos for the domain 'yahoo.com'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@yahoo.com")
+        ).to eq("bob.jones@yahoo.com")
+      end
+
+      %w[yahoo.co yahoo.con].each do |domain|
+        it "autocorrects '#{domain}' to 'yahoo.com'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@yahoo.com")
+        end
+      end
+    end
+
+    context "with typos for the domain 'yahoo.co.uk'" do
+      it "doesn't change a correct email address" do
+        expect(
+          described_class.call("bob.jones@yahoo.co.uk")
+        ).to eq("bob.jones@yahoo.co.uk")
+      end
+
+      %w[
+        yahoo.co.uk
+        tahoo.co.uk
+        uahoo.co.uk
+        yaho.co.uk
+        yahoo.co.ik
+        yahoo.co.uj
+        yahoo.co.ul
+        yahoo.co.um
+        yahoo.co.un
+        yahoo.co.yk
+        yahoo.conuk
+        yahoo.couk
+        yahoo.uk
+        yahooco.uk
+        yhoo.co.uk
+        yshoo.co.uk
+      ].each do |domain|
+        it "autocorrects '#{domain}' to 'yahoo.co.uk'" do
+          expect(
+            described_class.call("bob.jones@#{domain}")
+          ).to eq("bob.jones@yahoo.co.uk")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initially looked at using a Levenshtein algorithm to calculate edit distance and autocorrect based on that but there are too many false positives even when capping the edit distance to a maximum of 1.

Instead, we analysed a corpus of emails to find the most common errors for our highest-traffic domains and then generated regular expressions to correct those errors. We only autocorrect on the first submission of the email which presents the user a chance to correct any false positives when we replay their email back to them.