### PR TITLE
Add the ability to pause signature collection

### DIFF
--- a/app/assets/stylesheets/petitions/_forms.scss
+++ b/app/assets/stylesheets/petitions/_forms.scss
@@ -21,6 +21,10 @@ select.form-control {
   width: 25%;
 }
 
+.form-control-1-2 {
+  width: 50%;
+}
+
 .form-control-auto {
   width: auto;
 }

--- a/app/assets/stylesheets/petitions/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/views/_shared.scss
@@ -89,17 +89,21 @@ input.back-page {
     left: $gutter-half;
   }
 
-  .header {
+  h3, .header {
     margin-top: 0px;
     @include bold-24();
   }
 
-  .content {
+  p {
     margin-top: 0px;
+    @include core-19();
+  }
+
+  p.content {
     @include bold-19();
   }
 
-  .link {
+  p.link {
     @include core-16();
   }
 

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -34,7 +34,10 @@ class Admin::SitesController < Admin::AdminController
       :signature_count_interval, :update_signature_counts,
       :disable_trending_petitions, :threshold_for_moderation_delay,
       :disable_invalid_signature_count_check, :disable_daily_update_statistics_job,
-      :disable_plus_address_check, :disable_feedback_sending
+      :disable_plus_address_check, :disable_feedback_sending,
+      :show_home_page_message, :home_page_message,
+      :show_petition_page_message, :petition_page_message,
+      :disable_collecting_signatures
     )
   end
 end

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -164,13 +164,13 @@ class SignaturesController < ApplicationController
   end
 
   def redirect_to_petition_page_if_closed
-    if @petition.closed?
+    if @petition.closed? || Site.signature_collection_disabled?
       redirect_to petition_url(@petition), notice: "Sorry, you can't sign petitions that have been closed"
     end
   end
 
   def redirect_to_petition_page_if_closed_for_signing
-    if @petition.closed_for_signing?
+    if @petition.closed_for_signing? || Site.signature_collection_disabled?
       redirect_to petition_url(@petition), notice: "Sorry, you can't sign petitions that have been closed"
     end
   end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,9 +1,13 @@
 module FormHelper
-  def form_row opts={}, &block
-    css_classes = ['form-group']
-    css_classes.push opts[:class] if opts[:class]
-    css_classes.push 'error' if opts[:for] && opts[:for][0].errors[opts[:for][1]].any?
-    content_tag :div, capture(&block), :class => css_classes.join(' ')
+  def form_row(options, &block)
+    classes = %w[form-group]
+    classes.push options.delete(:class) if options.key?(:class)
+
+    object, field = options.delete(:for)
+    classes.push 'error' if object && object.errors[field].any?
+
+    options[:class] = classes.join(' ')
+    content_tag(:div, capture(&block), options)
   end
 
   def countries_for_select

--- a/app/jobs/extend_petition_deadlines_job.rb
+++ b/app/jobs/extend_petition_deadlines_job.rb
@@ -1,0 +1,17 @@
+class ExtendPetitionDeadlinesJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform
+    if Site.signature_collection_disabled?
+      open_petitions.find_each do |petition|
+        petition.extend_deadline!
+      end
+    end
+  end
+
+  private
+
+  def open_petitions
+    Petition.open_state
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -16,6 +16,7 @@ class Site < ActiveRecord::Base
     disable_daily_update_statistics_job
     disable_plus_address_check
     disable_feedback_sending
+    disable_collecting_signatures
   ]
 
   class << self
@@ -114,7 +115,29 @@ class Site < ActiveRecord::Base
     end
 
     def touch(*names)
-      instance.touch(*names)
+      if instance.persisted?
+        instance.touch(*names)
+      end
+    end
+
+    def signature_collection_disabled?
+      disable_collecting_signatures?
+    end
+
+    def home_page_message
+      instance.home_page_message
+    end
+
+    def petition_page_message
+      instance.petition_page_message
+    end
+
+    def show_home_page_message?
+      instance.show_home_page_message?
+    end
+
+    def show_petition_page_message?
+      instance.show_petition_page_message?
     end
 
     def disable_signature_counts!
@@ -315,7 +338,28 @@ class Site < ActiveRecord::Base
     end
   end
 
+  store_accessor :feature_flags, :home_page_message
+  store_accessor :feature_flags, :show_home_page_message
+  store_accessor :feature_flags, :petition_page_message
+  store_accessor :feature_flags, :show_petition_page_message
+
   attr_reader :password
+
+  def show_home_page_message?
+    disable_collecting_signatures || show_home_page_message
+  end
+
+  def show_home_page_message=(value)
+    super(type_cast_feature_flag(value))
+  end
+
+  def show_petition_page_message?
+    disable_collecting_signatures || show_petition_page_message
+  end
+
+  def show_petition_page_message=(value)
+    super(type_cast_feature_flag(value))
+  end
 
   def authenticate(username, password)
     self.username == username && self.password_digest == password
@@ -426,6 +470,10 @@ class Site < ActiveRecord::Base
   validates :username, presence: true, length: { maximum: 30 }, if: :protected?
   validates :password, length: { maximum: 30 }, confirmation: true, if: :protected?
   validates :login_timeout, presence: true, numericality: { only_integer: true }
+  validates :home_page_message, presence: true, if: -> { disable_collecting_signatures || show_home_page_message? }
+  validates :home_page_message, length: { maximum: 800 }
+  validates :petition_page_message, presence: true, if: -> { disable_collecting_signatures || show_petition_page_message? }
+  validates :petition_page_message, length: { maximum: 800 }
 
   validate if: :protected? do
     errors.add(:password, :blank) unless password_digest?

--- a/app/views/admin/sites/_access.html.erb
+++ b/app/views/admin/sites/_access.html.erb
@@ -1,50 +1,55 @@
 <%= hidden_field_tag :tab, "access" %>
 
-<%= form_row for: [form.object, :enabled], class: "inline" do %>
-  <%= form.label :enabled, "Disable public website?", class: "form-label" %>
-  <%= error_messages_for_field @site, :enabled %>
-  <div class="multiple-choice">
-    <%= form.radio_button :enabled, false %>
-    <%= form.label :enabled, "Yes", for: "site_enabled_false" %>
-  </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :enabled, true %>
-    <%= form.label :enabled, "No", for: "site_enabled_true" %>
-  </div>
-<% end %>
+<div class="grid-row">
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :enabled], class: "inline" do %>
+      <%= form.label :enabled, "Disable public website?", class: "form-label" %>
+      <%= error_messages_for_field @site, :enabled %>
+      <div class="multiple-choice">
+        <%= form.radio_button :enabled, false %>
+        <%= form.label :enabled, "Yes", for: "site_enabled_false" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :enabled, true %>
+        <%= form.label :enabled, "No", for: "site_enabled_true" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :protected], class: "inline" do %>
-  <%= form.label :protected, "Password protect public website?", class: "form-label" %>
-  <%= error_messages_for_field @site, :protected %>
-  <div class="multiple-choice">
-    <%= form.radio_button :protected, true %>
-    <%= form.label :protected, "Yes", for: "site_protected_true" %>
-  </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :protected, false %>
-    <%= form.label :protected, "No", for: "site_protected_false" %>
-  </div>
-<% end %>
+    <%= form_row for: [form.object, :protected], class: "inline" do %>
+      <%= form.label :protected, "Password protect public website?", class: "form-label" %>
+      <%= error_messages_for_field @site, :protected %>
+      <div class="multiple-choice">
+        <%= form.radio_button :protected, true %>
+        <%= form.label :protected, "Yes", for: "site_protected_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :protected, false %>
+        <%= form.label :protected, "No", for: "site_protected_false" %>
+      </div>
+    <% end %>
 
