### PR TITLE
Redirect to the petition page if sponsor token is invalid

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -175,7 +175,13 @@ class SignaturesController < ApplicationController
   end
 
   def token_failure_url
-    petition_url(@petition)
+    if @petition.visible?
+      petition_url(@petition)
+    elsif @petition.collecting_sponsors?
+      gathering_support_petition_url(@petition)
+    else
+      moderation_info_petition_url(@petition)
+    end
   end
 
   def redirect_to_petition_page_if_rejected

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -28,7 +28,7 @@ class SponsorsController < SignaturesController
     end
 
     unless @petition.sponsor_token == token_param
-      raise ActiveRecord::RecordNotFound, "Unable to find Petition with sponsor token: #{token_param.inspect}"
+      redirect_to token_failure_url
     end
   end
 
@@ -71,10 +71,6 @@ class SponsorsController < SignaturesController
 
   def thank_you_url
     thank_you_petition_sponsors_url(@petition, token: @petition.sponsor_token)
-  end
-
-  def token_failure_url
-    moderation_info_petition_url(@petition)
   end
 
   def redirect_to_new_sponsor_page_if_validated

--- a/app/jobs/concerns/email_delivery.rb
+++ b/app/jobs/concerns/email_delivery.rb
@@ -1,3 +1,5 @@
+require 'net/smtp'
+
 module EmailDelivery
   # Send a single email to a recipient informing them about a petition that they have signed
   # Implemented as a custom job rather than using action mailers #deliver_later so we can do

--- a/app/jobs/email_job.rb
+++ b/app/jobs/email_job.rb
@@ -1,3 +1,5 @@
+require 'net/smtp'
+
 class EmailJob < ApplicationJob
   before_perform :set_appsignal_namespace
 

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -22,10 +22,9 @@ RSpec.describe SponsorsController, type: :controller do
     context "when the token is invalid" do
       let(:petition) { FactoryBot.create(:pending_petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :new, params: { petition_id: petition.id, token: 'token' }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
+      it "redirects to the petition gathering support page" do
+        get :new, params: { petition_id: petition.id, token: 'token' }
+        expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
       end
     end
 
@@ -149,10 +148,9 @@ RSpec.describe SponsorsController, type: :controller do
     context "when the token is invalid" do
       let(:petition) { FactoryBot.create(:pending_petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          post :confirm, params: { petition_id: petition.id, token: 'token', signature: params }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
+      it "redirects to the petition gathering support page" do
+        post :confirm, params: { petition_id: petition.id, token: 'token', signature: params }
+        expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
       end
     end
 
@@ -287,10 +285,9 @@ RSpec.describe SponsorsController, type: :controller do
     context "when the token is invalid" do
       let(:petition) { FactoryBot.create(:pending_petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          post :create, params: { petition_id: petition.id, token: 'token', signature: params }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
+      it "redirects to the petition gathering support page" do
+        post :create, params: { petition_id: petition.id, token: 'token', signature: params }
+        expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
       end
     end
 
@@ -554,10 +551,9 @@ RSpec.describe SponsorsController, type: :controller do
     context "when the token is invalid" do
       let(:petition) { FactoryBot.create(:pending_petition) }
 
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :thank_you, params: { petition_id: petition.id, token: 'token' }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
+      it "redirects to the petition gathering support page" do
+        get :thank_you, params: { petition_id: petition.id, token: 'token' }
+        expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
       end
     end
 
@@ -666,9 +662,9 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
 
-      it "redirects to the petition moderation info page" do
+      it "redirects to the petition gathering support page" do
         get :verify, params: { id: signature.id, token: "token" }
-        expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+        expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
       end
     end
 
@@ -1101,9 +1097,9 @@ RSpec.describe SponsorsController, type: :controller do
       let(:petition) { FactoryBot.create(:pending_petition) }
       let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
 
-      it "redirects to the petition moderation info page" do
+      it "redirects to the petition gathering support page" do
         get :signed, params: { id: signature.id }
-        expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+        expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
       end
     end
 
@@ -1277,8 +1273,12 @@ RSpec.describe SponsorsController, type: :controller do
             get :signed, params: { id: signature.id }
           end
 
-          it "redirects to the petition moderation info page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+          it "redirects to the correct petition page" do
+            if petition.collecting_sponsors?
+              expect(response).to redirect_to("/petitions/#{petition.id}/gathering-support")
+            else
+              expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+            end
           end
 
           context "and signature collection is paused" do


### PR DESCRIPTION
Every now and then Facebook spams the site with requests to the new sponsor url with hundreds of variants of the token. It's unclear why it's doing this and blocking the ip addresses it uses for this prevents the link sharing from working so redirect to the relevant petition page if this happens instead of returning a 404. This prevents the CloudWatch alarm for 4XX requests being triggered unnecessarily.