### PR TITLE
Add models, mailers and jobs for petition mailshots

### DIFF
--- a/app/jobs/archive_petition_job.rb
+++ b/app/jobs/archive_petition_job.rb
@@ -45,6 +45,7 @@ class ArchivePetitionJob < ApplicationJob
           p.email_requested_for_debate_scheduled_at = receipt.debate_scheduled
           p.email_requested_for_debate_outcome_at = receipt.debate_outcome
           p.email_requested_for_petition_email_at = receipt.petition_email
+          p.email_requested_for_petition_mailshot_at = receipt.petition_mailshot
         end
 
         if note = petition.note
@@ -71,6 +72,16 @@ class ArchivePetitionJob < ApplicationJob
             e.sent_by = email.sent_by
             e.created_at = email.created_at
             e.updated_at = email.updated_at
+          end
+        end
+
+        petition.mailshots.each do |mailshot|
+          p.mailshots.build do |m|
+            m.subject = mailshot.subject
+            m.body = mailshot.body
+            m.sent_by = mailshot.sent_by
+            m.created_at = mailshot.created_at
+            m.updated_at = mailshot.updated_at
           end
         end
 

--- a/app/jobs/archive_signatures_job.rb
+++ b/app/jobs/archive_signatures_job.rb
@@ -37,6 +37,7 @@ class ArchiveSignaturesJob < ApplicationJob
                 s.debate_scheduled_email_at = signature.debate_scheduled_email_at
                 s.debate_outcome_email_at = signature.debate_outcome_email_at
                 s.petition_email_at = signature.petition_email_at
+                s.petition_mailshot_at = signature.petition_mailshot_at
                 s.creator = signature.creator?
                 s.sponsor = signature.sponsor?
                 s.created_at = signature.created_at

--- a/app/jobs/archived/deliver_petition_mailshot_job.rb
+++ b/app/jobs/archived/deliver_petition_mailshot_job.rb
@@ -1,0 +1,20 @@
+module Archived
+  class DeliverPetitionMailshotJob < ApplicationJob
+    include EmailDelivery
+
+    attr_reader :mailshot
+
+    def perform(**args)
+      @mailshot = args[:mailshot]
+      super
+    end
+
+    def create_email
+      if signature.creator?
+        mailer.mailshot_for_creator petition, signature, mailshot
+      else
+        mailer.mailshot_for_signer petition, signature, mailshot
+      end
+    end
+  end
+end

