### PR TITLE
Add additional sanitization to browseable params

### DIFF
--- a/app/controllers/archived/petitions_controller.rb
+++ b/app/controllers/archived/petitions_controller.rb
@@ -79,8 +79,12 @@ class Archived::PetitionsController < ApplicationController
     params[:state].present?
   end
 
+  def sanitized_state
+    params[:state].to_s[0..30].to_sym
+  end
+
   def valid_state?
-    archived_petition_facets.include?(params[:state].to_sym)
+    archived_petition_facets.include?(sanitized_state)
   end
 
   def search_params(overrides = {})

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -141,8 +141,12 @@ class PetitionsController < ApplicationController
     params[:state].present?
   end
 
+  def sanitized_state
+    params[:state].to_s[0..30].to_sym
+  end
+
   def valid_state?
-    public_petition_facets.include?(params[:state].to_sym)
+    public_petition_facets.include?(sanitized_state)
   end
 
   def search_params(overrides = {})

--- a/spec/controllers/archived/petitions_controller_spec.rb
+++ b/spec/controllers/archived/petitions_controller_spec.rb
@@ -40,6 +40,76 @@ RSpec.describe Archived::PetitionsController, type: :controller do
           expect(assigns(:petitions).scope).to eq :published
         end
       end
+
+      context "and it is an array" do
+        it "redirects to itself with state=all" do
+          get :index, params: { state: [ "l337haxxor" ] }
+          expect(response).to redirect_to "https://petition.parliament.uk/archived/petitions?state=all"
+        end
+
+        it "preserves other params when it redirects" do
+          get :index, params: { q: "what is clocks", state: [ "l337haxxor" ] }
+          expect(response).to redirect_to "https://petition.parliament.uk/archived/petitions?q=what+is+clocks&state=all"
+        end
+      end
+
+      context "and it is a hash" do
+        it "redirects to itself with state=all" do
+          get :index, params: { state: { l337: "haxxor" } }
+          expect(response).to redirect_to "https://petition.parliament.uk/archived/petitions?state=all"
+        end
+
+        it "preserves other params when it redirects" do
+          get :index, params: { q: "what is clocks", state: { l337: "haxxor" } }
+          expect(response).to redirect_to "https://petition.parliament.uk/archived/petitions?q=what+is+clocks&state=all"
+        end
+      end
+    end
+
+    context "when a page param is provided" do
+      context "and it is an array" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: [ "l337haxxor" ] }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+
+      context "and it is a hash" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: { l337: "haxxor" } }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+
+      context "and it is out of range" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: "414141414141414141" }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+    end
+
+    context "when a count param is provided" do
+      context "and it is an array" do
+        it "uses the default count" do
+          get :index, params: { count: [ "l337haxxor" ] }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
+
+      context "and it is a hash" do
+        it "uses the default count" do
+          get :index, params: { count: { l337: "haxxor" } }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
+
+      context "and it is out of range" do
+        it "uses the default count" do
+          get :index, params: { count: "414141414141414141" }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
     end
   end
 

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -385,6 +385,76 @@ RSpec.describe PetitionsController, type: :controller do
           expect(assigns(:petitions).scope).to eq :open
         end
       end
+
+      context "and it is an array" do
+        it "redirects to itself with state=all" do
+          get :index, params: { state: [ "l337haxxor" ] }
+          expect(response).to redirect_to "https://petition.parliament.uk/petitions?state=all"
+        end
+
+        it "preserves other params when it redirects" do
+          get :index, params: { q: "what is clocks", state: [ "l337haxxor" ] }
+          expect(response).to redirect_to "https://petition.parliament.uk/petitions?q=what+is+clocks&state=all"
+        end
+      end
+
+      context "and it is a hash" do
+        it "redirects to itself with state=all" do
+          get :index, params: { state: { l337: "haxxor" } }
+          expect(response).to redirect_to "https://petition.parliament.uk/petitions?state=all"
+        end
+
+        it "preserves other params when it redirects" do
+          get :index, params: { q: "what is clocks", state: { l337: "haxxor" } }
+          expect(response).to redirect_to "https://petition.parliament.uk/petitions?q=what+is+clocks&state=all"
+        end
+      end
+    end
+
+    context "when a page param is provided" do
+      context "and it is an array" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: [ "l337haxxor" ] }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+
+      context "and it is a hash" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: { l337: "haxxor" } }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+
+      context "and it is out of range" do
+        it "is treated as being on the first page" do
+          get :index, params: { page: "414141414141414141" }
+          expect(assigns(:petitions).current_page).to eq 1
+        end
+      end
+    end
+
+    context "when a count param is provided" do
+      context "and it is an array" do
+        it "uses the default count" do
+          get :index, params: { count: [ "l337haxxor" ] }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
+
+      context "and it is a hash" do
+        it "uses the default count" do
+          get :index, params: { count: { l337: "haxxor" } }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
+
+      context "and it is out of range" do
+        it "uses the default count" do
+          get :index, params: { count: "414141414141414141" }
+          expect(assigns(:petitions).page_size).to eq 50
+        end
+      end
     end
 
     context "when parliament has not yet opened" do

--- a/spec/models/concerns/browseable_spec.rb
+++ b/spec/models/concerns/browseable_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Browseable, type: :model do
   describe Browseable::Search do
     let(:scopes)  { { all: -> { self }, open: -> { self } } }
     let(:filters) { {} }
-    let(:klass)   { double(:klass, facet_definitions: scopes, filter_definitions: filters) }
+    let(:klass)   { double(:klass, facet_definitions: scopes, filter_definitions: filters, default_page_size: 50, max_page_size: 50) }
     let(:params)  { { q: 'search', page: '3'} }
     let(:search)  { described_class.new(klass, params) }
 
@@ -265,16 +265,16 @@ RSpec.describe Browseable, type: :model do
       context "when the count param is set to zero" do
         let(:params) { { q: 'search', page: '1', count: '0' } }
 
-        it "returns 1" do
-          expect(search.page_size).to eq(1)
+        it "returns the default page size" do
+          expect(search.page_size).to eq(50)
         end
       end
 
       context "when the count param is set to less than 0" do
         let(:params) { { q: 'search', page: '1', count: '-10' } }
 
-        it "returns 1" do
-          expect(search.page_size).to eq(1)
+        it "returns the default page size" do
+          expect(search.page_size).to eq(50)
         end
       end
     end


### PR DESCRIPTION
Every now and again someone decides to run a tool like Acunetix across the website and whilst nothing bad happens the spike of Appsignal reports is annoying so prevent some of those 500 errors occurring.