### PR TITLE
Return '410 Gone' for petitions that have been removed

### DIFF
--- a/app/controllers/archived/petitions_controller.rb
+++ b/app/controllers/archived/petitions_controller.rb
@@ -63,6 +63,10 @@ class Archived::PetitionsController < ApplicationController
   end
 
   def fetch_petition
+    if Archived::Petition.removed?(petition_id)
+      raise Site::PetitionRemoved, "Archived petition #{petition_id} has been removed"
+    end
+
     @petition = Archived::Petition.visible.find(petition_id)
     @parliament = @petition.parliament
 

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -124,6 +124,10 @@ class PetitionsController < ApplicationController
   end
 
   def retrieve_petition
+    if Petition.removed?(petition_id)
+      raise Site::PetitionRemoved, "Petition #{petition_id} has been removed"
+    end
+
     @petition = Petition.show.find(petition_id)
   end
 

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -207,6 +207,14 @@ module Archived
         where(threshold_for_debate_reached.or(scheduled_for_debate))
       end
 
+      def removed
+        where(state: HIDDEN_STATE).where.not(opened_at: nil)
+      end
+
+      def removed?(id)
+        removed.exists?(id)
+      end
+
       private
 
       def debate_date_in_the_past(date)
@@ -256,6 +264,10 @@ module Archived
 
     def published?
       state.in?(PUBLISHED_STATES)
+    end
+
+    def visible?
+      state.in?(VISIBLE_STATES)
     end
 
     def duration

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -443,6 +443,14 @@ class Petition < ActiveRecord::Base
       where(grouping(last_signed_at.gt(signature_count_validated_at)).eq(true))
     end
 
+    def removed
+      where(state: HIDDEN_STATE).where.not(opened_at: nil)
+    end
+
+    def removed?(id)
+      removed.exists?(id)
+    end
+
     private
 
     def grouping(expression)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,6 +4,7 @@ require 'active_support/number_helper'
 
 class Site < ActiveRecord::Base
   class ServiceUnavailable < StandardError; end
+  class PetitionRemoved < StandardError; end
 
   include ActiveSupport::NumberHelper
 

--- a/app/views/admin/archived/petitions/_petition_details.html.erb
+++ b/app/views/admin/archived/petitions/_petition_details.html.erb
@@ -24,8 +24,10 @@
     <dd><%= date_format_admin(@petition.rejected_at) %></dd>
   <% end %>
 
-  <dt>Link to petition</dt>
-  <dd><%= link_to archived_petition_path(@petition), archived_petition_url(@petition), target: "_blank" %></dd>
+  <% if @petition.visible? %>
+    <dt>Link to petition</dt>
+    <dd><%= link_to archived_petition_path(@petition), archived_petition_url(@petition), target: "_blank" %></dd>
+  <% end %>
 
   <dt>ID</dt>
   <dd><%= @petition.id %></dd>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:title) do %>
-<title>The page you're looking for doesn’t exist (error 404)</title>
+<title>The page you’re looking for doesn’t exist (error 404)</title>
 <% end %>
 
 <h1>
   <span class="heading-secondary">Error 404</span>
-  The page you're looking for doesn't exist
+  The page you’re looking for doesn't exist
 </h1>
 <p>If you typed a web address, check it was correct</p>
 <p>

--- a/app/views/errors/410.html.erb
+++ b/app/views/errors/410.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) do %>
+<title>The page you’re looking for is no longer available (error 410)</title>
+<% end %>
+
+<h1>
+  <span class="heading-secondary">Error 410</span>
+  The page you’re looking for is no longer available
+</h1>
+<p>
+  You can <a href="/" title="Petitions home">go back to the homepage</a> or
+  <a href="/petitions" title="All petitions">search for a petition</a>
+</p>

--- a/app/views/errors/422.html.erb
+++ b/app/views/errors/422.html.erb
@@ -4,9 +4,9 @@
 
 <h1>
   <span class="heading-secondary">Error 422</span>
-  We couldn't do that, sorry
+  We couldn’t do that, sorry
 </h1>
