### PR TITLE
Update PrivacyNotification petitions scope

### DIFF
--- a/app/jobs/email_privacy_policy_updates_job.rb
+++ b/app/jobs/email_privacy_policy_updates_job.rb
@@ -2,8 +2,8 @@ class EmailPrivacyPolicyUpdatesJob < ApplicationJob
   queue_as :high_priority
 
   def perform(time:)
-    Petition.where(created_at: time..).find_each do |petition|
-      EmailPrivacyPolicyUpdateJob.perform_later(petition)
+    Petition.moderated.where(created_at: time..).find_each do |petition|
+      EmailPrivacyPolicyUpdateJob.perform_later(petition: petition, time: time)
     end
   end
 end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -184,8 +184,8 @@ class PetitionMailer < ApplicationMailer
 
   def privacy_policy_update_email(privacy_notification)
     @name = privacy_notification.name
-    @petitions = privacy_notification.petitions
-    @remaining_petition_count = privacy_notification.remaining_petition_count
+    @petitions = privacy_notification.petitions.sample
+    @remaining_petition_count = privacy_notification.petitions.remaining_count
 
     mail(
       to: privacy_notification.email,

--- a/app/models/privacy_notification.rb
+++ b/app/models/privacy_notification.rb
@@ -1,16 +1,32 @@
 class PrivacyNotification < ActiveRecord::Base
   PETITION_LIMIT = 5
+
   PETITION_SCOPE = lambda {
-    not_anonymized.moderated.distinct.by_most_recent.limit(PETITION_LIMIT)
+    moderated.distinct.by_most_recent
   }
 
   has_one :signature, foreign_key: :uuid
   has_many :signatures, -> { validated }, foreign_key: :uuid
-  has_many :petitions, PETITION_SCOPE, through: :signatures
+
+  has_many :petitions, PETITION_SCOPE, through: :signatures do
+    def sample
+      applicable.limit(PETITION_LIMIT)
+    end
+
+    def remaining_count
+      [applicable.count - PETITION_LIMIT, 0].max
+    end
+
+    private
+
+    def applicable
+      where(created_at: ignore_petitions_before..)
+    end
+
+    def ignore_petitions_before
+      proxy_association.owner.ignore_petitions_before
+    end
+  end
 
   delegate :name, :email, to: :signature
-
-  def remaining_petition_count
-    [petitions.limit(nil).count - PETITION_LIMIT, 0].max
-  end
 end

--- a/db/migrate/20220225141800_add_time_to_privacy_notifications.rb
+++ b/db/migrate/20220225141800_add_time_to_privacy_notifications.rb
@@ -1,0 +1,5 @@
+class AddTimeToPrivacyNotifications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :privacy_notifications, :ignore_petitions_before, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_31_160157) do
+ActiveRecord::Schema.define(version: 2022_02_25_141800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -559,6 +559,7 @@ ActiveRecord::Schema.define(version: 2022_01_31_160157) do
   create_table "privacy_notifications", id: :uuid, default: nil, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "ignore_petitions_before", null: false
   end
 
   create_table "rate_limits", id: :serial, force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -901,6 +901,8 @@ FactoryBot.define do
   end
 
   factory :privacy_notification do
+    ignore_petitions_before { 1.year.ago }
+
     sequence(:id) do |n|
       Digest::UUID.uuid_v5(
         Digest::UUID::URL_NAMESPACE, "mailto:jo#{n}@public.com"

--- a/spec/jobs/email_privacy_policy_updates_job_spec.rb
+++ b/spec/jobs/email_privacy_policy_updates_job_spec.rb
@@ -4,33 +4,51 @@ RSpec.describe EmailPrivacyPolicyUpdatesJob, type: :job do
   let(:time) { 1.year.ago }
   let(:subject) { described_class.perform_now(time: time) }
 
-  context "petition created after given time" do
-    let!(:petition) do
-      FactoryBot.create(:open_petition, created_at: time + 1.day)
-    end
+  Petition::MODERATED_STATES.each do |state|
+    context "#{state} petition" do
+      context "petition created after given time" do
+        let!(:petition) do
+          FactoryBot.create("#{state}_petition", created_at: time + 1.day)
+        end
 
-    it "enqueues job" do
-      expect { subject }.to change { enqueued_jobs.count }.by(1)
+        it "enqueues job" do
+          expect { subject }.to change { enqueued_jobs.count }.by(1)
+        end
+      end
+
+      context "petition created at given time" do
+        let!(:petition) do
+          FactoryBot.create("#{state}_petition", created_at: time)
+        end
+
+        it "enqueues job" do
+          expect { subject }.to change { enqueued_jobs.count }.by(1)
+        end
+      end
+
+      context "petition created before given time" do
+        let!(:petition) do
+          FactoryBot.create("#{state}_petition", created_at: time - 1.day)
+        end
+
+        it "does not enqueue job" do
+          expect { subject }.not_to change { enqueued_jobs.count }
+        end
+      end
     end
   end
 
-  context "petition created at given time" do
-    let!(:petition) do
-      FactoryBot.create(:open_petition, created_at: time)
-    end
+  (Petition::STATES - Petition::MODERATED_STATES).each do |state|
+    context "#{state} petition" do
+      context "petition created after given time" do
+        let!(:petition) do
+          FactoryBot.create("#{state}_petition", created_at: time + 1.day)
+        end
 
-    it "enqueues job" do
-      expect { subject }.to change { enqueued_jobs.count }.by(1)
-    end
-  end
-
-  context "petition created after given time" do
-    let!(:petition) do
-      FactoryBot.create(:open_petition, created_at: time - 1.day)
-    end
-
-    it "does not enqueue job" do
-      expect { subject }.not_to change { enqueued_jobs.count }
+        it "does not enqueue job" do
+          expect { subject }.not_to change { enqueued_jobs.count }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What

- Update `privacy_policy_update_email` to list petitions scoped by `created_at`.

### Why

The task has been updated to only send emails for petitions with a `created_at` after a specific date, and the petitions listed in the email need to reflect that.