### PR TITLE
Switch to reset_session CSRF protection strategy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :reset_session
 
   before_action :reload_site
   before_action :reload_parliament

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_epets_session', expire_after: 2.weeks
+Rails.application.config.session_store :cookie_store, key: '_epets_session', same_site: :strict

--- a/spec/requests/session_cookie_spec.rb
+++ b/spec/requests/session_cookie_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe 'session cookie', type: :request, show_exceptions: true do
     expect(subject).to match(/; httponly/i)
   end
 
-  it "should set the expiry to 2 weeks from now" do
-    expect(subject).to match(/; expires=Tue, 26 Apr 2016 12:59:59 GMT/)
+  it "should set the samesite option" do
+    expect(subject).to match(/; samesite=strict/i)
+  end
+
+  it "should not set any expiry" do
+    expect(subject).not_to match(/; expires/)
   end
 end


### PR DESCRIPTION
When mobile browsers are expunged from memory they can lose session cookies but keep the in-page CSRF token which leads to a 422 error when submitting a form. Since all forms are unauthenticated on the public site then we can use the reset_session strategy as after checking we don't have any prepend_before_action scenarios that could lead to CSRF protected being bypassed. Since the moderation site is on a different domain the session reset won't affect moderators.

Additionally add the SameSite=Strict cookie option to improve security.
