### PR TITLE
Allow admins to decide whether to anonymize petitions

### DIFF
--- a/app/controllers/admin/archived/petition_details_controller.rb
+++ b/app/controllers/admin/archived/petition_details_controller.rb
@@ -19,7 +19,14 @@ class Admin::Archived::PetitionDetailsController < Admin::AdminController
   end
 
   def petition_attributes
-    %i[action background additional_details committee_note special_consideration]
+    %i[
+      action
+      background
+      additional_details
+      committee_note
+      special_consideration
+      do_not_anonymize
+    ]
   end
 
   def petition_params

--- a/app/controllers/admin/petition_details_controller.rb
+++ b/app/controllers/admin/petition_details_controller.rb
@@ -21,7 +21,8 @@ class Admin::PetitionDetailsController < Admin::AdminController
   def petition_params
     params.require(:petition).permit(
       :action, :background, :additional_details, :committee_note,
-      :special_consideration, :creator_attributes => [:name, :email]
+      :special_consideration, :do_not_anonymize,
+      :creator_attributes => [:name, :email]
     )
   end
 end

--- a/app/jobs/archive_petition_job.rb
+++ b/app/jobs/archive_petition_job.rb
@@ -23,6 +23,7 @@ class ArchivePetitionJob < ApplicationJob
         p.state = petition.state
         p.debate_state = petition.debate_state
         p.special_consideration = petition.special_consideration
+        p.do_not_anonymize = petition.do_not_anonymize
         p.opened_at = petition.opened_at
         p.closed_at = petition.closed_at
         p.rejected_at = petition.rejected_at

--- a/app/views/admin/archived/petition_details/show.html.erb
+++ b/app/views/admin/archived/petition_details/show.html.erb
@@ -39,6 +39,14 @@
         <%= error_messages_for_field @petition, :special_consideration %>
       <% end %>
 
+      <%= form_row for: [f.object, :do_not_anonymize] do %>
+        <div class="multiple-choice">
+          <%= f.check_box :do_not_anonymize, tabindex: increment %>
+          <%= f.label :do_not_anonymize, 'Do not anonymize this petition' %>
+        </div>
+        <%= error_messages_for_field @petition, :do_not_anonymize %>
+      <% end %>
+
       <%= f.submit 'Save', class: 'button' %>
       <%= link_to 'Cancel', admin_archived_petition_path(@petition), class: 'button-secondary' %>
     <% end %>

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -59,6 +59,14 @@
         <%= error_messages_for_field @petition, :special_consideration %>
       <% end %>
 
+      <%= form_row for: [f.object, :do_not_anonymize] do %>
+        <div class="multiple-choice">
+          <%= f.check_box :do_not_anonymize, tabindex: increment, disabled: @petition.editing_disabled? %>
+          <%= f.label :do_not_anonymize, 'Do not anonymize this petition' %>
+        </div>
+        <%= error_messages_for_field @petition, :do_not_anonymize %>
+      <% end %>
+
       <%= f.submit 'Save', class: 'button', disabled: @petition.editing_disabled? %>
 
       <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>

