### PR TITLE
Add unreject petitions feature

### DIFF
--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -14,7 +14,7 @@ class Admin::ModerationController < Admin::AdminController
   private
 
   def fetch_petition
-    @petition = Petition.todo_list.find(params[:petition_id])
+    @petition = Petition.moderatable.find(params[:petition_id])
   end
 
   def moderation_params

--- a/app/jobs/notify_everyone_of_moderation_decision_job.rb
+++ b/app/jobs/notify_everyone_of_moderation_decision_job.rb
@@ -9,7 +9,7 @@ class NotifyEveryoneOfModerationDecisionJob < ApplicationJob
 
     if petition.published?
       notify_everyone_of_publication(creator, sponsors)
-    elsif petition.rejected? || petition.hidden?
+    elsif petition.rejection?
       notify_everyone_of_rejection(creator, sponsors)
     end
   end

--- a/app/views/admin/admin/_petition_action_moderation.html.erb
+++ b/app/views/admin/admin/_petition_action_moderation.html.erb
@@ -1,2 +1,8 @@
-<%= render 'admin/moderation/form', petition: @petition %>
-<%= render 'edit_lock' %>
+<% if controller_name.in?(%w[petitions moderation]) %>
+  <%= render 'admin/moderation/form', petition: @petition %>
+  <%= render 'edit_lock' %>
+<% elsif @petition.moderated? %>
+  <%= link_to 'Change moderation', admin_petition_path(@petition), class: 'petition-action-heading' %>
+<% else %>
+  <%= link_to 'Moderate this petition', admin_petition_path(@petition), class: 'petition-action-heading' %>
+<% end %>

--- a/app/views/admin/archived/petitions/_petition_details.html.erb
+++ b/app/views/admin/archived/petitions/_petition_details.html.erb
@@ -19,7 +19,7 @@
   <% if @petition.closed? %>
     <dt>Closed</dt>
     <dd><%= date_format_admin(@petition.closed_at) %></dd>
-  <% elsif @petition.rejected? || @petition.hidden? %>
+  <% elsif @petition.rejection? %>
     <dt>Rejected</dt>
     <dd><%= date_format_admin(@petition.rejected_at) %></dd>
   <% end %>

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -1,16 +1,22 @@
-<%= form_for petition, url: admin_petition_moderation_path(petition), method: :patch do |f| -%>
+<%= form_for petition, url: admin_petition_moderation_path(petition), method: :patch do |f| %>
   <%= form_row for: [petition, :moderation], class: 'inline' do %>
-    <h2 class="petition-action-heading">Moderate this petition</h2>
+    <% if petition.rejection? %>
+      <h2 class="petition-action-heading">Change moderation</h2>
+    <% else %>
+      <h2 class="petition-action-heading">Moderate this petition</h2>
+    <% end %>
     <%= error_messages_for_field petition, :moderation %>
     <div class="multiple-choice">
       <%= f.radio_button :moderation, 'approve' %>
       <%= f.label :moderation_approve, "Approve", for: "petition_moderation_approve" %>
     </div>
-    <div class="multiple-choice">
-      <%= f.radio_button :moderation, 'reject' %>
-      <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>
-    </div>
-    <% if f.object.flagged? || f.object.dormant? %>
+    <% unless f.object.rejection? %>
+      <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'reject' %>
+        <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>
+      </div>
+    <% end %>
+    <% if f.object.flagged? || f.object.dormant? || f.object.rejection? %>
       <div class="multiple-choice">
         <%= f.radio_button :moderation, 'restore' %>
         <%= f.label :moderation_restore, "Restore", for: "petition_moderation_restore" %>
@@ -28,35 +34,38 @@
     <% end %>
   <% end %>
 
-  <%= render 'admin/petitions/reject', f: f %>
+  <% unless f.object.rejection? %>
+    <%= render 'admin/petitions/reject', f: f %>
+  <% end %>
 
   <%= f.submit 'Email petition creator', name: 'save_and_email', class: 'button', tabindex: increment %>
   <%= f.submit 'Save without emailing', name: 'save', class: 'button-secondary', tabindex: increment %>
 