-<div id="protected-fields">
-  <%= form_row for: [form.object, :username] do %>
-    <%= form.label :username, class: "form-label" %>
-    <%= error_messages_for_field @site, :username %>
-    <%= form.text_field :username, tabindex: increment, maxlength: 50, class: "form-control" %>
-  <% end %>
+    <div id="protected-fields">
+      <%= form_row for: [form.object, :username] do %>
+        <%= form.label :username, class: "form-label" %>
+        <%= error_messages_for_field @site, :username %>
+        <%= form.text_field :username, tabindex: increment, maxlength: 50, class: "form-control" %>
+      <% end %>
 
-  <%= form_row for: [form.object, :password] do %>
-    <%= form.label :password, class: "form-label" %>
-    <%= error_messages_for_field @site, :password %>
-    <%= form.password_field :password, tabindex: increment, maxlength: 50, class: "form-control" %>
-  <% end %>
+      <%= form_row for: [form.object, :password] do %>
+        <%= form.label :password, class: "form-label" %>
+        <%= error_messages_for_field @site, :password %>
+        <%= form.password_field :password, tabindex: increment, maxlength: 50, class: "form-control" %>
+      <% end %>
+    </div>
+  </div>
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :login_timeout] do %>
+      <%= form.label :login_timeout, "Login timeout for moderation users", class: "form-label" %>
+      <%= error_messages_for_field @site, :login_timeout %>
+      <%= form.text_field :login_timeout, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %> <span class="suffix">seconds</span>
+    <% end %>
+  </div>
 </div>
-
-<%= form_row for: [form.object, :login_timeout] do %>
-  <%= form.label :login_timeout, "Login timeout for moderation users", class: "form-label" %>
-  <%= error_messages_for_field @site, :login_timeout %>
-  <%= form.text_field :login_timeout, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %> <span class="suffix">seconds</span>
-<% end %>
 
 <%= javascript_tag do %>
   $().ready(function() {

--- a/app/views/admin/sites/_description.html.erb
+++ b/app/views/admin/sites/_description.html.erb
@@ -1,42 +1,47 @@
-<%= form_row for: [form.object, :title] do %>
-  <%= form.label :title, class: "form-label" %>
-  <%= error_messages_for_field @site, :title %>
-  <%= form.text_field :title, tabindex: increment, maxlength: 50, class: "form-control" %>
-<% end %>
+<div class="grid-row">
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :title] do %>
+      <%= form.label :title, class: "form-label" %>
+      <%= error_messages_for_field @site, :title %>
+      <%= form.text_field :title, tabindex: increment, maxlength: 50, class: "form-control" %>
+    <% end %>
 
-<%= form_row for: [form.object, :url] do %>
-  <%= form.label :url, "URL for public website", class: "form-label" %>
-  <%= error_messages_for_field @site, :url %>
-  <%= form.text_field :url, tabindex: increment, maxlength: 50, class: "form-control" %>
-<% end %>
+    <%= form_row for: [form.object, :url] do %>
+      <%= form.label :url, "URL for public website", class: "form-label" %>
+      <%= error_messages_for_field @site, :url %>
+      <%= form.text_field :url, tabindex: increment, maxlength: 50, class: "form-control" %>
+    <% end %>
 
-<%= form_row for: [form.object, :moderate_url] do %>
-  <%= form.label :moderate_url, "URL for moderation website", class: "form-label" %>
-  <%= error_messages_for_field @site, :moderate_url %>
-  <%= form.text_field :moderate_url, tabindex: increment, maxlength: 50, class: "form-control" %>
-<% end %>
-
-<%= form_row for: [form.object, :email_from] do %>
-  <%= form.label :email_from, "From address for emails", class: "form-label" %>
-  <%= error_messages_for_field @site, :email_from %>
-  <%= form.text_field :email_from, tabindex: increment, maxlength: 100, class: "form-control" %>
-<% end %>
-
-<%= form_row for: [form.object, :feedback_email] do %>
-  <%= form.label :feedback_email, "Email address for feedback messages", class: "form-label" %>
-  <%= error_messages_for_field @site, :feedback_email %>
-  <%= form.text_field :feedback_email, tabindex: increment, maxlength: 100, class: "form-control" %>
-<% end %>
-
-<%= form_row for: [form.object, :disable_feedback_sending], class: "inline" do %>
-  <%= form.label :disable_feedback_sending, "Disable sending of feedback messages?", class: "form-label" %>
-  <%= error_messages_for_field @site, :disable_feedback_sending %>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_feedback_sending, true %>
-    <%= form.label :disable_feedback_sending, "Yes", for: "site_disable_feedback_sending_true" %>
+    <%= form_row for: [form.object, :moderate_url] do %>
+      <%= form.label :moderate_url, "URL for moderation website", class: "form-label" %>
+      <%= error_messages_for_field @site, :moderate_url %>
+      <%= form.text_field :moderate_url, tabindex: increment, maxlength: 50, class: "form-control" %>
+    <% end %>
   </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_feedback_sending, false %>
-    <%= form.label :disable_feedback_sending, "No", for: "site_disable_feedback_sending_false" %>
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :email_from] do %>
+      <%= form.label :email_from, "From address for emails", class: "form-label" %>
+      <%= error_messages_for_field @site, :email_from %>
+      <%= form.text_field :email_from, tabindex: increment, maxlength: 100, class: "form-control" %>
+    <% end %>
+
+    <%= form_row for: [form.object, :feedback_email] do %>
+      <%= form.label :feedback_email, "Email address for feedback messages", class: "form-label" %>
+      <%= error_messages_for_field @site, :feedback_email %>
+      <%= form.text_field :feedback_email, tabindex: increment, maxlength: 100, class: "form-control form-control" %>
+    <% end %>
+
+    <%= form_row for: [form.object, :disable_feedback_sending], class: "inline" do %>
+      <%= form.label :disable_feedback_sending, "Disable sending of feedback messages?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_feedback_sending %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_feedback_sending, true %>
+        <%= form.label :disable_feedback_sending, "Yes", for: "site_disable_feedback_sending_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_feedback_sending, false %>
+        <%= form.label :disable_feedback_sending, "No", for: "site_disable_feedback_sending_false" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/admin/sites/_features.html.erb
+++ b/app/views/admin/sites/_features.html.erb
@@ -1,86 +1,91 @@
 <%= hidden_field_tag :tab, "features" %>
 <%= hidden_field_tag :"site[features]", "" %>
 
