### PR TITLE
Redirect to petition page if token is invalid

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -133,19 +133,19 @@ class SignaturesController < ApplicationController
 
   def verify_token
     unless @signature.perishable_token == token_param
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with token: #{token_param.inspect}"
+      redirect_to token_failure_url
     end
   end
 
   def verify_signed_token
     unless @signature.signed_token == fetch_signed_token
-      redirect_to signed_token_failure_url
+      redirect_to token_failure_url
     end
   end
 
   def verify_unsubscribe_token
     unless @signature.unsubscribe_token == token_param
-      raise ActiveRecord::RecordNotFound, "Unable to find Signature with unsubscribe token: #{token_param.inspect}"
+      redirect_to token_failure_url
     end
   end
 
@@ -174,7 +174,7 @@ class SignaturesController < ApplicationController
     thank_you_petition_signatures_url(@petition)
   end
 
-  def signed_token_failure_url
+  def token_failure_url
     petition_url(@petition)
   end
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -73,7 +73,7 @@ class SponsorsController < SignaturesController
     thank_you_petition_sponsors_url(@petition, token: @petition.sponsor_token)
   end
 
-  def signed_token_failure_url
+  def token_failure_url
     moderation_info_petition_url(@petition)
   end
 

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -647,10 +647,9 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :verify, params: { id: signature.id, token: "token" }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+      it "redirects to the petition page" do
+        get :verify, params: { id: signature.id, token: "token" }
+        expect(response).to redirect_to("/petitions/#{petition.id}")
       end
     end
 
@@ -1075,10 +1074,9 @@ RSpec.describe SignaturesController, type: :controller do
       let(:petition) { FactoryBot.create(:open_petition) }
       let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :unsubscribe, params: { id: signature.id, token: "token" }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+      it "redirects to the petition page" do
+        get :unsubscribe, params: { id: signature.id, token: "token" }
+        expect(response).to redirect_to("/petitions/#{petition.id}")
       end
     end
 

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -666,10 +666,9 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :verify, params: { id: signature.id, token: "token" }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+      it "redirects to the petition moderation info page" do
+        get :verify, params: { id: signature.id, token: "token" }
+        expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
       end
     end
 

--- a/spec/requests/missing_tokens_spec.rb
+++ b/spec/requests/missing_tokens_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "missing a 'token'", type: :request, show_exceptions: true do
       get "/signatures/#{signature.id}/verify"
     end
 
-    it "returns 404 Not Found" do
-      expect(response).to have_http_status(:not_found)
+    it "redirects to the petition page" do
+      expect(response).to redirect_to("/petitions/#{petition.id}")
     end
   end
 
@@ -34,8 +34,8 @@ RSpec.describe "missing a 'token'", type: :request, show_exceptions: true do
       get "/signatures/#{signature.id}/unsubscribe"
     end
 
-    it "returns 404 Not Found" do
-      expect(response).to have_http_status(:not_found)
+    it "redirects to the petition page" do
+      expect(response).to redirect_to("/petitions/#{petition.id}")
     end
   end
 end


### PR DESCRIPTION
Some email services like Hotmail are following links in emails to see if they contain malware and sometimes remove any query parameters. By redirecting to the petition page the service gets a valid page and not a 404 error which could affect deliverability.