### PR TITLE
Rate limit creator signatures across petitions

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -723,8 +723,14 @@ class Signature < ActiveRecord::Base
   end
 
   def rate(window = 5.minutes)
-    period = Range.new(created_at - window, created_at)
-    petition.signatures.where(ip_address: ip_address, created_at: period).count
+    time = created_at || Time.current
+    period = Range.new(time - window, time)
+
+    if creator?
+      self.class.where(ip_address: ip_address, created_at: period).count
+    else
+      petition.signatures.where(ip_address: ip_address, created_at: period).count
+    end
   end
 
   def update_uuid

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -201,3 +201,20 @@ Scenario: Charlie creates a petition when blocked
   When I press "Yes – this is my email address"
   Then a petition should not exist with action: "The wombats of wimbledon rock.", state: "pending"
   And a signature should not exist with email: "womboid@wimbledon.com", state: "pending"
+
+Scenario: Charlie creates a petition when his IP address is rate limited
+  Given the burst rate limit is 1 per minute
+  And there are no allowed IPs
+  And there are no blocked IPs
+  And there are 2 petitions created from this IP address
+  And I start a new petition
+  And I fill in the petition details
+  And I press "Preview petition"
+  And I press "This looks good"
+  And I fill in my details
+  When I press "Continue"
+  Then the markup should be valid
+  And I am asked to review my email address
+  When I press "Yes – this is my email address"
+  Then a petition should not exist with action: "The wombats of wimbledon rock.", state: "pending"
+  And a signature should not exist with email: "womboid@wimbledon.com", state: "pending"

--- a/features/step_definitions/rate_limit_steps.rb
+++ b/features/step_definitions/rate_limit_steps.rb
@@ -6,6 +6,10 @@ Given(/^there are no allowed IPs$/) do
   RateLimit.first_or_create!.update!(allowed_ips: "")
 end
 
+Given(/^there are no blocked IPs$/) do
+  RateLimit.first_or_create!.update!(blocked_ips: "")
+end
+
 Given(/^the IP address (\d+\.\d+\.\d+\.\d+) is blocked$/) do |ip_address|
   RateLimit.first_or_create!.update!(blocked_ips: ip_address)
 end
@@ -27,6 +31,12 @@ Given(/^there is a signature already from this IP address$/) do
     Then I am told to check my inbox to complete signing
     And "existing@example.com" should receive 1 email
   )
+end
+
+Given(/^there (?:are|is) (\d+) petitions? created from this IP address$/) do |count|
+  count.times do
+    FactoryBot.create(:pending_petition, creator_attributes: { ip_address: "127.0.0.1" })
+  end
 end
 
 When(/^I wait (\d+) seconds?$/) do |duration|


### PR DESCRIPTION
TODO: add a separate rate limit for petition creation.