-<%= form_row for: [form.object, :disable_plus_address_check], class: "inline" do %>
-  <%= form.label :disable_plus_address_check, "Disable check for plus email addressing?", class: "form-label" %>
-  <%= error_messages_for_field @site, :disable_plus_address_check %>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_plus_address_check, true %>
-    <%= form.label :disable_plus_address_check, "Yes", for: "site_disable_plus_address_check_true" %>
-  </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_plus_address_check, false %>
-    <%= form.label :disable_plus_address_check, "No", for: "site_disable_plus_address_check_false" %>
-  </div>
-<% end %>
+<div class="grid-row">
+  <div class="column-half">
+    <%= form_row for: [form.object, :disable_daily_update_statistics_job], class: "inline" do %>
+      <%= form.label :disable_daily_update_statistics_job, "Disable updating of petition statistics?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_daily_update_statistics_job %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_daily_update_statistics_job, true %>
+        <%= form.label :disable_daily_update_statistics_job, "Yes", for: "site_disable_daily_update_statistics_job_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_daily_update_statistics_job, false %>
+        <%= form.label :disable_daily_update_statistics_job, "No", for: "site_disable_daily_update_statistics_job_false" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :disable_constituency_api], class: "inline" do %>
-  <%= form.label :disable_constituency_api, "Disable fetching of constituency by postcode?", class: "form-label" %>
-  <%= error_messages_for_field @site, :disable_constituency_api %>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_constituency_api, true %>
-    <%= form.label :disable_constituency_api, "Yes", for: "site_disable_constituency_api_true" %>
-  </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_constituency_api, false %>
-    <%= form.label :disable_constituency_api, "No", for: "site_disable_constituency_api_false" %>
-  </div>
-<% end %>
+    <%= form_row for: [form.object, :disable_invalid_signature_count_check], class: "inline" do %>
+      <%= form.label :disable_invalid_signature_count_check, "Disable overnight check on invalid signature counts?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_invalid_signature_count_check %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_invalid_signature_count_check, true %>
+        <%= form.label :disable_invalid_signature_count_check, "Yes", for: "site_disable_invalid_signature_count_check_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_invalid_signature_count_check, false %>
+        <%= form.label :disable_invalid_signature_count_check, "No", for: "site_disable_invalid_signature_count_check_false" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :disable_trending_petitions], class: "inline" do %>
-  <%= form.label :disable_trending_petitions, "Disable trending petitions on the home page?", class: "form-label" %>
-  <%= error_messages_for_field @site, :disable_trending_petitions %>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_trending_petitions, true %>
-    <%= form.label :disable_trending_petitions, "Yes", for: "site_disable_constituency_api_true" %>
-  </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_trending_petitions, false %>
-    <%= form.label :disable_trending_petitions, "No", for: "site_disable_constituency_api_false" %>
-  </div>
-<% end %>
+    <%= form_row for: [form.object, :update_signature_counts], class: "inline" do %>
+      <%= form.label :update_signature_counts, "Disable automatic signature count updates?", class: "form-label" %>
+      <%= error_messages_for_field @site, :update_signature_counts %>
+      <div class="multiple-choice">
+        <%= form.radio_button :update_signature_counts, false %>
+        <%= form.label :update_signature_counts, "Yes", for: "site_update_signature_counts_false" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :update_signature_counts, true %>
+        <%= form.label :update_signature_counts, "No", for: "site_update_signature_counts_true" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :disable_daily_update_statistics_job], class: "inline" do %>
-  <%= form.label :disable_daily_update_statistics_job, "Disable updating of petition statistics?", class: "form-label" %>
-  <%= error_messages_for_field @site, :disable_daily_update_statistics_job %>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_daily_update_statistics_job, true %>
-    <%= form.label :disable_daily_update_statistics_job, "Yes", for: "site_disable_daily_update_statistics_job_true" %>
+    <%= form_row for: [form.object, :signature_count_interval] do %>
+      <%= form.label :signature_count_interval, "Signature count update interval", class: "form-label" %>
+      <%= error_messages_for_field @site, :signature_count_interval %>
+      <%= form.select :signature_count_interval, signature_count_interval_menu, {}, class: "form-control form-control-1-2" %>
+    <% end %>
   </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_daily_update_statistics_job, false %>
-    <%= form.label :disable_daily_update_statistics_job, "No", for: "site_disable_daily_update_statistics_job_false" %>
-  </div>
-<% end %>
+  <div class="column-half">
+    <%= form_row for: [form.object, :disable_trending_petitions], class: "inline" do %>
+      <%= form.label :disable_trending_petitions, "Disable trending petitions on the home page?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_trending_petitions %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_trending_petitions, true %>
+        <%= form.label :disable_trending_petitions, "Yes", for: "site_disable_constituency_api_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_trending_petitions, false %>
+        <%= form.label :disable_trending_petitions, "No", for: "site_disable_constituency_api_false" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :disable_invalid_signature_count_check], class: "inline" do %>
-  <%= form.label :disable_invalid_signature_count_check, "Disable overnight check on invalid signature counts?", class: "form-label" %>
-  <%= error_messages_for_field @site, :disable_invalid_signature_count_check %>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_invalid_signature_count_check, true %>
-    <%= form.label :disable_invalid_signature_count_check, "Yes", for: "site_disable_invalid_signature_count_check_true" %>
-  </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :disable_invalid_signature_count_check, false %>
-    <%= form.label :disable_invalid_signature_count_check, "No", for: "site_disable_invalid_signature_count_check_false" %>
-  </div>
-<% end %>
+    <%= form_row for: [form.object, :disable_plus_address_check], class: "inline" do %>
+      <%= form.label :disable_plus_address_check, "Disable check for plus email addressing?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_plus_address_check %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_plus_address_check, true %>
+        <%= form.label :disable_plus_address_check, "Yes", for: "site_disable_plus_address_check_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_plus_address_check, false %>
+        <%= form.label :disable_plus_address_check, "No", for: "site_disable_plus_address_check_false" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :update_signature_counts], class: "inline" do %>
-  <%= form.label :update_signature_counts, "Disable automatic signature count updates?", class: "form-label" %>
-  <%= error_messages_for_field @site, :update_signature_counts %>
-  <div class="multiple-choice">
-    <%= form.radio_button :update_signature_counts, false %>
-    <%= form.label :update_signature_counts, "Yes", for: "site_update_signature_counts_false" %>
+    <%= form_row for: [form.object, :disable_constituency_api], class: "inline" do %>
+      <%= form.label :disable_constituency_api, "Disable fetching of constituency by postcode?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_constituency_api %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_constituency_api, true %>
+        <%= form.label :disable_constituency_api, "Yes", for: "site_disable_constituency_api_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_constituency_api, false %>
+        <%= form.label :disable_constituency_api, "No", for: "site_disable_constituency_api_false" %>
+      </div>
+    <% end %>
   </div>