--- a/app/jobs/archived/email_constituencies_job.rb
+++ b/app/jobs/archived/email_constituencies_job.rb
@@ -1,0 +1,18 @@
+module Archived
+  class EmailConstituenciesJob < ApplicationJob
+    queue_as :high_priority
+
+    def perform(mailshot, constituency_ids, requested_at: nil)
+      requested_at ||= Time.current
+
+      constituency_ids.each do |constituency_id|
+        Archived::EmailConstituencyJob.run_later_tonight(
+          petition: mailshot.petition,
+          mailshot: mailshot,
+          scope: { constituency_id: constituency_id },
+          requested_at: requested_at
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/archived/email_constituency_job.rb
+++ b/app/jobs/archived/email_constituency_job.rb
@@ -1,0 +1,34 @@
+module Archived
+  class EmailConstituencyJob < ApplicationJob
+    include EmailAllPetitionSignatories
+
+    self.email_delivery_job_class = Archived::DeliverPetitionMailshotJob
+    self.timestamp_name = 'petition_mailshot'
+
+    attr_reader :mailshot
+
+    # It's likely that the email got deleted so we just log the error and move on
+    rescue_from ActiveJob::DeserializationError do |exception|
+      log_exception(exception)
+    end
+
+    def perform(**args)
+      @mailshot = args[:mailshot]
+      super
+    end
+
+    private
+
+    def mailer_arguments(signature)
+      super.merge(mailshot: mailshot)
+    end
+
+    def log_exception(exception)
+      logger.info(log_message(exception))
+    end
+
+    def log_message(exception)
+      "#{exception.class.name} while running #{self.class.name}"
+    end
+  end
+end

--- a/app/jobs/deliver_petition_mailshot_job.rb
+++ b/app/jobs/deliver_petition_mailshot_job.rb
@@ -1,0 +1,18 @@
+class DeliverPetitionMailshotJob < ApplicationJob
+  include EmailDelivery
+
+  attr_reader :mailshot
+
+  def perform(**args)
+    @mailshot = args[:mailshot]
+    super
+  end
+
+  def create_email
+    if signature.creator?
+      mailer.mailshot_for_creator petition, signature, mailshot
+    else
+      mailer.mailshot_for_signer petition, signature, mailshot
+    end
+  end
+end

--- a/app/jobs/email_constituencies_job.rb
+++ b/app/jobs/email_constituencies_job.rb
@@ -1,0 +1,16 @@
+class EmailConstituenciesJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform(mailshot, constituency_ids, requested_at: nil)
+    requested_at ||= Time.current
+
+    constituency_ids.each do |constituency_id|
+      EmailConstituencyJob.run_later_tonight(
+        petition: mailshot.petition,
+        mailshot: mailshot,
+        scope: { constituency_id: constituency_id },
+        requested_at: requested_at
+      )
+    end
+  end
+end

--- a/app/jobs/email_constituency_job.rb
+++ b/app/jobs/email_constituency_job.rb
@@ -1,0 +1,32 @@
+class EmailConstituencyJob < ApplicationJob
+  include EmailAllPetitionSignatories
+
+  self.email_delivery_job_class = DeliverPetitionMailshotJob
+  self.timestamp_name = 'petition_mailshot'
+
+  attr_reader :mailshot
+
+  # It's likely that the email got deleted so we just log the error and move on
+  rescue_from ActiveJob::DeserializationError do |exception|
+    log_exception(exception)
+  end
+
+  def perform(**args)
+    @mailshot = args[:mailshot]
+    super
+  end
+
+  private
+
+  def mailer_arguments(signature)
+    super.merge(mailshot: mailshot)
+  end
+
+  def log_exception(exception)
+    logger.info(log_message(exception))
+  end
+
+  def log_message(exception)
+    "#{exception.class.name} while running #{self.class.name}"
+  end
+end

--- a/app/mailers/archived/petition_mailer.rb
+++ b/app/mailers/archived/petition_mailer.rb
@@ -12,8 +12,25 @@ module Archived
 
     def email_creator(petition, signature, email)
       @petition, @signature, @email = petition, signature, email
+
       mail to: @signature.email,
         subject: subject_for(:email_creator),
+        list_unsubscribe: unsubscribe_url
+    end
+
+    def mailshot_for_signer(petition, signature, mailshot)
+      @petition, @signature, @mailshot = petition, signature, mailshot
+
+      mail to: @signature.email,
+        subject: subject_for(:mailshot_for_signer),
+        list_unsubscribe: unsubscribe_url
+    end
+
+    def mailshot_for_creator(petition, signature, mailshot)
+      @petition, @signature, @mailshot = petition, signature, mailshot
+
+      mail to: @signature.email,
+        subject: subject_for(:mailshot_for_creator),
         list_unsubscribe: unsubscribe_url
     end
 
@@ -96,6 +113,10 @@ module Archived
 
         if defined?(@email)
           options[:subject] = @email.subject
+        end
+
+        if defined?(@mailshot)
+          options[:subject] = @mailshot.subject
         end
       end
     end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -27,8 +27,25 @@ class PetitionMailer < ApplicationMailer
 
   def email_creator(petition, signature, email)
     @petition, @signature, @email = petition, signature, email
+
     mail to: @signature.email,
       subject: subject_for(:email_creator),
+      list_unsubscribe: unsubscribe_url
+  end
+
+  def mailshot_for_signer(petition, signature, mailshot)
+    @petition, @signature, @mailshot = petition, signature, mailshot
+
+    mail to: @signature.email,
+      subject: subject_for(:mailshot_for_signer),
+      list_unsubscribe: unsubscribe_url
+  end
+
+  def mailshot_for_creator(petition, signature, mailshot)
+    @petition, @signature, @mailshot = petition, signature, mailshot
+
+    mail to: @signature.email,
+      subject: subject_for(:mailshot_for_creator),
       list_unsubscribe: unsubscribe_url
   end
 
@@ -187,6 +204,10 @@ class PetitionMailer < ApplicationMailer
 
       if defined?(@email)
         options[:subject] = @email.subject
+      end
+
+      if defined?(@mailshot)
+        options[:subject] = @mailshot.subject
       end
 
       if defined?(@subject)

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -26,7 +26,8 @@ module Archived
     has_one :note, dependent: :destroy
     has_one :rejection, dependent: :destroy
 
-    has_many :emails, :dependent => :destroy
+    has_many :emails, dependent: :destroy
+    has_many :mailshots, dependent: :destroy
     has_many :signatures
     has_many :sponsors, -> { sponsors }, class_name: "Signature"
 
@@ -340,11 +341,11 @@ module Archived
       update_column("email_requested_for_#{name}_at", to)
     end
 
-    def signatures_to_email_for(name)
+    def signatures_to_email_for(name, scope = nil)
       if timestamp = get_email_requested_at_for(name)
-        signatures.need_emailing_for(name, since: timestamp)
+        signatures.need_emailing_for(name, since: timestamp, scope: scope)
       else
-        raise ArgumentError, "The #{name} email has not been requested for petition #{id}"
+        raise ArgumentError, "The #{name} email has not been requested for archived petition #{id}"
       end
     end
 

--- a/app/models/archived/petition/mailshot.rb
+++ b/app/models/archived/petition/mailshot.rb
@@ -1,0 +1,24 @@
+require_dependency 'archived'
+
+module Archived
+  class Petition < ActiveRecord::Base
+    class Mailshot < ActiveRecord::Base
+      belongs_to :petition, touch: true
+
+      validates :petition, presence: true
+      validates :subject, presence: true, length: { maximum: 100 }
+      validates :body, presence: true, length: { maximum: 10000 }
+
+      class << self
+        def default_scope
+          order(:created_at)
+        end
+      end
+
+      def send_preview(name: nil, email: nil)
+        signature = FeedbackSignature.new(petition, name, email)
+        Archived::PetitionMailer.mailshot_for_signer(petition, signature, self).deliver_now
+      end
+    end
+  end
+end

--- a/app/models/archived/signature.rb
+++ b/app/models/archived/signature.rb
@@ -22,7 +22,8 @@ module Archived
       'government_response' => :government_response_email_at,
       'debate_scheduled'    => :debate_scheduled_email_at,
       'debate_outcome'      => :debate_outcome_email_at,
-      'petition_email'      => :petition_email_at
+      'petition_email'      => :petition_email_at,
+      'petition_mailshot'   => :petition_mailshot_at
     }
 
     belongs_to :petition
@@ -99,8 +100,8 @@ module Archived
         where(column.eq(nil).or(column.lt(since)))
       end
 
-      def need_emailing_for(timestamp, since:)
-        validated.subscribed.for_timestamp(timestamp, since: since)
+      def need_emailing_for(timestamp, since:, scope: nil)
+        validated.subscribed.where(scope).for_timestamp(timestamp, since: since)
       end
 
       def subscribed

--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -61,6 +61,22 @@ class Constituency < ActiveRecord::Base
       end
     end
 
+    def english
+      where(arel_table[:ons_code].matches('E%'))
+    end
+
+    def northern_irish
+      where(arel_table[:ons_code].matches('N%'))
+    end
+
+    def scottish
+      where(arel_table[:ons_code].matches('S%'))
+    end
+
+    def welsh
+      where(arel_table[:ons_code].matches('W%'))
+    end
+
     def query
       ApiQuery.new
     end

--- a/app/models/feedback_signature.rb
+++ b/app/models/feedback_signature.rb
@@ -1,10 +1,10 @@
-FeedbackSignature = Struct.new(:petition) do
+FeedbackSignature = Struct.new(:petition, :name, :email) do
   def name
-    'Petitions team'
+    self[:name] || 'Petitions team'
   end
 
   def email
-    rfc2822.address
+    self[:email] || rfc2822.address
   end
 
   def unsubscribe_token

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -101,6 +101,7 @@ class Petition < ActiveRecord::Base
   has_many :country_petition_journals, dependent: :destroy
   has_many :constituency_petition_journals, dependent: :destroy
   has_many :emails, dependent: :destroy