-<p>We couldn't do what you wanted to do. Please try again.</p>
+<p>We couldn’t do what you wanted to do. Please try again.</p>
 <p>
   You can <a href="/" title="Petitions home">go back to the homepage</a> or
   <a href="/petitions" title="All petitions">search for a petition</a>

--- a/app/views/errors/503.html.erb
+++ b/app/views/errors/503.html.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <h1>Petitions is down for maintenance</h1>
-<p>We know about it and we're working on it.</p>
+<p>We know about it and we’re working on it.</p>
 <p>Please try again later.</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,6 +62,7 @@ module Epets
 
     # Add additional exceptions to the rescue responses
     config.action_dispatch.rescue_responses.merge!(
+      'Site::PetitionRemoved' => :gone,
       'Site::ServiceUnavailable' => :service_unavailable,
       'BulkVerification::InvalidBulkRequest' => :bad_request
     )

--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -27,7 +27,7 @@ namespace :errors do
 
     lookup_context = ActionView::LookupContext.new('app/views')
 
-    %w[400 403 404 406 422 500 503].each do |status|
+    %w[400 403 404 406 410 422 500 503].each do |status|
       context = context_class.new(lookup_context, { status: status }, controller_class.new)
       File.open(Rails.public_path.join("#{status}.html"), 'wb') do |f|
         f.write context.render(template: "errors/#{status}", layout: 'errors/layout')

--- a/spec/controllers/archived/petitions_controller_spec.rb
+++ b/spec/controllers/archived/petitions_controller_spec.rb
@@ -166,6 +166,16 @@ RSpec.describe Archived::PetitionsController, type: :controller do
       end
     end
 
+    context "when the petition is hidden after opening" do
+      let(:petition) { FactoryBot.create(:archived_petition, :hidden, open_at: 3.years.ago) }
+
+      it "raises a Site::PetitionRemoved exception" do
+        expect {
+          get :show, params: { id: petition.id }
+        }.to raise_error(Site::PetitionRemoved)
+      end
+    end
+
     context "when the petition is stopped" do
       let!(:petition) { FactoryBot.create(:archived_petition, :stopped) }
 

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -346,6 +346,16 @@ RSpec.describe PetitionsController, type: :controller do
         end
       end
     end
+
+    context "when the petition is hidden after opening" do
+      let(:petition) { FactoryBot.create(:hidden_petition, open_at: 1.month.ago) }
+
+      it "raises a Site::PetitionRemoved exception" do
+        expect {
+          get :show, params: { id: petition.id }
+        }.to raise_error(Site::PetitionRemoved)
+      end
+    end
   end
 
   describe "GET /petitions" do

--- a/spec/requests/removed_petitions_spec.rb
+++ b/spec/requests/removed_petitions_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Removed petitions", type: :request, show_exceptions: true do
+  context "When requesting a petition that has been hidden after opening" do
+    let(:petition) { FactoryBot.create(:hidden_petition, open_at: 1.month.ago) }
+
+    it "returns a 410 Gone response" do
+      get "/petitions/#{petition.id}"
+      expect(response).to have_http_status(:gone)
+    end
+  end
+
+  context "When requesting an archived petition that has been hidden after opening" do
+    let(:petition) { FactoryBot.create(:archived_petition, :hidden, open_at: 3.years.ago) }
+
+    it "returns a 410 Gone response" do
+      get "/archived/petitions/#{petition.id}"
+      expect(response).to have_http_status(:gone)
+    end
+  end
+end

--- a/spec/tasks/errors_spec.rb
+++ b/spec/tasks/errors_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "errors:precompile", type: :task do
     expect(public_files).to include('403.html')
     expect(public_files).to include('404.html')
     expect(public_files).to include('406.html')
+    expect(public_files).to include('410.html')
     expect(public_files).to include('422.html')
     expect(public_files).to include('500.html')
     expect(public_files).to include('503.html')


### PR DESCRIPTION
Sometimes petitions have been removed at the request of the petitioner so we should return a 410 Gone for these so API consumers know not to re-request the data in the future.