### PR TITLE
Add space to privacy notice email

### DIFF
--- a/app/views/petition_mailer/privacy_policy_update_email.html.erb
+++ b/app/views/petition_mailer/privacy_policy_update_email.html.erb
@@ -1,7 +1,7 @@
 <p>Dear <%= @name %></p>
 
 <p>
-  We're getting in touch to let you know we’re making changes to the privacy notice for the UK Government and Parliament Petitions site (<%= link_to(nil, home_url) %>)on 1st March 2022. We are contacting you to make you aware of these changes because you have started/signed the following petitions that will be affected by these changes:
+  We're getting in touch to let you know we’re making changes to the privacy notice for the UK Government and Parliament Petitions site (<%= link_to(nil, home_url) %>) on 1st March 2022. We are contacting you to make you aware of these changes because you have started/signed the following petitions that will be affected by these changes:
 </p>
 
 <% @petitions.each do |petition| %>


### PR DESCRIPTION
There was a missing space in the privacy notice update email