+  has_many :mailshots, dependent: :destroy
   has_many :invalidations
   has_many :trending_ips, dependent: :delete_all
   has_many :trending_domains, dependent: :delete_all
@@ -977,10 +978,12 @@ class Petition < ActiveRecord::Base
     email_requested_receipt!.set(name, to)
   end
 
-  def signatures_to_email_for(name)
-    timestamp = get_email_requested_at_for(name)
-    raise ArgumentError if timestamp.nil?
-    signatures.need_emailing_for(name, since: timestamp)
+  def signatures_to_email_for(name, scope = nil)
+    if timestamp = get_email_requested_at_for(name)
+      signatures.need_emailing_for(name, since: timestamp, scope: scope)
+    else
+      raise ArgumentError, "The #{name} email has not been requested for petition #{id}"
+    end
   end
 
   def awaiting_debate?

--- a/app/models/petition/mailshot.rb
+++ b/app/models/petition/mailshot.rb
@@ -1,0 +1,20 @@
+class Petition < ActiveRecord::Base
+  class Mailshot < ActiveRecord::Base
+    belongs_to :petition, touch: true
+
+    validates :petition, presence: true
+    validates :subject, presence: true, length: { maximum: 100 }
+    validates :body, presence: true, length: { maximum: 6000 }
+
+    class << self
+      def default_scope
+        order(:created_at)
+      end
+    end
+
+    def send_preview(name: nil, email: nil)
+      signature = FeedbackSignature.new(petition, name, email)
+      PetitionMailer.mailshot_for_signer(petition, signature, self).deliver_now
+    end
+  end
+end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -28,7 +28,8 @@ class Signature < ActiveRecord::Base
     'government_response' => :government_response_email_at,
     'debate_scheduled'    => :debate_scheduled_email_at,
     'debate_outcome'      => :debate_outcome_email_at,
-    'petition_email'      => :petition_email_at
+    'petition_email'      => :petition_email_at,
+    'petition_mailshot'   => :petition_mailshot_at
   }
 
   belongs_to :petition
@@ -194,8 +195,8 @@ class Signature < ActiveRecord::Base
       end
     end
 
-    def need_emailing_for(timestamp, since:)
-      validated.subscribed.for_timestamp(timestamp, since: since)
+    def need_emailing_for(timestamp, since:, scope: nil)
+      validated.subscribed.where(scope).for_timestamp(timestamp, since: since)
     end
 
     def open_at_dissolution

--- a/app/views/archived/petition_mailer/mailshot_for_creator.html.erb
+++ b/app/views/archived/petition_mailer/mailshot_for_creator.html.erb
@@ -1,0 +1,18 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently created the petition “<%= @petition.action %>”:<br />
+<%= link_to nil, archived_petition_url(@petition) %></p>
+
+<%= markdown_to_html(@mailshot.body) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/mailshot_for_creator.text.erb
+++ b/app/views/archived/petition_mailer/mailshot_for_creator.text.erb
@@ -1,0 +1,18 @@
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+You recently created the petition “<%= @petition.action %>”:
+<%= archived_petition_url(@petition) %>
+
+<%= markdown_to_text(@mailshot.body) %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/archived/petition_mailer/mailshot_for_signer.html.erb
+++ b/app/views/archived/petition_mailer/mailshot_for_signer.html.erb
@@ -1,0 +1,18 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently signed the petition “<%= @petition.action %>”:<br />
+<%= link_to nil, archived_petition_url(@petition) %></p>
+
+<%= markdown_to_html(@mailshot.body) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/archived/petition_mailer/mailshot_for_signer.text.erb
+++ b/app/views/archived/petition_mailer/mailshot_for_signer.text.erb
@@ -1,0 +1,18 @@
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+You recently signed the petition “<%= @petition.action %>”:
+<%= archived_petition_url(@petition) %>
+
+<%= markdown_to_text(@mailshot.body) %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_archived_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/mailshot_for_creator.html.erb
+++ b/app/views/petition_mailer/mailshot_for_creator.html.erb
@@ -1,0 +1,18 @@
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently created the petition “<%= @petition.action %>”:<br />
+<%= link_to nil, petition_url(@petition) %></p>
+
+<%= markdown_to_html(@mailshot.body) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you created this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/mailshot_for_creator.text.erb
+++ b/app/views/petition_mailer/mailshot_for_creator.text.erb
@@ -1,0 +1,18 @@
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+You recently created the petition “<%= @petition.action %>”:
+<%= petition_url(@petition) %>
+
+<%= markdown_to_text(@mailshot.body) %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you created this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/app/views/petition_mailer/mailshot_for_signer.html.erb
+++ b/app/views/petition_mailer/mailshot_for_signer.html.erb
@@ -1,0 +1,18 @@
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>
+<hr>
+
+<p>Dear <%= @signature.name %>,</p>
+
+<p>You recently signed the petition “<%= @petition.action %>”:<br />
+<%= link_to nil, petition_url(@petition) %></p>
+
+<%= markdown_to_html(@mailshot.body) %>
+
+<p>Thanks,<br />
+<%= t("petitions.emails.signoff_prefix") %><br />
+<%= t("petitions.emails.signoff_suffix") %></p>
+
+<hr>
+<p><small>You’re receiving this email because you signed this petition: “<%= @petition.action %>”.</small></p>
+<p><small>To unsubscribe from getting emails about this petition: <%= link_to nil, unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %></small></p>

--- a/app/views/petition_mailer/mailshot_for_signer.text.erb
+++ b/app/views/petition_mailer/mailshot_for_signer.text.erb
@@ -1,0 +1,18 @@
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>
+--
+
+Dear <%= @signature.name %>,
+
+You recently signed the petition “<%= @petition.action %>”:
+<%= petition_url(@petition) %>
+
+<%= markdown_to_text(@mailshot.body) %>
+
+Thanks,
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+--
+You’re receiving this email because you signed this petition: “<%= @petition.action %>”.
+To unsubscribe from getting emails about this petition: <%= unsubscribe_signature_url(@signature, token: @signature.unsubscribe_token) %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -139,6 +139,8 @@ en-GB:
           Please confirm your email address
         email_duplicate_signatures: |-
           Duplicate signature of petition
