### PR TITLE
Similar petitions grammar fix

### DIFF
--- a/app/views/petitions/check_results.html.erb
+++ b/app/views/petitions/check_results.html.erb
@@ -27,7 +27,7 @@
 
   <h1 class="page-title">We checked for similar petitions</h1>
   <p>We checked for similar petitions and it doesn’t look like there are any.</p>
-  <p>But, there might be a similar petition has used different words. If there is already a petition on the same topic, your petition might not be published.</p>
+  <p>But there might be a similar petition that has used different words. If there is already a petition on the same topic, your petition might not be published.</p>
 
   <%= link_to("Continue", new_petition_path(q: @new_petition.action), class: "button") %>
 


### PR DESCRIPTION
Before

> But, there might be a similar petition has used different words.

After

> But there might be a similar petition that has used different words.