### PR TITLE
Ensure correct debate state

### DIFF
--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -386,7 +386,7 @@ module Archived
       if scheduled_debate_date?
         scheduled_debate_date > Date.current ? 'scheduled' : 'debated'
       else
-        'awaiting'
+        debate_threshold_reached_at? ? 'awaiting' : 'pending'
       end
     end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -573,19 +573,24 @@ class Petition < ActiveRecord::Base
   end
 
   def decrement_signature_count!(time = Time.current)
-    updates = ""
+    updates = []
 
     if below_threshold_for_debate?
-      updates << "debate_threshold_reached_at = NULL, "
-      updates << "debate_state = 'pending', "
+      updates << "debate_threshold_reached_at = NULL"
+
+      if debate_state == 'awaiting'
+        updates << "debate_state = 'pending'"
+      end
     end
 
     if below_threshold_for_response?
-      updates << "response_threshold_reached_at = NULL, "
+      updates << "response_threshold_reached_at = NULL"
     end
 
-    updates << "signature_count = greatest(signature_count - 1, 1), "
+    updates << "signature_count = greatest(signature_count - 1, 1)"
     updates << "updated_at = :now"
+
+    updates = updates.join(", ")
 
     if update_all([updates, now: time]) > 0
       self.reload

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -995,7 +995,7 @@ class Petition < ActiveRecord::Base
     if scheduled_debate_date?
       scheduled_debate_date > Date.current ? 'scheduled' : 'debated'
     else
-      'awaiting'
+      debate_threshold_reached_at? ? 'awaiting' : 'pending'
     end
   end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -554,7 +554,10 @@ class Petition < ActiveRecord::Base
 
       if at_threshold_for_debate?
         updates << "debate_threshold_reached_at = :now"
-        updates << "debate_state = 'awaiting'"
+
+        if debate_state == 'pending'
+          updates << "debate_state = 'awaiting'"
+        end
       end
 
       updates = updates.join(", ")

--- a/spec/models/archived/petition_spec.rb
+++ b/spec/models/archived/petition_spec.rb
@@ -30,71 +30,151 @@ RSpec.describe Archived::Petition, type: :model do
 
   describe "callbacks" do
     describe "updating the scheduled debate date" do
-      context "when the debate date is changed to nil" do
-        subject(:petition) {
-          FactoryBot.create(:archived_petition,
-            scheduled_debate_date: 2.days.from_now,
-            debate_state: "scheduled"
-          )
-        }
-
-        it "sets the debate state to 'awaiting'" do
-          expect {
-            petition.update(scheduled_debate_date: nil)
-          }.to change {
-            petition.debate_state
-          }.from("scheduled").to("awaiting")
-        end
-      end
-
-      context "when the debate date is in the future" do
-        subject(:petition) {
-          FactoryBot.create(:archived_petition,
-            scheduled_debate_date: nil,
-            debate_state: "awaiting"
-          )
-        }
-
-        it "sets the debate state to 'awaiting'" do
-          expect {
-            petition.update(scheduled_debate_date: 2.days.from_now)
-          }.to change {
-            petition.debate_state
-          }.from("awaiting").to("scheduled")
-        end
-      end
-
-      context "when the debate date is in the past" do
-        subject(:petition) {
-          FactoryBot.create(:archived_petition,
-            scheduled_debate_date: nil,
-            debate_state: "awaiting"
-          )
-        }
-
-        it "sets the debate state to 'debated'" do
-          expect {
-            petition.update(scheduled_debate_date: 2.days.ago)
-          }.to change {
-            petition.debate_state
-          }.from("awaiting").to("debated")
-        end
-      end
-
-      context "when the debate date is not changed" do
-        subject(:petition) {
-          FactoryBot.create(:archived_petition,
-            scheduled_debate_date: Date.yesterday,
-            debate_state: "awaiting"
-          )
-        }
-
-        it "does not change the debate state" do
-          expect {
-            petition.update(special_consideration: true)
-          }.not_to change {
-            petition.debate_state
+      context "when the debate threshold has been reached" do
+        context "and the debate date is changed to nil" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: 6.months.ago,
+              scheduled_debate_date: 2.days.from_now,
+              debate_state: "scheduled"
+            )
           }