-  <%= javascript_tag do %>
-    $().ready(function() {
-      var $rejection_controls = $('.petition-rejection-controls'),
-          $reject_control = $('#petition_moderation_reject'),
-          $flag_control = $('#petition_moderation_flag'),
-          $all_controls = $('.edit_petition input[name="petition[moderation]"][type=radio]');
-      // Hide it straight away if there were no errors displayed
-      if ($rejection_controls.find('.error-message').size() === 0) {
-        $rejection_controls.hide();
-      }
-
-      // Ensure that we get the onchange event when the users uses the keyboard
-      // Details: http://bit.ly/iZx9nh
-      $all_controls.keyup(function() {
-        this.blur();
-        this.focus();
-      }).change(function() {
-        if ($reject_control.is(':checked')) {
-          $rejection_controls.show();
-        } else {
+  <% unless f.object.rejection? %>
+    <%= javascript_tag do %>
+      $().ready(function() {
+        var $rejection_controls = $('.petition-rejection-controls'),
+            $reject_control = $('#petition_moderation_reject'),
+            $flag_control = $('#petition_moderation_flag'),
+            $all_controls = $('.edit_petition input[name="petition[moderation]"][type=radio]');
+        // Hide it straight away if there were no errors displayed
+        if ($rejection_controls.find('.error-message').size() === 0) {
           $rejection_controls.hide();
         }
-      });
-    });
-  <% end -%>
 
-<% end -%>
+        // Ensure that we get the onchange event when the users uses the keyboard
+        // Details: http://bit.ly/iZx9nh
+        $all_controls.keyup(function() {
+          this.blur();
+          this.focus();
+        }).change(function() {
+          if ($reject_control.is(':checked')) {
+            $rejection_controls.show();
+          } else {
+            $rejection_controls.hide();
+          }
+        });
+      });
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/petitions/_petition_actions.html.erb
+++ b/app/views/admin/petitions/_petition_actions.html.erb
@@ -1,5 +1,13 @@
 <nav class="petition-actions" role="navigation">
   <ul>
+    <% if @petition.rejection? %>
+      <% if current_user.can_moderate_petitions? %>
+        <li class="petition-action">
+          <%= render 'petition_action_moderation', petition: @petition %>
+        </li>
+      <% end %>
+    <% end %>
+
     <li class="petition-action">
       <%= render 'petition_action_tags', petition: @petition %>
     </li>
@@ -58,7 +66,7 @@
             <%= render 'petition_action_take_down', petition: @petition %>
           </li>
 
-        <% elsif @petition.rejected? || @petition.hidden? -%>
+        <% elsif @petition.rejection? -%>
           <li class="petition-action">
             <%= render 'petition_action_change_rejection_status', petition: @petition %>
           </li>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -38,7 +38,7 @@
   <% if @petition.open? %>
     <dt>Deadline</dt>
     <dd><%= date_format_admin(@petition.deadline) %></dd>
-  <% elsif @petition.rejected? || @petition.hidden? %>
+  <% elsif @petition.rejection? %>
     <dt>Rejected on</dt>
     <dd><%= date_format_admin(@petition.rejected_at) %></dd>
   <% elsif @petition.stopped? %>

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -137,3 +137,41 @@ Feature: Moderator respond to petition
     But it can still be approved
     And it can still be rejected
     And it can be restored to a sponsored state
+
+  @javascript
+  Scenario: Moderator publishes a rejected petition
+    Given I am logged in as a moderator named "Ben Macintosh"
+    When I look at the next petition on my list
+    And I reject the petition
+    Then the creator should receive a rejection notification email
+    And the petition is not available for signing
+    But the petition is still available for searching or viewing
+    Given no emails have been sent
+    When I revisit the petition
+    Then the petition can no longer be rejected
+    And the petition can no longer be marked as dormant
+    But it can still be approved
+    And it can still be restored
+    When I publish the petition
+    Then I should see "Published by Ben Macintosh"
+    And the petition should be visible on the site for signing
+    And the creator should receive a notification email
+
+  @javascript
+  Scenario: Moderator restores a rejected petition
+    Given I am logged in as a moderator named "Ben Macintosh"
+    When I look at the next petition on my list
+    And I reject the petition
+    Then the creator should receive a rejection notification email
+    And the petition is not available for signing
+    But the petition is still available for searching or viewing
+    Given no emails have been sent
+    When I revisit the petition
+    Then the petition can no longer be rejected
+    And the petition can no longer be marked as dormant
+    But it can still be approved
+    And it can still be restored
+    When I restore to a sponsored state
+    Then the creator should not receive a notification email
+    And the petition is not available for searching or viewing
+    But the petition will still show up in the back-end reporting

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -8,6 +8,12 @@ When(/^I visit a sponsored petition with action: "([^"]*)", that has background:
   visit admin_petition_url(@sponsored_petition)
 end
 