-  <div class="multiple-choice">
-    <%= form.radio_button :update_signature_counts, true %>
-    <%= form.label :update_signature_counts, "No", for: "site_update_signature_counts_true" %>
-  </div>
-<% end %>
-
-<%= form_row for: [form.object, :signature_count_interval] do %>
-  <%= form.label :signature_count_interval, "Signature count update interval", class: "form-label" %>
-  <%= error_messages_for_field @site, :signature_count_interval %>
-  <%= form.select :signature_count_interval, signature_count_interval_menu, {}, class: "form-control form-control-1-4" %>
-<% end %>
+</div>

--- a/app/views/admin/sites/_moderation.html.erb
+++ b/app/views/admin/sites/_moderation.html.erb
@@ -1,25 +1,30 @@
 <%= hidden_field_tag :tab, "moderation" %>
 
-<%= form_row for: [form.object, :threshold_for_moderation] do %>
-  <%= form.label :threshold_for_moderation, "Threshold for moderation", class: "form-label" %>
-  <%= error_messages_for_field @site, :threshold_for_moderation %>
-  <%= form.text_field :threshold_for_moderation, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
-<% end %>
+<div class="grid-row">
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :threshold_for_moderation] do %>
+      <%= form.label :threshold_for_moderation, "Threshold for moderation", class: "form-label" %>
+      <%= error_messages_for_field @site, :threshold_for_moderation %>
+      <%= form.text_field :threshold_for_moderation, tabindex: increment, maxlength: 10, class: "form-control form-control-1-2" %>
+    <% end %>
 
-<%= form_row for: [form.object, :threshold_for_moderation_delay] do %>
-  <%= form.label :threshold_for_moderation_delay, "Threshold for moderation delay", class: "form-label" %>
-  <%= error_messages_for_field @site, :threshold_for_moderation_delay %>
-  <%= form.text_field :threshold_for_moderation_delay, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
-<% end %>
+    <%= form_row for: [form.object, :threshold_for_moderation_delay] do %>
+      <%= form.label :threshold_for_moderation_delay, "Threshold for moderation delay", class: "form-label" %>
+      <%= error_messages_for_field @site, :threshold_for_moderation_delay %>
+      <%= form.text_field :threshold_for_moderation_delay, tabindex: increment, maxlength: 10, class: "form-control form-control-1-2" %>
+    <% end %>
+  </div>
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :minimum_number_of_sponsors] do %>
+      <%= form.label :minimum_number_of_sponsors, class: "form-label" %>
+      <%= error_messages_for_field @site, :minimum_number_of_sponsors %>
+      <%= form.text_field :minimum_number_of_sponsors, tabindex: increment, maxlength: 10, class: "form-control form-control-1-2" %>
+    <% end %>
 
-<%= form_row for: [form.object, :minimum_number_of_sponsors] do %>
-  <%= form.label :minimum_number_of_sponsors, class: "form-label" %>
-  <%= error_messages_for_field @site, :minimum_number_of_sponsors %>
-  <%= form.text_field :minimum_number_of_sponsors, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
-<% end %>
-
-<%= form_row for: [form.object, :maximum_number_of_sponsors] do %>
-  <%= form.label :maximum_number_of_sponsors, class: "form-label" %>
-  <%= error_messages_for_field @site, :maximum_number_of_sponsors %>
-  <%= form.text_field :maximum_number_of_sponsors, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
-<% end %>
+    <%= form_row for: [form.object, :maximum_number_of_sponsors] do %>
+      <%= form.label :maximum_number_of_sponsors, class: "form-label" %>
+      <%= error_messages_for_field @site, :maximum_number_of_sponsors %>
+      <%= form.text_field :maximum_number_of_sponsors, tabindex: increment, maxlength: 10, class: "form-control form-control-1-2" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/sites/_petitions.html.erb
+++ b/app/views/admin/sites/_petitions.html.erb
@@ -1,19 +1,136 @@
 <%= hidden_field_tag :tab, "petitions" %>
 
-<%= form_row for: [form.object, :petition_duration] do %>
-  <%= form.label :petition_duration, "Duration", class: "form-label" %>
-  <%= error_messages_for_field @site, :petition_duration %>
-  <%= form.text_field :petition_duration, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %> <span class="suffix">months</span>
-<% end %>
+<div class="grid-row">
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :disable_collecting_signatures], class: "inline" do %>
+      <%= form.label :disable_collecting_signatures, "Pause all petitions?", class: "form-label" %>
+      <%= error_messages_for_field @site, :disable_collecting_signatures %>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_collecting_signatures, true %>
+        <%= form.label :disable_collecting_signatures, "Yes", for: "site_disable_collecting_signatures_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :disable_collecting_signatures, false %>
+        <%= form.label :disable_collecting_signatures, "No", for: "site_disable_collecting_signatures_false" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :threshold_for_response] do %>
-  <%= form.label :threshold_for_response, "Threshold for government response", class: "form-label" %>
-  <%= error_messages_for_field @site, :threshold_for_response %>
-  <%= form.text_field :threshold_for_response, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
-<% end %>
+    <%= form_row for: [form.object, :show_home_page_message], class: "inline message-control" do %>
+      <%= form.label :show_home_page_message, "Show message on the home page?", class: "form-label" %>
+      <%= error_messages_for_field @site, :show_home_page_message %>
+      <div class="multiple-choice">
+        <%= form.radio_button :show_home_page_message, true %>
+        <%= form.label :show_home_page_message, "Show", for: "site_show_home_page_message_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :show_home_page_message, false %>
+        <%= form.label :show_home_page_message, "Hide", for: "site_show_home_page_message_false" %>
+      </div>
+    <% end %>
 