--- a/db/migrate/20211105152949_add_do_not_anonymize_to_petition.rb
+++ b/db/migrate/20211105152949_add_do_not_anonymize_to_petition.rb
@@ -1,0 +1,6 @@
+class AddDoNotAnonymizeToPetition < ActiveRecord::Migration[6.1]
+  def change
+    add_column :petitions, :do_not_anonymize, :boolean
+    add_column :archived_petitions, :do_not_anonymize, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_214559) do
+ActiveRecord::Schema.define(version: 2021_11_05_152949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.datetime "anonymized_at"
     t.integer "moderated_by_id"
     t.integer "topics", default: [], null: false, array: true
+    t.boolean "do_not_anonymize"
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "index_archived_petitions_on_action", using: :gin
     t.index "to_tsvector('english'::regconfig, (background)::text)", name: "index_archived_petitions_on_background", using: :gin
     t.index "to_tsvector('english'::regconfig, additional_details)", name: "index_archived_petitions_on_additional_details", using: :gin
@@ -508,6 +509,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.integer "moderated_by_id"
     t.integer "deadline_extension", default: 0, null: false
     t.integer "topics", default: [], null: false, array: true
+    t.boolean "do_not_anonymize"
     t.index "((last_signed_at > signature_count_validated_at))", name: "index_petitions_on_validated_at_and_signed_at"
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "index_petitions_on_action", using: :gin
     t.index "to_tsvector('english'::regconfig, (background)::text)", name: "index_petitions_on_background", using: :gin

--- a/features/admin/moderator_edits_an_archived_petition.feature
+++ b/features/admin/moderator_edits_an_archived_petition.feature
@@ -1,0 +1,15 @@
+@admin
+Feature: Moderator edits an archived petition
+  As a moderator
+  I want to edit an archived petition
+
+  Scenario: Moderator edits archived petition
+    Given I am logged in as a moderator named "Ben Macintosh"
+    And I visit an archived petition with action: "We need to save our planet"
+    Then I am on the admin archived petition edit details page for "We need to save our planet"
+    And the markup should be valid
+    And I check "Do not anonymize this petition"
+    And I press "Save"
+    Then I am on the admin archived petition page for "We need to save our planet"
+    And I follow "Edit petition"
+    Then the "Do not anonymize this petition" checkbox should be checked

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -26,11 +26,14 @@ Feature: Moderator respond to petition
     Then I fill in "Action" with "We need to save our planet"
     And I fill in "Background" with "Reduce pollution"
     And I fill in "Additional details" with "Enforce Kyoto Protocol in more countries"
+    And I check "Do not anonymize this petition"
     And I press "Save"
     Then I am on the admin petition page for "We need to save our planet"
     And I should see "We need to save our planet"
     And I should see "Reduce pollution"
     And I should see "Enforce Kyoto Protocol in more countries"
+    And I follow "Edit petition"
+    Then the "Do not anonymize this petition" checkbox should be checked
 
   Scenario: Moderator edits and tries to save an invalid petition
     Given I am logged in as a moderator named "Ben Macintosh"

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -8,6 +8,11 @@ When(/^I visit a sponsored petition with action: "([^"]*)", that has background:
   visit admin_petition_url(@sponsored_petition)
 end
 
+Given(/^I visit an archived petition with action: "([^"]*)"$/) do |petition_action|
+  @archived_petition = FactoryBot.create(:archived_petition, action: petition_action)
+  visit admin_archived_petition_url(@archived_petition)
+end
+
 When(/^I reject the petition$/) do
   choose "Reject"
   select "Duplicate petition", :from => :petition_rejection_code

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -128,6 +128,12 @@ module NavigationHelpers
     when /^petition edit details page for "([^\"]*)"$/
       admin_petition_details_url(Petition.find_by(action: $1))
 
+    when /^archived petition page for "([^\"]*)"$/
+      admin_archived_petition_url(Archived::Petition.find_by(action: $1))
+
+    when /^archived petition edit details page for "([^\"]*)"$/
+      admin_archived_petition_details_url(Archived::Petition.find_by(action: $1))
+
     else
       raise "Can't find mapping from \"#{admin_page}\" to an Admin path.\n" +
         "Now, go and add a mapping in #{__FILE__}"

--- a/spec/jobs/archive_petition_job_spec.rb
+++ b/spec/jobs/archive_petition_job_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe ArchivePetitionJob, type: :job do
         opened_at: 6.months.ago,
         closed_at: 2.months.ago,
         signature_count: 1234,
+        do_not_anonymize: true,
         moderation_threshold_reached_at: 7.months.ago,
         moderation_lag: 30,
         last_signed_at: 3.months.ago,
@@ -74,6 +75,7 @@ RSpec.describe ArchivePetitionJob, type: :job do
       expect(archived_petition.opened_at).to be_usec_precise_with(petition.opened_at)
       expect(archived_petition.closed_at).to be_usec_precise_with(petition.closed_at)
       expect(archived_petition.signature_count).to eq(petition.signature_count)
+      expect(archived_petition.do_not_anonymize).to eq(petition.do_not_anonymize)
       expect(archived_petition.moderation_threshold_reached_at).to be_usec_precise_with(petition.moderation_threshold_reached_at)
       expect(archived_petition.moderation_lag).to eq(petition.moderation_lag)
       expect(archived_petition.last_signed_at).to be_usec_precise_with(petition.last_signed_at)


### PR DESCRIPTION
### What 

- Add `do_not_anonymize` to `Petition` and `Archived::Petition`
- Allow admins to edit this column, and when a Petition is archived, the value is copied over

### Why

This allows admins to decide whether petitions should be anonymized when the anonymize task is run 