### PR TITLE
Ignore Rack parameter parsing errors

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -29,6 +29,8 @@ default: &defaults
     - ActionController::UnknownFormat
     - ActionController::UnknownHttpMethod
     - ActiveRecord::RecordNotFound
+    - Rack::QueryParser::ParameterTypeError
+    - Rack::QueryParser::InvalidParameterError
     - Site::PetitionRemoved
     - Site::ServiceUnavailable
 


### PR DESCRIPTION
These return a 400 Bad Request so there's no need to log them in Appsignal.