### PR TITLE
Update logic for displaying 'Anonymize Petitions' button

### DIFF
--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -66,7 +66,7 @@ class Admin::ParliamentsController < Admin::AdminController
   end
 
   def anonymize_petitions?
-    params.key?(:anonymize_petitions) && Archived::Petition.can_anonymize?
+    params.key?(:anonymize_petitions) && @parliament.can_anonymize_petitions?
   end
 
   def archive_parliament?

--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -29,7 +29,7 @@ class Admin::ParliamentsController < Admin::AdminController
         redirect_to admin_parliament_url(tab: params[:tab]), notice: :parliament_updated
       end
     else
-      render :show
+      render :show, alert: :parliament_not_updated
     end
   end
 

--- a/app/views/admin/parliaments/_form.html.erb
+++ b/app/views/admin/parliaments/_form.html.erb
@@ -14,7 +14,7 @@
       <%= form.submit 'Send dissolution emails', name: 'send_emails', class: 'button-secondary', data: { confirm: 'Email everyone about dissolution?' } %>
     <% end %>
   <% end %>
-  <% if Archived::Petition.can_anonymize? %>
+  <% if @parliament.can_anonymize_petitions? %>
     <%= form.submit 'Anonymize petitions', name: 'anonymize_petitions', class: 'button-secondary', data: { confirm: 'Anonymize all archived petitions?' } %>
   <% end %>
   <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -83,6 +83,7 @@ en-GB:
       petitions_archiving: "Archiving of petitions was successfully started"
       petitions_anonymizing: "Anonymizing of petitions was successfully started"
       parliament_archived: "Parliament archived successfully"
+      parliament_not_updated: "Parliament could not be updated - please check the form for errors"
       parliament_updated: "Parliament updated successfully"
       petition_email_created: "Created other parliamentary business successfully"
       petition_email_updated: "Updated other parliamentary business successfully"

--- a/features/admin/anonymize_petitions.feature
+++ b/features/admin/anonymize_petitions.feature
@@ -8,8 +8,7 @@ Feature: An admin anonymizes petitions
 
   @javascript
   Scenario: Admin anonymizes petitions 6 months after parliament closes
-    Given Parliament is dissolved
-    And 2 archived petitions exist
+    Given 2 archived petitions exist
     When I go to the admin parliament page
     And I press "Anonymize petitions"
     And I accept the alert


### PR DESCRIPTION
With the new data retention policy the button shouldn't be shown until after a parliament has been dissolved and archived.