+
+          it "sets the debate state to 'awaiting'" do
+            expect {
+              petition.update(scheduled_debate_date: nil)
+            }.to change {
+              petition.debate_state
+            }.from("scheduled").to("awaiting")
+          end
+        end
+
+        context "and the debate date is in the future" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: 6.months.ago,
+              scheduled_debate_date: nil,
+              debate_state: "awaiting"
+            )
+          }
+
+          it "sets the debate state to 'scheduled'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.from_now)
+            }.to change {
+              petition.debate_state
+            }.from("awaiting").to("scheduled")
+          end
+        end
+
+        context "and the debate date is in the past" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: 6.months.ago,
+              scheduled_debate_date: nil,
+              debate_state: "awaiting"
+            )
+          }
+
+          it "sets the debate state to 'debated'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.ago)
+            }.to change {
+              petition.debate_state
+            }.from("awaiting").to("debated")
+          end
+        end
+
+        context "and the debate date is not changed" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: 6.months.ago,
+              scheduled_debate_date: Date.yesterday,
+              debate_state: "debated"
+            )
+          }
+
+          it "does not change the debate state" do
+            expect {
+              petition.update(special_consideration: true)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
+        end
+      end
+
+      context "when the debate threshold has not been reached" do
+        context "and the debate date is changed to nil" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: 2.days.from_now,
+              debate_state: "scheduled"
+            )
+          }
+
+          it "sets the debate state to 'awaiting'" do
+            expect {
+              petition.update(scheduled_debate_date: nil)
+            }.to change {
+              petition.debate_state
+            }.from("scheduled").to("pending")
+          end
+        end
+
+        context "and the debate date is in the future" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'scheduled'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.from_now)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("scheduled")
+          end
+        end
+
+        context "and the debate date is in the past" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'debated'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.ago)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("debated")
+          end
+        end
+
+        context "and the debate date is not changed" do
+          subject(:petition) {
+            FactoryBot.create(:archived_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: Date.yesterday,
+              debate_state: "debated"
+            )
+          }
+
+          it "does not change the debate state" do
+            expect {
+              petition.update(special_consideration: true)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
         end
       end
     end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -905,6 +905,7 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is changed to nil" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: 2.days.from_now,
             debate_state: "scheduled"
           )
@@ -922,25 +923,27 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is in the future" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
-            debate_state: "pending"
+            debate_state: "awaiting"
           )
         }
 
-        it "sets the debate state to 'awaiting'" do
+        it "sets the debate state to 'scheduled'" do
           expect {
             petition.update(scheduled_debate_date: 2.days.from_now)
           }.to change {
             petition.debate_state
-          }.from("pending").to("scheduled")
+          }.from("awaiting").to("scheduled")
         end
       end
 
       context "and the debate date is in the past" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
-            debate_state: "pending"
+            debate_state: "awaiting"
           )
         }
 
@@ -949,15 +952,16 @@ RSpec.describe Petition, type: :model do
             petition.update(scheduled_debate_date: 2.days.ago)
           }.to change {
             petition.debate_state
-          }.from("pending").to("debated")
+          }.from("awaiting").to("debated")
         end
       end
 
       context "and the debate date is not changed" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: Date.yesterday,
-            debate_state: "awaiting"
+            debate_state: "scheduled"
           )
         }
 
@@ -969,12 +973,87 @@ RSpec.describe Petition, type: :model do
           }
         end
       end
+
+      context "and has not reached the debate threshold" do
+        context "and the debate date is changed to nil" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: 2.days.from_now,
+              debate_state: "scheduled"
+            )
+          }
+
+          it "sets the debate state to 'pending'" do
+            expect {
+              petition.update(scheduled_debate_date: nil)
+            }.to change {
+              petition.debate_state
+            }.from("scheduled").to("pending")
+          end
+        end
+
+        context "and the debate date is in the future" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'scheduled'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.from_now)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("scheduled")
+          end
+        end
+
+        context "and the debate date is in the past" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'debated'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.ago)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("debated")
+          end
+        end
+
+        context "and the debate date is not changed" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: Date.yesterday,
+              debate_state: "debated"
+            )
+          }
+
+          it "does not change the debate state" do
+            expect {
+              petition.update(open_at: 5.days.ago)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
+        end
+      end
     end
 
     context "when the petition is closed" do
       context "and the debate date is changed to nil" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: 2.days.from_now,
             debate_state: "scheduled"
           )
@@ -992,6 +1071,7 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is in the future" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
             debate_state: "awaiting"
           )
@@ -1009,6 +1089,7 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is in the past" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
             debate_state: "awaiting"
           )
@@ -1026,8 +1107,9 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is not changed" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: Date.yesterday,
-            debate_state: "awaiting"
+            debate_state: "debated"
           )
         }
 
@@ -1037,6 +1119,80 @@ RSpec.describe Petition, type: :model do
           }.not_to change {
             petition.debate_state
           }
+        end
+      end
+
+      context "and has not reached the debate threshold" do
+        context "and the debate date is changed to nil" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: 2.days.from_now,
+              debate_state: "scheduled"
+            )
+          }
+
+          it "sets the debate state to 'pending'" do
+            expect {
+              petition.update(scheduled_debate_date: nil)
+            }.to change {
+              petition.debate_state
+            }.from("scheduled").to("pending")
+          end
+        end
+
+        context "and the debate date is in the future" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'scheduled'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.from_now)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("scheduled")
+          end
+        end
+
+        context "and the debate date is in the past" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'debated'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.ago)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("debated")
+          end
+        end
+
+        context "and the debate date is not changed" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: Date.yesterday,
+              debate_state: "debated"
+            )
+          }
+
+          it "does not change the debate state" do
+            expect {
+              petition.update(open_at: 5.days.ago)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
If a petition has been scheduled for a debate, has been debated, or a decision to not debate it has been taken then don't reset the `debate_state` column to an incorrect value.