-<%= form_row for: [form.object, :threshold_for_debate] do %>
-  <%= form.label :threshold_for_debate, "Threshold for consideration for a debate", class: "form-label" %>
-  <%= error_messages_for_field @site, :threshold_for_debate %>
-  <%= form.text_field :threshold_for_debate, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
-<% end %>
+    <%= form_row for: [form.object, :home_page_message], id: "home-page-message", class: "message-field", style: "display: none;" do %>
+      <%= form.label :home_page_message, "Message for the home page", class: "form-label message-label", style: "display: none;" %>
+      <%= error_messages_for_field @site, :home_page_message %>
+      <%= form.text_area :home_page_message, tabindex: increment, rows: 7, class: 'form-control' %>
+    <% end %>
+
+    <%= form_row for: [form.object, :show_petition_page_message], class: "inline message-control" do %>
+      <%= form.label :show_petition_page_message, "Show message on the petition page?", class: "form-label" %>
+      <%= error_messages_for_field @site, :show_petition_page_message %>
+      <div class="multiple-choice">
+        <%= form.radio_button :show_petition_page_message, true %>
+        <%= form.label :show_petition_page_message, "Show", for: "site_show_petition_page_message_true" %>
+      </div>
+      <div class="multiple-choice">
+        <%= form.radio_button :show_petition_page_message, false %>
+        <%= form.label :show_petition_page_message, "Hide", for: "site_show_petition_page_message_false" %>
+      </div>
+    <% end %>
+
+    <%= form_row for: [form.object, :petition_page_message], id: "petition-page-message", class: "message-field", style: "display: none;" do %>
+      <%= form.label :petition_page_message, "Message for the petition page", class: "form-label message-label", style: "display: none;" %>
+      <%= error_messages_for_field @site, :petition_page_message %>
+      <%= form.text_area :petition_page_message, tabindex: increment, rows: 10, class: 'form-control' %>
+    <% end %>
+  </div>
+
+  <div class="column-half extra-gutter">
+    <%= form_row for: [form.object, :petition_duration] do %>
+      <%= form.label :petition_duration, "Duration", class: "form-label" %>
+      <%= error_messages_for_field @site, :petition_duration %>
+      <%= form.text_field :petition_duration, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %> <span class="suffix">months</span>
+    <% end %>
+
+    <%= form_row for: [form.object, :threshold_for_response] do %>
+      <%= form.label :threshold_for_response, "Threshold for a response", class: "form-label" %>
+      <%= error_messages_for_field @site, :threshold_for_response %>
+      <%= form.text_field :threshold_for_response, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
+    <% end %>
+
+    <%= form_row for: [form.object, :threshold_for_debate] do %>
+      <%= form.label :threshold_for_debate, "Threshold for a debate", class: "form-label" %>
+      <%= error_messages_for_field @site, :threshold_for_debate %>
+      <%= form.text_field :threshold_for_debate, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
+    <% end %>
+  </div>
+</div>
+
+<%= javascript_tag do %>
+  $().ready(function() {
+    var $disabled_true = $('input[name="site[disable_collecting_signatures]"][value=true]');
+    var $disabled = $('input[name="site[disable_collecting_signatures]"]');
+    var $show_home_page_true = $('input[name="site[show_home_page_message]"][value=true]');
+    var $show_home_page = $('input[name="site[show_home_page_message]"]');
+    var $home_page_msg = $('#home-page-message');
+    var $show_petition_page_true = $('input[name="site[show_petition_page_message]"][value=true]');
+    var $show_petition_page = $('input[name="site[show_petition_page_message]"]');
+    var $petition_page_msg = $('#petition-page-message');
+    var $message_fields = $('.message-field');
+    var $message_controls = $('.message-control');
+    var $message_labels = $('.message-label');
+
+    var blurAndFocus = function() {
+      this.blur();
+      this.focus();
+    }
+
+    var toggleMessageField = function(control, field) {
+      if (control.is(':checked')) {
+        field.show();
+      } else {
+        field.hide();
+      }
+    }
+
+    toggleMessageField($show_home_page_true, $home_page_msg);
+    toggleMessageField($show_petition_page_true, $petition_page_msg);
+
+    if ($disabled_true.is(':checked')) {
+      $message_controls.hide();
+      $message_labels.show();
+      $message_fields.show();
+    }
+
+    $disabled.keyup(blurAndFocus).change(function() {
+      if ($disabled_true.is(':checked')) {
+        $message_controls.hide();
+        $message_labels.show();
+        $message_fields.show();
+      } else {
+        $message_controls.show();
+        $message_labels.hide();
+
+        toggleMessageField($show_home_page_true, $home_page_msg);
+        toggleMessageField($show_petition_page_true, $petition_page_msg);
+      }
+    });
+
+    $show_home_page.keyup(blurAndFocus).change(function() {
+      toggleMessageField($show_home_page_true, $home_page_msg);
+    });
+
+    $show_petition_page.keyup(blurAndFocus).change(function() {
+      toggleMessageField($show_petition_page_true, $petition_page_msg);
+    });
+  });
+<% end -%>

--- a/app/views/admin/sites/edit.html.erb
+++ b/app/views/admin/sites/edit.html.erb
@@ -5,7 +5,7 @@
     <%= render "admin/shared/site_tabs" %>
   </div>
 
-  <div class="column-two-thirds extra-gutter">
+  <div class="grid-column extra-gutter">
     <% if params[:tab] == "petitions" %>
       <%= render "form", tab: "petitions" %>
     <% elsif params[:tab] == "moderation" %>

--- a/app/views/pages/home/_opened.html.erb
+++ b/app/views/pages/home/_opened.html.erb
@@ -4,6 +4,13 @@
   </div>
 <% end %>
 
+<% if Site.show_home_page_message? %>
+  <div class="notification">
+    <span class="icon icon-warning-white"></span>
+    <%= markdown_to_html(Site.home_page_message) %>
+  </div>
+<% end %>
+
 <%= render "pages/home/actioned_petitions" %>
 
 <% unless no_petitions_yet? %>

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -1,4 +1,11 @@
 <%= cache_for :petition do %>
+  <% if Site.show_petition_page_message? %>
+    <div class="notification">
+      <span class="icon icon-warning-white"></span>
+      <%= markdown_to_html(Site.petition_page_message) %>
+    </div>
+  <% end %>
+
   <h1>
     <span class="heading-secondary">Petition</span>
     <%= petition.action %>
@@ -18,7 +25,9 @@
     </details>
   <% end %>
 
-  <%= link_to "Sign this petition", new_petition_signature_path(petition), :class => 'button button-sign-petition', :tabindex => increment(5) %>
+  <% unless Site.signature_collection_disabled? %>
+    <%= link_to "Sign this petition", new_petition_signature_path(petition), :class => 'button button-sign-petition', :tabindex => increment(5) %>
+  <% end %>
 
   <div class="signature-count">
     <p class="signature-count-number">

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -98,6 +98,20 @@ en-GB:
               too_long:
                 one: "Tag is too long (maximum is 1 character)"
                 other: "Tag is too long (maximum is %{count} characters)"
+                
+        site:
+          attributes:
+            home_page_message:
+              blank: "Message must be completed"
+              too_long:
+                one: "Message is too long (maximum is 1 character)"
+                other: "Message is too long (maximum is %{count} characters)"
+
+            petition_page_message:
+              blank: "Message must be completed"
+              too_long:
+                one: "Message is too long (maximum is 1 character)"
+                other: "Message is too long (maximum is %{count} characters)"
 
   errors:
     attributes:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -45,6 +45,10 @@ every :day, at: '7.15am' do
   rake "epets:petitions:debated", output: nil
 end
 
+every :day, at: '7.30am' do
+  rake "epets:petitions:extend_deadline", output: nil
+end
+
 every 15.minutes do
   rake "epets:site:signature_counts", output: nil
 end