+        mailshot_for_signer: |-
+          %{subject}
         notify_signer_of_positive_debate_outcome: |-
           Parliament debated “%{action}”
         notify_signer_of_negative_debate_outcome: |-
@@ -150,6 +152,8 @@ en-GB:
 
         # Emails to people who create petitions
         email_creator: |-
+          %{subject}
+        mailshot_for_creator: |-
           %{subject}
         notify_creator_of_positive_debate_outcome: |-
           Parliament debated “%{action}”

--- a/db/migrate/20220131153014_create_petition_mailshot.rb
+++ b/db/migrate/20220131153014_create_petition_mailshot.rb
@@ -1,0 +1,19 @@
+class CreatePetitionMailshot < ActiveRecord::Migration[6.1]
+  def change
+    create_table :archived_petition_mailshots, id: :serial do |t|
+      t.belongs_to :petition, index: true, foreign_key: { to_table: :archived_petitions }
+      t.string "subject", null: false
+      t.text "body"
+      t.string "sent_by"
+      t.timestamps
+    end
+
+    create_table :petition_mailshots, id: :serial do |t|
+      t.belongs_to :petition, index: true, foreign_key: { to_table: :petitions }
+      t.string "subject", null: false
+      t.text "body"
+      t.string "sent_by"
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220131160157_add_petition_mailshot_timestamps.rb
+++ b/db/migrate/20220131160157_add_petition_mailshot_timestamps.rb
@@ -1,0 +1,37 @@
+class AddPetitionMailshotTimestamps < ActiveRecord::Migration[6.1]
+  def up
+    unless column_exists?(:email_requested_receipts, :petition_mailshot)
+      add_column :email_requested_receipts, :petition_mailshot, :datetime
+    end
+
+    unless column_exists?(:archived_petitions, :email_requested_for_petition_mailshot_at)
+      add_column :archived_petitions, :email_requested_for_petition_mailshot_at, :datetime
+    end
+
+    unless column_exists?(:archived_signatures, :petition_mailshot_at)
+      add_column :archived_signatures, :petition_mailshot_at, :datetime
+    end
+
+    unless column_exists?(:signatures, :petition_mailshot_at)
+      add_column :signatures, :petition_mailshot_at, :datetime
+    end
+  end
+
+  def down
+    if column_exists?(:email_requested_receipts, :petition_mailshot)
+      remove_column :email_requested_receipts, :petition_mailshot, :datetime
+    end
+
+    if column_exists?(:archived_petitions, :email_requested_for_petition_mailshot_at)
+      remove_column :archived_petitions, :email_requested_for_petition_mailshot_at, :datetime
+    end
+
+    if column_exists?(:archived_signatures, :petition_mailshot_at)
+      remove_column :archived_signatures, :petition_mailshot_at, :datetime
+    end
+
+    if column_exists?(:signatures, :petition_mailshot_at)
+      remove_column :signatures, :petition_mailshot_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_214559) do
+ActiveRecord::Schema.define(version: 2022_01_31_160157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -115,6 +115,16 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.index ["petition_id"], name: "index_archived_petition_emails_on_petition_id"
   end
 
+  create_table "archived_petition_mailshots", id: :serial, force: :cascade do |t|
+    t.bigint "petition_id"
+    t.string "subject", null: false
+    t.text "body"
+    t.string "sent_by"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["petition_id"], name: "index_archived_petition_mailshots_on_petition_id"
+  end
+
   create_table "archived_petitions", id: :serial, force: :cascade do |t|
     t.string "state", limit: 10, default: "closed", null: false
     t.datetime "opened_at"
@@ -152,6 +162,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.datetime "anonymized_at"
     t.integer "moderated_by_id"
     t.integer "topics", default: [], null: false, array: true
+    t.datetime "email_requested_for_petition_mailshot_at"
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "index_archived_petitions_on_action", using: :gin
     t.index "to_tsvector('english'::regconfig, (background)::text)", name: "index_archived_petitions_on_background", using: :gin
     t.index "to_tsvector('english'::regconfig, additional_details)", name: "index_archived_petitions_on_additional_details", using: :gin
@@ -206,6 +217,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.boolean "creator", default: false, null: false
     t.boolean "sponsor", default: false, null: false
     t.datetime "anonymized_at"
+    t.datetime "petition_mailshot_at"
     t.index "((ip_address)::inet)", name: "index_archived_signatures_on_inet"
     t.index "((regexp_replace(\"left\"(lower((email)::text), (\"position\"((email)::text, '@'::text) - 1)), '\\.|\\+.+'::text, ''::text, 'g'::text) || \"substring\"(lower((email)::text), \"position\"((email)::text, '@'::text))))", name: "index_archived_signatures_on_lower_normalized_email"
     t.index "\"left\"((postcode)::text, '-3'::integer), petition_id", name: "index_archived_signatures_on_sector_and_petition_id"
@@ -338,6 +350,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.datetime "updated_at", null: false
     t.datetime "debate_scheduled"
     t.datetime "petition_email"
+    t.datetime "petition_mailshot"
     t.index ["petition_id"], name: "index_email_requested_receipts_on_petition_id"
   end
 
@@ -459,6 +472,16 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["petition_id"], name: "index_petition_emails_on_petition_id"
+  end
+
+  create_table "petition_mailshots", id: :serial, force: :cascade do |t|
+    t.bigint "petition_id"
+    t.string "subject", null: false
+    t.text "body"
+    t.string "sent_by"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["petition_id"], name: "index_petition_mailshots_on_petition_id"
   end
 
   create_table "petition_statistics", id: :serial, force: :cascade do |t|
@@ -620,6 +643,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
     t.string "validated_ip"
     t.string "canonical_email"
     t.datetime "anonymized_at"
+    t.datetime "petition_mailshot_at"
     t.index "((ip_address)::inet)", name: "index_signatures_on_inet"
     t.index "((regexp_replace(\"left\"(lower((email)::text), (\"position\"((email)::text, '@'::text) - 1)), '\\.|\\+.+'::text, ''::text, 'g'::text) || \"substring\"(lower((email)::text), \"position\"((email)::text, '@'::text))))", name: "index_signatures_on_lower_normalized_email"
     t.index "\"left\"((postcode)::text, '-3'::integer), petition_id", name: "index_signatures_on_sector_and_petition_id"
@@ -732,6 +756,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
   add_foreign_key "archived_government_responses", "archived_petitions", column: "petition_id", on_delete: :cascade
   add_foreign_key "archived_notes", "archived_petitions", column: "petition_id", on_delete: :cascade
   add_foreign_key "archived_petition_emails", "archived_petitions", column: "petition_id", on_delete: :cascade
+  add_foreign_key "archived_petition_mailshots", "archived_petitions", column: "petition_id"
   add_foreign_key "archived_petitions", "admin_users", column: "moderated_by_id"
   add_foreign_key "archived_petitions", "parliaments"
   add_foreign_key "archived_rejections", "archived_petitions", column: "petition_id", on_delete: :cascade
@@ -745,6 +770,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_214559) do
   add_foreign_key "government_responses", "petitions", on_delete: :cascade
   add_foreign_key "notes", "petitions", on_delete: :cascade
   add_foreign_key "petition_emails", "petitions", on_delete: :cascade
