### PR TITLE
Customise Link header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,16 @@
     <%= cache_for :head do %>
       <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
+      <%= preload_link_tag 'application.css', nopush: true %>
+      <%= preload_link_tag 'application.js', nopush: true %>
+
+      <% if open_petition_page? %>
+        <%= preload_link_tag 'auto-updater.js', nopush: true %>
+      <% end %>
+      <% if create_petition_page? %>
+        <%= preload_link_tag 'character-counter.js', nopush: true %>
+      <% end %>
+
       <!--[if gt IE 8]><!--><%= stylesheet_link_tag 'application' %><!--<![endif]-->
       <!--[if IE 7]><%= stylesheet_link_tag 'application-ie7' %><![endif]-->
       <!--[if IE 8]><%= stylesheet_link_tag 'application-ie8' %><![endif]-->

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,9 @@ module Epets
     # Configure Active Job queue adapter
     config.active_job.queue_adapter = :delayed_job
 
+    # Customise the preload link header
+    config.action_view.preload_links_header = false
+
     # Remove the error wrapper from around the form element
     config.action_view.field_error_proc = -> (html_tag, instance) { html_tag }
 

--- a/config/fragments.yml
+++ b/config/fragments.yml
@@ -1,5 +1,7 @@
 head:
   keys:
+    - :create_petition_page
+    - :open_petition_page
     - :site_updated_at
     - :url
   options:

--- a/spec/requests/link_header_spec.rb
+++ b/spec/requests/link_header_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe 'Link header', type: :request do
+  let(:link_header) { response.headers['Link'] }
+  let(:status) { response.status }
+
+  context "when visiting the home page" do
+    before do
+      get "/"
+    end
+
+    it "sets the correct Link header" do
+      expect(status).to eq(200)
+      expect(link_header).to be_present
+      expect(link_header).to include("</assets/application.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).to include("</assets/application.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/application-ie7.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/application-ie8.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/ie.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/details.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/auto-updater.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/character-counter.js>; rel=preload; as=script; type=text/javascript; nopush")
+    end
+  end
+
+  context "when visiting the help page" do
+    before do
+      get "/help"
+    end
+
+    it "sets the correct Link header" do
+      expect(status).to eq(200)
+      expect(link_header).to be_present
+      expect(link_header).to include("</assets/application.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).to include("</assets/application.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/application-ie7.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/application-ie8.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/ie.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/details.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/auto-updater.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/character-counter.js>; rel=preload; as=script; type=text/javascript; nopush")
+    end
+  end
+
+  context "when visiting the check petition page" do
+    before do
+      get "/petitions/check"
+    end
+
+    it "sets the correct Link header" do
+      expect(status).to eq(200)
+      expect(link_header).to be_present
+      expect(link_header).to include("</assets/application.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).to include("</assets/application.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/application-ie7.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/application-ie8.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/ie.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/details.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/auto-updater.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).to include("</assets/character-counter.js>; rel=preload; as=script; type=text/javascript; nopush")
+    end
+  end
+
+  context "when visiting an open petition page" do
+    let!(:petition) { FactoryBot.create(:open_petition) }
+
+    before do
+      get "/petitions/#{petition.id}"
+    end
+
+    it "sets the correct Link header" do
+      expect(status).to eq(200)
+      expect(link_header).to be_present
+      expect(link_header).to include("</assets/application.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).to include("</assets/application.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/application-ie7.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/application-ie8.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/ie.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/details.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).to include("</assets/auto-updater.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/character-counter.js>; rel=preload; as=script; type=text/javascript; nopush")
+    end
+  end
+
+  context "when visiting a closed petition page" do
+    let!(:petition) { FactoryBot.create(:closed_petition) }
+
+    before do
+      get "/petitions/#{petition.id}"
+    end
+
+    it "sets the correct Link header" do
+      expect(status).to eq(200)
+      expect(link_header).to be_present
+      expect(link_header).to include("</assets/application.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).to include("</assets/application.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/application-ie7.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/application-ie8.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/ie.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/details.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/auto-updater.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/character-counter.js>; rel=preload; as=script; type=text/javascript; nopush")
+    end
+  end
+
+  context "when visiting an archived petition page" do
+    let!(:petition) { FactoryBot.create(:archived_petition) }
+
+    before do
+      get "/archived/petitions/#{petition.id}"
+    end
+
+    it "sets the correct Link header" do
+      expect(status).to eq(200)
+      expect(link_header).to be_present
+      expect(link_header).to include("</assets/application.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).to include("</assets/application.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/application-ie7.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/application-ie8.css>; rel=preload; as=style; type=text/css; nopush")
+      expect(link_header).not_to include("</assets/ie.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/details.js>; rel=preload; as=script; type=text/javascript; nopush")
+
+      expect(link_header).not_to include("</assets/auto-updater.js>; rel=preload; as=script; type=text/javascript; nopush")
+      expect(link_header).not_to include("</assets/character-counter.js>; rel=preload; as=script; type=text/javascript; nopush")
+    end
+  end
+end


### PR DESCRIPTION
By default Rails 6.1 adds all assets to the Link header but there's no point doing that for the legacy IE assets since it doesn't support it.