--- a/db/migrate/20200316072107_add_deadline_extension_to_petitions.rb
+++ b/db/migrate/20200316072107_add_deadline_extension_to_petitions.rb
@@ -1,0 +1,24 @@
+class AddDeadlineExtensionToPetitions < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  class Petition < ActiveRecord::Base; end
+
+  def up
+    unless column_exists?(:petitions, :deadline_extension)
+      add_column :petitions, :deadline_extension, :integer
+
+      Petition.find_each do |petition|
+        petition.update(deadline_extension: 0)
+      end
+
+      change_column_default :petitions, :deadline_extension, 0
+      change_column_null :petitions, :deadline_extension, false
+    end
+  end
+
+  def down
+    if column_exists?(:petitions, :deadline_extension)
+      remove_column :petitions, :deadline_extension
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_062655) do
+ActiveRecord::Schema.define(version: 2020_03_16_072107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -468,6 +468,7 @@ ActiveRecord::Schema.define(version: 2020_03_03_062655) do
     t.integer "departments", default: [], null: false, array: true
     t.datetime "anonymized_at"
     t.integer "moderated_by_id"
+    t.integer "deadline_extension", default: 0, null: false
     t.index "((last_signed_at > signature_count_validated_at))", name: "index_petitions_on_validated_at_and_signed_at"
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "index_petitions_on_action", using: :gin
     t.index "to_tsvector('english'::regconfig, (background)::text)", name: "index_petitions_on_background", using: :gin

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -182,11 +182,11 @@ Given(/^the petition "([^"]*)" has been closed early because of parliament disso
 end
 
 Given(/^the petition has closed$/) do
-  @petition.close!
+  @petition.close!(@petition.deadline)
 end
 
 Given(/^the petition has closed some time ago$/) do
-  @petition.close!(2.days.ago)
+  @petition.close_early!(2.days.ago)
 end
 
 Given(/^a petition "([^"]*)" has been rejected( with the reason "([^"]*)")?$/) do |petition_action, reason_or_not, reason|
@@ -527,6 +527,6 @@ end
 
 Given(/^all the open petitions have been closed$/) do
   Petition.open_state.find_each do |petition|
-    petition.close!(1.day.ago)
+    petition.close_early!(1.day.ago)
   end
 end

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -1,3 +1,7 @@
+Then /^I can sign the petition$/ do
+  expect(page).to have_css("a", :text => "Sign")
+end
+
 Then /^I cannot sign the petition$/ do
   expect(page).not_to have_css("a", :text => "Sign")
 end

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -1,0 +1,60 @@
+Given(/^petitions are collecting signatures$/) do
+  allow_any_instance_of(Site).to receive(:disable_collecting_signatures).and_return(false)
+end
+
+Given(/^petitions are not collecting signatures$/) do
+  allow_any_instance_of(Site).to receive(:disable_collecting_signatures).and_return(true)
+
+  home_page_message = <<~MESSAGE
+    ### Petitions have stopped collecting signatures
+
+    With the nation currently facing extremely challenging circumstances due to coronavirus (COVID-19), Parliament has been closed and can’t debate petitions. As a consequence we have stopped collecting signatures on petitions. Once Parliament has reconvened we will allow signature collection to begin again.
+
+    For further information please see [the Parliament web site][1].
+
+    [1]: https://www.parliament.uk/business/news/2020/march/uk-parliament-coronavirus-update/
+  MESSAGE
+
+  petition_page_message = <<~MESSAGE
+    ### This petition has stopped collecting signatures
+
+    With the nation currently facing extremely challenging circumstances due to coronavirus (COVID-19), Parliament has been closed and can’t debate petitions. As a consequence we have stopped collecting signatures on petitions. Once Parliament has reconvened we will allow signature collection to begin again.
+
+    For further information please see [the Parliament web site][1].
+
+    [1]: https://www.parliament.uk/business/news/2020/march/uk-parliament-coronavirus-update/
+  MESSAGE
+
+  allow(Site).to receive(:home_page_message).and_return(home_page_message)
+  allow(Site).to receive(:petition_page_message).and_return(petition_page_message)
+end
+
+Given(/^a home page message has been enabled$/) do
+  allow_any_instance_of(Site).to receive(:show_home_page_message).and_return(true)
+
+  message = <<~MESSAGE
+    ### Petition moderation is experiencing delays
+
+    Thank you to everyone who’s starting or signing petitions at the moment.
+
+    We’re working to check the new petitions you’ve submitted as quickly as we can, but we’ve got a lot more than usual, so it might take us longer than our usual 7 days.
+
+    For further information about Petitions please see [the Parliament web site][1].
+
+    [1]: https://committees.parliament.uk/committee/326/petitions-committee/content/145126/find-out-more-about-epetitions/
+  MESSAGE
+
+  allow(Site).to receive(:home_page_message).and_return(message)
+end
+
+Given(/^a petition page message has been enabled$/) do
+  allow_any_instance_of(Site).to receive(:show_petition_page_message).and_return(true)
+
+  message = <<~MESSAGE
+    ### We are experiencing delays when signing this petition
+
+    Due to unprecedented demand we are experiencing delays delivering emails.
+  MESSAGE
+
+  allow(Site).to receive(:petition_page_message).and_return(message)
+end

--- a/features/support/custom_env.rb
+++ b/features/support/custom_env.rb
@@ -1,5 +1,6 @@
 require 'email_spec/cucumber'
 require 'rspec/core/pending'
+require 'rspec/mocks'
 require 'multi_test'
 require 'faker'
 
@@ -85,6 +86,7 @@ World(CucumberHelpers)
 World(CucumberSanitizer)
 World(MarkdownHelper)
 World(RejectionHelper)
+World(RSpec::Mocks::ExampleMethods)
 
 # run background jobs inline with delayed job
 ActiveJob::Base.queue_adapter = :delayed_job

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -20,6 +20,16 @@ Before do
 end
 
 Before do
+  ::RSpec::Mocks.setup
+end
+
+After do
+  ::RSpec::Mocks.verify
+ensure
+  ::RSpec::Mocks.teardown
+end
+
+Before do
   Rails.cache.clear
 end
 

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -165,3 +165,17 @@ Feature: Suzie views a petition
     Then I should not see "At 10,000 signatures..."
     Then I should not see "At 100,000 signatures..."
     And I should see a summary of the debate outcome
+
+  Scenario: Suzie sees a message when viewing a petition and signature collection has been paused
+    Given petitions are not collecting signatures
+    And an open petition "Spend more money on Defence"
+    When I view the petition
+    Then I should see "This petition has stopped collecting signatures"
+    And I cannot sign the petition
+
+  Scenario: Suzie sees a message when viewing a petition and a message has been enabled
+    Given a petition page message has been enabled
+    And an open petition "Spend more money on Defence"
+    When I view the petition
+    Then I should see "We are experiencing delays when signing this petition"
+    And I can sign the petition

--- a/features/suzie_views_the_home_page.feature
+++ b/features/suzie_views_the_home_page.feature
@@ -1,0 +1,19 @@
+Feature: Suzy Signer views the home page
+  In order to explore the Petitions website
+  As Suzy the signer
+  I visit the home page
+
+  Scenario: I navigate to the home page when petitions are collecting signatures
+    Given petitions are collecting signatures
+    When I go to the home page
+    Then I should not see "Petitions have stopped collecting signatures"
+
+  Scenario: I navigate to the home page when petitions are not collecting signatures
+    Given petitions are not collecting signatures
+    When I go to the home page
+    Then I should see "Petitions have stopped collecting signatures"
+
+  Scenario: I navigate to the home page when a message is configured
+    Given a home page message has been enabled
+    When I go to the home page
+    Then I should see "Petition moderation is experiencing delays"

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -32,6 +32,13 @@ namespace :epets do
       end
     end
 