+  add_foreign_key "petition_mailshots", "petitions"
   add_foreign_key "petition_statistics", "petitions"
   add_foreign_key "petitions", "admin_users", column: "moderated_by_id"
   add_foreign_key "rejections", "petitions", on_delete: :cascade

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -61,6 +61,13 @@ FactoryBot.define do
     sent_by { "Admin User" }
   end
 
+  factory :archived_petition_mailshot, class: "Archived::Petition::Mailshot" do
+    association :petition, factory: :archived_petition
+    subject { "Message Subject" }
+    body { "Message body" }
+    sent_by { "Admin User" }
+  end
+
   factory :archived_petition, class: "Archived::Petition" do
     transient do
       sponsors_signed { nil }
@@ -317,6 +324,7 @@ FactoryBot.define do
         email_requested_for_debate_scheduled_at { nil }
         email_requested_for_debate_outcome_at { nil }
         email_requested_for_petition_email_at { nil }
+        email_requested_for_petition_mailshot_at { nil }
       end
 
       after(:build) do |petition, evaluator|
@@ -325,6 +333,7 @@ FactoryBot.define do
           r.debate_scheduled = evaluator.email_requested_for_debate_scheduled_at
           r.debate_outcome = evaluator.email_requested_for_debate_outcome_at
           r.petition_email = evaluator.email_requested_for_petition_email_at
+          r.petition_mailshot = evaluator.email_requested_for_petition_mailshot_at
         end
       end
     end
@@ -642,7 +651,7 @@ FactoryBot.define do
 
     england
 
-    name { Faker::Address.county }
+    name { Faker::Address.unique.county }
     external_id { generate(:constituency_id) }
     mp_name { "#{Faker::Name.name} MP" }
     mp_id { generate(:mp_id) }
@@ -691,6 +700,13 @@ FactoryBot.define do
   end
 
   factory :petition_email, class: "Petition::Email" do
+    association :petition, factory: :petition
+    subject { "Message Subject" }
+    body { "Message body" }
+    sent_by { "Admin User" }
+  end
+
+  factory :petition_mailshot, class: "Petition::Mailshot" do
     association :petition, factory: :petition
     subject { "Message Subject" }
     body { "Message body" }

--- a/spec/jobs/archive_petition_job_spec.rb
+++ b/spec/jobs/archive_petition_job_spec.rb
@@ -314,4 +314,14 @@ RSpec.describe ArchivePetitionJob, type: :job do
       expect(archived_petition.email_requested_for_petition_email_at).to be_usec_precise_with(email_request.petition_email)
     end
   end
+
+  context "with a petition that has an petition_mailshot email scheduled" do
+    let(:petition) do
+      FactoryBot.create(:closed_petition, :email_requested, email_requested_for_petition_mailshot_at: Time.current)
+    end
+
+    it "copies the receipt timestamp to the archived petition" do
+      expect(archived_petition.email_requested_for_petition_mailshot_at).to be_usec_precise_with(email_request.petition_mailshot)
+    end
+  end
 end

--- a/spec/jobs/archive_signatures_job_spec.rb
+++ b/spec/jobs/archive_signatures_job_spec.rb
@@ -193,6 +193,20 @@ RSpec.describe ArchiveSignaturesJob, type: :job do
     end
   end
 
