### PR TITLE
Use correct task name for constituency refresh

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,7 @@
 env :PATH, ENV['PATH']
 
 every :day, at: '1.45am' do
-  rake "epets:constituencies:fetch", output: nil
+  rake "epets:constituencies:refresh", output: nil
 end
 
 every :day, at: '2.30am' do


### PR DESCRIPTION
This prevented the party being updated correctly after the by-election for Amersham and Chesham so fix it ahead of the Batley and Spen one.