+    desc "Add a task to the queue to extend petition deadlines at midnight"
+    task :extend_deadline => :environment do
+      Task.run("epets:petitions:extend_deadline") do
+        ExtendPetitionDeadlinesJob.set(wait_until: Date.tomorrow.beginning_of_day).perform_later
+      end
+    end
+
     desc "Add a task to the queue to update petition statistics"
     task :update_statistics => :environment do
       Task.run("epets:petitions:update_statistics", 12.hours) do

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe SignaturesController, type: :controller do
         expect(response).to render_template("signatures/new")
       end
     end
+
+    context "when the petition is open but signature collection is paused" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+
+        get :new, params: { petition_id: petition.id }
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}")
+      end
+    end
   end
 
   describe "POST /petitions/:petition_id/signatures/new" do
@@ -164,6 +178,20 @@ RSpec.describe SignaturesController, type: :controller do
         it "renders the signatures/new template" do
           expect(response).to render_template("signatures/new")
         end
+      end
+    end
+
+    context "when the petition is open but signature collection is paused" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}")
       end
     end
   end
@@ -385,6 +413,22 @@ RSpec.describe SignaturesController, type: :controller do
         end
       end
     end
+
+    context "when the petition is open but signature collection is paused" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+
+        perform_enqueued_jobs {
+          post :create, params: { petition_id: petition.id, signature: params }
+        }
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}")
+      end
+    end
   end
 
   describe "GET /petitions/:petition_id/signatures/thank-you" do
@@ -484,6 +528,24 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "renders the signatures/thank_you template" do
         expect(response).to render_template("signatures/thank_you")
+      end
+    end
+
+    context "when the petition is open but signature collection is paused" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+
+        get :thank_you, params: { petition_id: petition.id }
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}")
+      end
+
+      it "doesn't create a signature" do
+        expect(petition.signatures.find_by(email: "ted@example.com")).to be_nil
       end
     end
   end
@@ -684,6 +746,25 @@ RSpec.describe SignaturesController, type: :controller do
         end
       end
     end
+
+    context "when the petition is open but signature collection is paused" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+
+        get :verify, params: { id: signature.id, token: signature.perishable_token }
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}")
+      end
+
+      it "doesn't verify the signature" do
+        expect(signature.reload).to be_pending
+      end
+    end
   end
 
   describe "GET /signatures/:id/signed" do
@@ -857,6 +938,22 @@ RSpec.describe SignaturesController, type: :controller do
         it "redirects to the petition page" do
           expect(response).to redirect_to("/petitions/#{petition.id}")
         end
+      end
+    end
+
+    context "when the petition is open but signature collection is paused" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
+
+      before do
+        expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+        session[:signed_tokens] = { signature.id.to_s => signature.signed_token }
+
+        get :signed, params: { id: signature.id }
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}")
       end
     end
   end

--- a/spec/jobs/extend_petition_deadlines_job_spec.rb
+++ b/spec/jobs/extend_petition_deadlines_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ExtendPetitionDeadlinesJob, type: :job do
+  let!(:petition) { FactoryBot.create(:open_petition) }
+
+  context "when signature collection is not disabled" do
+    before do
+      expect(Site).to receive(:signature_collection_disabled?).and_return(false)
+    end
+
+    it "doesn't increment the deadline_extension attribute" do
+      expect {
+        described_class.perform_now
+      }.not_to change {
+        petition.reload.deadline_extension
+      }
+    end
+  end
+
+  context "when signature collection is disabled" do
+    before do
+      expect(Site).to receive(:signature_collection_disabled?).and_return(true)
+    end
+
+    it "increments the deadline_extension attribute by 1 day" do
+      expect {
+        described_class.perform_now
+      }.to change {
+        petition.reload.deadline_extension
+      }.from(0.days).to(1.day)
+    end
+  end
+end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2278,9 +2278,198 @@ RSpec.describe Petition, type: :model do
     let(:closing_date) { (now + duration).end_of_day }
     let(:debate_state) { 'pending' }
 