+  context "with a signature that has been sent a mailshot" do
+    let!(:signature) { FactoryBot.create(:validated_signature, petition: petition, petition_mailshot_at: 4.weeks.ago) }
+
+    before do
+      described_class.perform_now(petition, archived_petition)
+    end
+
+    it_behaves_like "a copied signature"
+
+    it "copies the petition_mailshot_at timestamp" do
+      expect(archived_signature.petition_mailshot_at).to be_usec_precise_with(signature.petition_mailshot_at)
+    end
+  end
+
   context "with a signature that has invalid attributes" do
     let!(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
 

--- a/spec/jobs/archived/email_constituencies_job_spec.rb
+++ b/spec/jobs/archived/email_constituencies_job_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Archived::EmailConstituenciesJob, type: :job do
+  let!(:petition) { FactoryBot.create(:archived_petition) }
+  let!(:mailshot) { FactoryBot.create(:archived_petition_mailshot, petition: petition) }
+  let!(:constituency_ids) { %w[3427 3320 3703] }
+  let!(:requested_at) { Time.now }
+  let!(:requested_at_iso8601) { requested_at.getutc.iso8601(6) }
+
+  it "enqueues an Archived::EmailConstituencyJob job for every constituency" do
+    described_class.perform_now(mailshot, constituency_ids, requested_at: requested_at)
+
+    expect(Archived::EmailConstituencyJob).to have_been_enqueued
+      .on_queue(:high_priority).with(
+        petition: petition,
+        mailshot: mailshot,
+        scope: { constituency_id: "3427" },
+        requested_at: requested_at_iso8601
+      )
+
+    expect(Archived::EmailConstituencyJob).to have_been_enqueued
+      .on_queue(:high_priority).with(
+        petition: petition,
+        mailshot: mailshot,
+        scope: { constituency_id: "3320" },
+        requested_at: requested_at_iso8601
+      )
+
+    expect(Archived::EmailConstituencyJob).to have_been_enqueued
+      .on_queue(:high_priority).with(
+        petition: petition,
+        mailshot: mailshot,
+        scope: { constituency_id: "3703" },
+        requested_at: requested_at_iso8601
+      )
+  end
+end

--- a/spec/jobs/archived/email_constituency_job_spec.rb
+++ b/spec/jobs/archived/email_constituency_job_spec.rb
@@ -1,23 +1,24 @@
 require 'rails_helper'
-require_relative 'shared_examples'
+require_relative '../shared_examples'
 
-RSpec.describe EmailPetitionersJob, type: :job do
-  let(:email_requested_at) { Time.current }
-  let(:petition) { FactoryBot.create(:open_petition) }
-  let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
-  let(:email) { FactoryBot.create(:petition_email, petition: petition) }
-  let(:arguments) { { petition: petition, email: email } }
+RSpec.describe Archived::EmailConstituencyJob, type: :job do
+  let(:mailshot_requested_at) { Time.current }
+  let(:petition) { FactoryBot.create(:archived_petition) }
+  let(:signature) { FactoryBot.create(:archived_signature, petition: petition) }
+  let(:mailshot) { FactoryBot.create(:archived_petition_mailshot, petition: petition) }
+  let(:scope) { { constituency_id: "3427" } }
+  let(:arguments) { { petition: petition, mailshot: mailshot } }
 
   before do
-    petition.set_email_requested_at_for('petition_email', to: email_requested_at)
+    petition.set_email_requested_at_for('petition_mailshot', to: mailshot_requested_at)
     allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
   end
 
   it_behaves_like "job to enqueue signatory mailing jobs"
 
-  context "when the petition email has been deleted" do
+  context "when the petition mailshot has been deleted" do
     before do
-      email.destroy
+      mailshot.destroy
     end
 
     it "enqueues a job" do

--- a/spec/jobs/email_constituencies_job_spec.rb
+++ b/spec/jobs/email_constituencies_job_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe EmailConstituenciesJob, type: :job do
+  let!(:petition) { FactoryBot.create(:closed_petition) }
+  let!(:mailshot) { FactoryBot.create(:petition_mailshot, petition: petition) }
+  let!(:constituency_ids) { %w[3427 3320 3703] }
+  let!(:requested_at) { Time.now }
+  let!(:requested_at_iso8601) { requested_at.getutc.iso8601(6) }
+
+  it "enqueues an EmailConstituencyJob job for every constituency" do
+    described_class.perform_now(mailshot, constituency_ids, requested_at: requested_at)
+
+    expect(EmailConstituencyJob).to have_been_enqueued
+      .on_queue(:high_priority).with(
+        petition: petition,
+        mailshot: mailshot,
+        scope: { constituency_id: "3427" },
+        requested_at: requested_at_iso8601
+      )
+
+    expect(EmailConstituencyJob).to have_been_enqueued
+      .on_queue(:high_priority).with(
+        petition: petition,
+        mailshot: mailshot,
+        scope: { constituency_id: "3320" },
+        requested_at: requested_at_iso8601
+      )
+
+    expect(EmailConstituencyJob).to have_been_enqueued
+      .on_queue(:high_priority).with(
+        petition: petition,
+        mailshot: mailshot,
+        scope: { constituency_id: "3703" },
+        requested_at: requested_at_iso8601
+      )
+  end
+end

--- a/spec/jobs/email_constituency_job_spec.rb
+++ b/spec/jobs/email_constituency_job_spec.rb
@@ -1,23 +1,24 @@
 require 'rails_helper'
 require_relative 'shared_examples'
 
-RSpec.describe EmailPetitionersJob, type: :job do
-  let(:email_requested_at) { Time.current }
+RSpec.describe EmailConstituencyJob, type: :job do
+  let(:mailshot_requested_at) { Time.current }
   let(:petition) { FactoryBot.create(:open_petition) }
   let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
-  let(:email) { FactoryBot.create(:petition_email, petition: petition) }
-  let(:arguments) { { petition: petition, email: email } }
+  let(:mailshot) { FactoryBot.create(:petition_mailshot, petition: petition) }
+  let(:scope) { { constituency_id: "3427" } }
+  let(:arguments) { { petition: petition, mailshot: mailshot, scope: scope } }
 
   before do
-    petition.set_email_requested_at_for('petition_email', to: email_requested_at)
+    petition.set_email_requested_at_for('petition_mailshot', to: mailshot_requested_at)
     allow(petition).to receive_message_chain(:signatures_to_email_for, :find_each).and_yield(signature)
   end
 
   it_behaves_like "job to enqueue signatory mailing jobs"
 
-  context "when the petition email has been deleted" do
+  context "when the petition mailshot has been deleted" do
     before do
-      email.destroy
+      mailshot.destroy
     end
 
     it "enqueues a job" do

--- a/spec/mailers/archived/petition_mailer_spec.rb
+++ b/spec/mailers/archived/petition_mailer_spec.rb
@@ -542,4 +542,76 @@ RSpec.describe Archived::PetitionMailer, type: :mailer do
       end
     end
   end
+
+  describe "sending a mailshot" do
+    let :petition do
+      FactoryBot.create(:archived_petition,
+        action: "Allow organic vegetable vans to use red diesel",
+        background: "Add vans to permitted users of red diesel",
+        additional_details: "To promote organic vegetables"
+      )
+    end
+
+    let(:mailshot) do
+      FactoryBot.create(:archived_petition_mailshot,
+        subject: "This is a message from the committee",
+        body: "Message body from the petition committee",
+        petition: petition
+      )
+    end
+
+    shared_examples_for "a petition mailshot" do
+      it "has the correct subject" do
+        expect(mail).to have_subject("This is a message from the committee")
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear #{signature.name},")
+      end
+
+      it "sends it only to the signatory" do
+        expect(mail.to).to eq([signature.email])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+      end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+      end
+
+      it "includes the message body" do
+        expect(mail).to have_body_text(%r[Message body from the petition committee])
+      end
+    end
+
+    context "when the signature is the creator" do
+      let(:signature) { creator }
+      subject(:mail) { described_class.mailshot_for_creator(petition, signature, mailshot) }
+
+      it_behaves_like "a petition mailshot"
+
+      it "identifies them as the creator" do
+        expect(mail).to have_body_text(%[You recently created the petition])
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { signer }
+      subject(:mail) { described_class.mailshot_for_signer(petition, signature, mailshot) }
+
+      it_behaves_like "a petition mailshot"
+
+      it "identifies them as a ordinary signature" do
+        expect(mail).to have_body_text(%[You recently signed the petition])
+      end
+    end
+  end
 end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -793,6 +793,65 @@ RSpec.describe PetitionMailer, type: :mailer do
     end
   end
 
+  describe "sending a mailshot" do
+    let(:petition) { FactoryBot.create(:open_petition, :scheduled_for_debate, attributes) }
+    let(:mailshot) { FactoryBot.create(:petition_mailshot, petition: petition, subject: "This is a message from the committee", body: "Message body from the petition committee") }
+
+    shared_examples_for "a petition mailshot" do
+      it "has the correct subject" do
+        expect(mail).to have_subject("This is a message from the committee")
+      end
+
+      it "addresses the signatory by name" do
+        expect(mail).to have_body_text("Dear #{signature.name},")
+      end
+
+      it "sends it only to the signatory" do
+        expect(mail.to).to eq([signature.email])
+        expect(mail.cc).to be_blank
+        expect(mail.bcc).to be_blank
+      end
+
+      it "includes a link to the petition page" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/petitions/#{petition.id}])
+      end
+
+      it "includes an unsubscribe link" do
+        expect(mail).to have_body_text(%r[https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+      end
+
+      it "has a List-Unsubscribe header" do
+        expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+      end
+
+      it "includes the message body" do
+        expect(mail).to have_body_text(%r[Message body from the petition committee])
+      end
+    end
+
+    context "when the signature is the creator" do
+      let(:signature) { petition.creator }
+      subject(:mail) { described_class.mailshot_for_creator(petition, signature, mailshot) }
+
+      it_behaves_like "a petition mailshot"
+
+      it "identifies them as the creator" do
+        expect(mail).to have_body_text(%[You recently created the petition])
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { FactoryBot.create(:validated_signature, petition: petition, name: "Laura Palmer", email: "laura@red-room.example.com") }
+      subject(:mail) { described_class.mailshot_for_signer(petition, signature, mailshot) }
+
+      it_behaves_like "a petition mailshot"
+
+      it "identifies them as a ordinary signature" do
+        expect(mail).to have_body_text(%[You recently signed the petition])
+      end
+    end
+  end
+
   describe "skipping anonymized signatures" do
     let(:petition) { FactoryBot.create(:closed_petition, attributes) }
     let(:email) { FactoryBot.create(:petition_email, petition: petition, subject: "This is a message from the committee", body: "Message body from the petition committee") }

--- a/spec/mailers/previews/archived/petition_mailer_preview.rb
+++ b/spec/mailers/previews/archived/petition_mailer_preview.rb
@@ -7,7 +7,7 @@ module Archived
       petition = email.petition
       signature = petition.signatures.validated.last
 
-      PetitionMailer.email_signer(petition, signature, email)
+      Archived::PetitionMailer.email_signer(petition, signature, email)
     end
 
     def email_creator
@@ -15,7 +15,23 @@ module Archived
       petition = email.petition
       signature = petition.creator
 
-      PetitionMailer.email_creator(petition, signature, email)
+      Archived::PetitionMailer.email_creator(petition, signature, email)
+    end
+
+    def mailshot_for_signer
+      mailshot = Archived::Petition::Mailshot.last
+      petition = mailshot.petition
+      signature = petition.signatures.validated.last
+
+      Archived::PetitionMailer.mailshot_for_signer(petition, signature, mailshot)
+    end
+
+    def mailshot_for_creator
+      mailshot = Archived::Petition::Mailshot.last
+      petition = mailshot.petition
+      signature = petition.creator
+
+      Archived::PetitionMailer.mailshot_for_creator(petition, signature, mailshot)
     end
 
     def notify_signer_of_threshold_response

--- a/spec/mailers/previews/petition_mailer_preview.rb
+++ b/spec/mailers/previews/petition_mailer_preview.rb
@@ -28,6 +28,22 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.email_creator(petition, signature, email)
   end
 
+  def mailshot_for_signer
+    mailshot = Petition::Mailshot.last
+    petition = mailshot.petition
+    signature = petition.signatures.validated.last
+
+    PetitionMailer.mailshot_for_signer(petition, signature, mailshot)
+  end
+
+  def mailshot_for_creator
+    mailshot = Petition::Mailshot.last
+    petition = mailshot.petition
+    signature = petition.creator
+
+    PetitionMailer.mailshot_for_creator(petition, signature, mailshot)
+  end
+
   def notify_creator_that_moderation_is_delayed
     petition = Petition.overdue_in_moderation.last
     signature = petition.creator

--- a/spec/models/archived/petition/mailshot_spec.rb
+++ b/spec/models/archived/petition/mailshot_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Archived::Petition::Mailshot, type: :model do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:archived_petition_mailshot)).to be_valid
+  end
+
+  describe "schema" do
+    it { is_expected.to have_db_column(:petition_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:subject).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:body).of_type(:text) }
+    it { is_expected.to have_db_column(:sent_by).of_type(:string) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:petition) }
+  end
+
+  describe "indexes" do
+    it { is_expected.to have_db_index([:petition_id]) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.build(:archived_petition_mailshot) }
+
+    it { is_expected.to validate_presence_of(:petition) }
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(100) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_length_of(:body).is_at_most(10000) }
+  end
+end