+When(/^I reject the petition$/) do
+  choose "Reject"
+  select "Duplicate petition", :from => :petition_rejection_code
+  click_button "Email petition creator"
+end
+
 When(/^I reject the petition with a reason code "([^"]*)"$/) do |reason_code|
   choose "Reject"
   select reason_code, :from => :petition_rejection_code
@@ -47,6 +53,13 @@ When(/^I mark the petition as dormant$/) do
   click_button "Save without emailing"
 end
 
+When(/^I restore to a sponsored state$/) do
+  choose "Restore"
+  click_button "Save without emailing"
+  expect(page).to have_content("Petition has been successfully updated")
+  expect(page).to have_content("Status Sponsored")
+end
+
 Then /^the petition is still available for searching or viewing$/ do
   step %{I search for "Rejected petitions" with "#{@petition.action}"}
   step %{I should see the petition "#{@petition.action}"}
@@ -74,6 +87,10 @@ Then /^the petition should be visible on the site for signing$/ do
   expect(page).to have_css("a", :text => "Sign")
 end
 
+Then(/^the petition can no longer be rejected$/) do
+  expect(page).to have_no_field('Reject', visible: false)
+end
+
 Then(/^the petition can no longer be flagged$/) do
   expect(page).to have_no_field('Flag', visible: false)
 end
@@ -92,6 +109,10 @@ end
 
 Then(/^it can still be rejected$/) do
   expect(page).to have_field('Reject', visible: false)
+end
+
+Then(/^it can still be restored$/) do
+  expect(page).to have_field('Restore', visible: false)
 end
 
 Then(/^it can be restored to a sponsored state$/) do

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -238,7 +238,11 @@ end
 Then(/^I should see the petition details$/) do
   expect(page).to have_content(@petition.action)
   expect(page).to have_content(@petition.background) if @petition.background?
-  expect(page).to have_content(@petition.additional_details) if @petition.additional_details?
+
+  if @petition.additional_details?
+    click_details "More details"
+    expect(page).to have_content(@petition.additional_details)
+  end
 end
 
 Then(/^I should see the vote count, closed and open dates$/) do

--- a/features/support/custom_env.rb
+++ b/features/support/custom_env.rb
@@ -78,7 +78,7 @@ end
 
 module CucumberHelpers
   def click_details(name)
-    if @javascript
+    if Capybara.current_driver == Capybara.javascript_driver
       page.find("//details/summary[contains(., '#{name}')]").click
     else
       page.find("//summary[contains(., '#{name}')]/..").click


### PR DESCRIPTION
When petitions are rejected it's meant to be a final state but sometimes mistakes are made and creators appeal so there are increasing manual requests to unreject petitions that require developer assistance.

By using the existing 'Restore' functionality we can give the ability to unreject petitions to moderators and remove developers as a block.