+    context "when the deadline has not passed" do
+      let(:time) { closing_date.yesterday.beginning_of_day }
+
+      it "doesn't set the state to CLOSED" do
+        expect {
+          petition.close!(time)
+        }.not_to change {
+          petition.state
+        }.from(Petition::OPEN_STATE)
+      end
+
+      it "doesn't set the closing date" do
+        expect {
+          petition.close!(time)
+        }.not_to change {
+          petition.closed_at
+        }.from(nil)
+      end
+
+      %w[pending awaiting scheduled debated not_debated].each do |state|
+        context "when the debate state is '#{state}'" do
+          let(:debate_state) { state }
+
+          it "doesn't change the debate state" do
+            expect {
+              petition.close!(time)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
+        end
+      end
+
+      (Petition::STATES - [Petition::OPEN_STATE]).each do |state|
+        context "when called on a #{state} petition" do
+          subject(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it "raises a RuntimeError" do
+            expect { petition.close!(time) }.to raise_error(RuntimeError)
+          end
+        end
+      end
+    end
+
+    context "when the deadline has passed" do
+      let(:time) { closing_date.tomorrow.beginning_of_day }
+
+      it "sets the state to CLOSED" do
+        expect {
+          petition.close!(time)
+        }.to change {
+          petition.state
+        }.from(Petition::OPEN_STATE).to(Petition::CLOSED_STATE)
+      end
+
+      it "sets the closing date to the deadline" do
+        expect {
+          petition.close!(time)
+        }.to change {
+          petition.closed_at
+        }.from(nil).to(closing_date)
+      end
+
+      %w[pending awaiting scheduled debated not_debated].each do |state|
+        context "when the debate state is '#{state}'" do
+          let(:debate_state) { state }
+
+          it "doesn't change the debate state" do
+            expect {
+              petition.close!(time)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
+        end
+      end
+
+      (Petition::STATES - [Petition::OPEN_STATE]).each do |state|
+        context "when called on a #{state} petition" do
+          subject(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it "raises a RuntimeError" do
+            expect { petition.close!(time) }.to raise_error(RuntimeError)
+          end
+        end
+      end
+    end
+
+    context "when the deadline has been extended" do
+      let(:new_closing_date) { closing_date + 7.days }
+      subject(:petition) { FactoryBot.create(:open_petition, deadline_extension: 7, debate_state: debate_state) }
+
+      context "and the new deadline hasn't passed" do
+        let(:time) { (closing_date + 6.days).beginning_of_day }
+
+        it "doesn't set the state to CLOSED" do
+          expect {
+            petition.close!(time)
+          }.not_to change {
+            petition.state
+          }.from(Petition::OPEN_STATE)
+        end
+
+        it "doesn't set the closing date" do
+          expect {
+            petition.close!(time)
+          }.not_to change {
+            petition.closed_at
+          }.from(nil)
+        end
+
+        %w[pending awaiting scheduled debated not_debated].each do |state|
+          context "when the debate state is '#{state}'" do
+            let(:debate_state) { state }
+
+            it "doesn't change the debate state" do
+              expect {
+                petition.close!(time)
+              }.not_to change {
+                petition.debate_state
+              }
+            end
+          end
+        end
+
+        (Petition::STATES - [Petition::OPEN_STATE]).each do |state|
+          context "when called on a #{state} petition" do
+            subject(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+            it "raises a RuntimeError" do
+              expect { petition.close!(time) }.to raise_error(RuntimeError)
+            end
+          end
+        end
+      end
+
+      context "and the new deadline has passed" do
+        let(:time) { (closing_date + 8.days).beginning_of_day }
+
+        it "sets the state to CLOSED" do
+          expect {
+            petition.close!(time)
+          }.to change {
+            petition.state
+          }.from(Petition::OPEN_STATE).to(Petition::CLOSED_STATE)
+        end
+
+        it "sets the closing date to the new deadline" do
+          expect {
+            petition.close!(time)
+          }.to change {
+            petition.closed_at
+          }.from(nil).to(new_closing_date)
+        end
+
+        %w[pending awaiting scheduled debated not_debated].each do |state|
+          context "when the debate state is '#{state}'" do
+            let(:debate_state) { state }
+
+            it "doesn't change the debate state" do
+              expect {
+                petition.close!(time)
+              }.not_to change {
+                petition.debate_state
+              }
+            end
+          end
+        end
+
+        (Petition::STATES - [Petition::OPEN_STATE]).each do |state|
+          context "when called on a #{state} petition" do
+            subject(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+            it "raises a RuntimeError" do
+              expect { petition.close!(time) }.to raise_error(RuntimeError)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#close_early!' do
+    subject(:petition) { FactoryBot.create(:open_petition, debate_state: debate_state) }
+    let(:now) { Time.current }
+    let(:duration) { Site.petition_duration.months }
+    let(:closing_date) { (now + duration).end_of_day }
+    let(:debate_state) { 'pending' }
+
     it "sets the state to CLOSED" do
       expect {
-        petition.close!(now)
+        petition.close_early!(now)
       }.to change {
         petition.state
       }.from(Petition::OPEN_STATE).to(Petition::CLOSED_STATE)
@@ -2288,7 +2477,7 @@ RSpec.describe Petition, type: :model do
 
     it "sets the closing date to now" do
       expect {
-        petition.close!(now)
+        petition.close_early!(now)
       }.to change {
         petition.closed_at
       }.from(nil).to(now)
@@ -2300,21 +2489,11 @@ RSpec.describe Petition, type: :model do
 
         it "doesn't change the debate state" do
           expect {
-            petition.close!
+            petition.close_early!(now)
           }.not_to change {
             petition.debate_state
           }
         end
-      end
-    end
-
-    context "when called without an argument" do
-      it "sets the closing date to the deadline" do
-        expect {
-          petition.close!
-        }.to change {
-          petition.closed_at
-        }.from(nil).to(petition.deadline)
       end
     end
 
@@ -2323,7 +2502,7 @@ RSpec.describe Petition, type: :model do
         subject(:petition) { FactoryBot.create(:"#{state}_petition") }
 
         it "raises a RuntimeError" do
-          expect { petition.close! }.to raise_error(RuntimeError)
+          expect { petition.close_early!(now) }.to raise_error(RuntimeError)
         end
       end
     end
@@ -2430,6 +2609,26 @@ RSpec.describe Petition, type: :model do
       it 'is nil' do
         expect(petition.deadline).to be_nil
       end
+    end
+  end
+
+  describe "#extend_deadline!" do
+    let(:petition) { FactoryBot.create(:open_petition, updated_at: 2.days.ago) }
+
+    it "increments the deadline_extension field by 1 day" do
+      expect {
+        petition.extend_deadline!
+      }.to change {
+        petition.reload.deadline_extension
+      }.from(0.days).to(1.day)
+    end
+
+    it "touches the updated_at timestamp" do
+      expect {
+        petition.extend_deadline!
+      }.to change {
+        petition.reload.updated_at
+      }.to(be_within(1.second).of(Time.current))
     end
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe Site, type: :model do
     it { is_expected.to validate_length_of(:email_from).is_at_most(100) }
     it { is_expected.to validate_length_of(:feedback_email).is_at_most(100) }
 
+    it { is_expected.to validate_length_of(:home_page_message).is_at_most(800) }
+    it { is_expected.to validate_length_of(:petition_page_message).is_at_most(800) }
+
     %w[
       petition_duration minimum_number_of_sponsors maximum_number_of_sponsors threshold_for_moderation
       threshold_for_moderation_delay threshold_for_response threshold_for_debate login_timeout
@@ -83,6 +86,13 @@ RSpec.describe Site, type: :model do
       it { is_expected.to validate_length_of(:username).is_at_most(30) }
       it { is_expected.to validate_length_of(:password).is_at_most(30) }
       it { is_expected.to validate_confirmation_of(:password) }
+    end
+
+    context "when signature collection is disabled" do
+      subject { described_class.new(disable_collecting_signatures: true) }
+
+      it { is_expected.to validate_presence_of(:home_page_message) }
+      it { is_expected.to validate_presence_of(:petition_page_message) }
     end
   end
 
@@ -257,6 +267,26 @@ RSpec.describe Site, type: :model do
     it "delegates signature_count_interval to the instance" do
       expect(site).to receive(:update_signature_counts).and_return(true)
       expect(Site.update_signature_counts).to eq(true)
+    end
+
+    it "delegates show_home_page_message? to the instance" do
+      expect(site).to receive(:show_home_page_message?).and_return(true)
+      expect(Site.show_home_page_message?).to eq(true)
+    end
+
+    it "delegates home_page_message to the instance" do
+      expect(site).to receive(:home_page_message).and_return("Message")
+      expect(Site.home_page_message).to eq("Message")
+    end
+
+    it "delegates show_petition_page_message? to the instance" do
+      expect(site).to receive(:show_petition_page_message?).and_return(true)
+      expect(Site.show_petition_page_message?).to eq(true)
+    end
+
+    it "delegates petition_page_message to the instance" do
+      expect(site).to receive(:petition_page_message).and_return("Message")
+      expect(Site.petition_page_message).to eq("Message")
     end
   end
 


### PR DESCRIPTION
There may be scenarios in which the Petitions service will have to pause collecting signatures on petitions but not fully stop like we do when an election is called. This change allows collection to be paused and the deadline for petitions open at the time to be extended by 1 day if the signature collection is paused at midnight.

It also allows for the messaging around any pause to be used independently of actually pausing collection should it be needed for other purposes such as making people aware of moderation delays, etc.