--- a/spec/models/archived/signature_spec.rb
+++ b/spec/models/archived/signature_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Archived::Signature, type: :model do
     it { is_expected.to have_db_column(:debate_scheduled_email_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:debate_outcome_email_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:petition_email_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:petition_mailshot_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
     it { is_expected.to have_db_column(:creator).of_type(:boolean).with_options(default: false, null: false) }
     it { is_expected.to have_db_column(:sponsor).of_type(:boolean).with_options(default: false, null: false) }
@@ -208,6 +209,21 @@ RSpec.describe Archived::Signature, type: :model do
 
         it "does not include the signature" do
           expect(signatures).not_to include(subscribed)
+        end
+      end
+
+      context "when there is an additional scope" do
+        let!(:coventry_signature) { FactoryBot.create(:archived_signature, :validated, constituency_id: "3427") }
+        let!(:romford_signature) { FactoryBot.create(:archived_signature, :validated, constituency_id: "3703") }
+
+        subject(:signatures) { described_class.need_emailing_for(timestamp, since: requested_at, scope: { constituency_id: "3427" }) }
+
+        it "returns signatures within the scope" do
+          expect(subject).to include coventry_signature
+        end
+
+        it "does not return signatures outside the scope" do
+          expect(subject).not_to include romford_signature
         end
       end
     end

--- a/spec/models/constituency_spec.rb
+++ b/spec/models/constituency_spec.rb
@@ -142,6 +142,62 @@ RSpec.describe Constituency, type: :model do
     end
   end
 
+  describe ".english" do
+    let!(:english_constituency) { FactoryBot.create(:constituency, :england) }
+    let!(:northern_irish_constituency) { FactoryBot.create(:constituency, :northern_ireland) }
+    let!(:scottish_constituency) { FactoryBot.create(:constituency, :scotland) }
+    let!(:welsh_constituency) { FactoryBot.create(:constituency, :wales) }
+
+    it "only finds English constituencies" do
+      expect(described_class.english).to include(english_constituency)
+      expect(described_class.english).not_to include(northern_irish_constituency)
+      expect(described_class.english).not_to include(scottish_constituency)
+      expect(described_class.english).not_to include(welsh_constituency)
+    end
+  end
+
+  describe ".northern_irish" do
+    let!(:english_constituency) { FactoryBot.create(:constituency, :england) }
+    let!(:northern_irish_constituency) { FactoryBot.create(:constituency, :northern_ireland) }
+    let!(:scottish_constituency) { FactoryBot.create(:constituency, :scotland) }
+    let!(:welsh_constituency) { FactoryBot.create(:constituency, :wales) }
+
+    it "only finds Northern Irish constituencies" do
+      expect(described_class.northern_irish).to include(northern_irish_constituency)
+      expect(described_class.northern_irish).not_to include(english_constituency)
+      expect(described_class.northern_irish).not_to include(scottish_constituency)
+      expect(described_class.northern_irish).not_to include(welsh_constituency)
+    end
+  end
+
+  describe ".scottish" do
+    let!(:english_constituency) { FactoryBot.create(:constituency, :england) }
+    let!(:northern_irish_constituency) { FactoryBot.create(:constituency, :northern_ireland) }
+    let!(:scottish_constituency) { FactoryBot.create(:constituency, :scotland) }
+    let!(:welsh_constituency) { FactoryBot.create(:constituency, :wales) }
+
+    it "only finds Scottish constituencies" do
+      expect(described_class.scottish).to include(scottish_constituency)
+      expect(described_class.scottish).not_to include(english_constituency)
+      expect(described_class.scottish).not_to include(northern_irish_constituency)
+      expect(described_class.scottish).not_to include(welsh_constituency)
+    end
+  end
+
+  describe ".welsh" do
+    let!(:english_constituency) { FactoryBot.create(:constituency, :england) }
+    let!(:northern_irish_constituency) { FactoryBot.create(:constituency, :northern_ireland) }
+    let!(:scottish_constituency) { FactoryBot.create(:constituency, :scotland) }
+    let!(:welsh_constituency) { FactoryBot.create(:constituency, :wales) }
+
+    it "only finds Welsh constituencies" do
+      expect(described_class.welsh).to include(welsh_constituency)
+      expect(described_class.welsh).not_to include(english_constituency)
+      expect(described_class.welsh).not_to include(northern_irish_constituency)
+      expect(described_class.welsh).not_to include(scottish_constituency)
+    end
+  end
+
   describe ".find_by_postcode" do
     context "when the constituency doesn't exist in the database" do
       before do

--- a/spec/models/petition/mailshot_spec.rb
+++ b/spec/models/petition/mailshot_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Petition::Mailshot, type: :model do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:petition_mailshot)).to be_valid
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:petition) }
+  end
+
+  describe "indexes" do
+    it { is_expected.to have_db_index([:petition_id]) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.build(:petition_mailshot) }
+
+    it { is_expected.to validate_presence_of(:petition) }
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(100) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_length_of(:body).is_at_most(6000) }
+  end
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -2083,7 +2083,8 @@ RSpec.describe Signature, type: :model do
         %w[government_response government_response_email_at],
         %w[debate_scheduled debate_scheduled_email_at],
         %w[debate_outcome debate_outcome_email_at],
-        %w[petition_email petition_email_at]
+        %w[petition_email petition_email_at],
+        %w[petition_mailshot petition_mailshot_at]
       ].each do |timestamp, column|
 
         context "when the timestamp '#{timestamp}' is not set" do
@@ -2113,7 +2114,8 @@ RSpec.describe Signature, type: :model do
         %w[government_response government_response_email_at],
         %w[debate_scheduled debate_scheduled_email_at],
         %w[debate_outcome debate_outcome_email_at],
-        %w[petition_email petition_email_at]
+        %w[petition_email petition_email_at],
+        %w[petition_mailshot petition_mailshot_at]
       ].each do |timestamp, column|
 
         context "when a time is supplied for timestamp '#{timestamp}'" do
@@ -2174,6 +2176,21 @@ RSpec.describe Signature, type: :model do
       it "returns signatures that have null for the requested timestamp" do
         a_signature.update_column(:government_response_email_at, nil)
         expect(subject).to match_array [a_signature, another_signature]
+      end
+
+      context "when there is an additional scope" do
+        let!(:coventry_signature) { FactoryBot.create(:validated_signature, constituency_id: "3427") }
+        let!(:romford_signature) { FactoryBot.create(:validated_signature, constituency_id: "3703") }
+
+        subject { Signature.need_emailing_for('petition_mailshot', since: since_timestamp, scope: { constituency_id: "3427" }) }
+
+        it "returns signatures within the scope" do
+          expect(subject).to include coventry_signature
+        end
+
+        it "does not return signatures outside the scope" do
+          expect(subject).not_to include romford_signature
+        end
       end
     end
   end


### PR DESCRIPTION
These are typically sent to specific constituencies or groups of constituencies either asking for feedback or to notify signatories of updates within their specific constituencies, e.g. notifying English constituencies of a law change that doesn't apply to the devolved nations.