### PR TITLE
Lower priority on anonymization job

### DIFF
--- a/app/jobs/anonymize_petition_job.rb
+++ b/app/jobs/anonymize_petition_job.rb
@@ -1,11 +1,11 @@
 class AnonymizePetitionJob < ApplicationJob
-  queue_as :high_priority
+  queue_as :low_priority
 
   rescue_from ActiveRecord::RecordInvalid do |exception|
     Appsignal.send_exception exception
   end
 
-  def perform(petition, time, limit: 1000)
+  def perform(petition, time, limit: 500)
     time = time.in_time_zone
     terminating = false
 
@@ -41,7 +41,7 @@ class AnonymizePetitionJob < ApplicationJob
 
   private
 
-  def reschedule_job(petition, time, limit: 1000, wait_until: 5.minutes.from_now)
+  def reschedule_job(petition, time, limit: 500, wait_until: 5.minutes.from_now)
     self.class.set(wait_until: wait_until).perform_later(petition, time, limit: limit)
   end
 end

--- a/app/jobs/archived/anonymize_petition_job.rb
+++ b/app/jobs/archived/anonymize_petition_job.rb
@@ -1,12 +1,12 @@
 module Archived
   class AnonymizePetitionJob < ApplicationJob
-    queue_as :high_priority
+    queue_as :low_priority
 
     rescue_from ActiveRecord::RecordInvalid do |exception|
       Appsignal.send_exception exception
     end
 
-    def perform(petition, time, limit: 1000)
+    def perform(petition, time, limit: 500)
       time = time.in_time_zone
       terminating = false
 
@@ -42,7 +42,7 @@ module Archived
 
     private
 
-    def reschedule_job(petition, time, limit: 1000, wait_until: 5.minutes.from_now)
+    def reschedule_job(petition, time, limit: 500, wait_until: 5.minutes.from_now)
       self.class.set(wait_until: wait_until).perform_later(petition, time, limit: limit)
     end
   end

--- a/spec/models/archived/petition_spec.rb
+++ b/spec/models/archived/petition_spec.rb
@@ -1189,7 +1189,7 @@ RSpec.describe Archived::Petition, type: :model do
         petition.anonymize!("2018-12-31T00:00:00Z".in_time_zone)
       }.to have_enqueued_job(Archived::AnonymizePetitionJob)
         .with(petition, "2018-12-31T00:00:00+00:00")
-        .on_queue("high_priority")
+        .on_queue("low_priority")
     end
   end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1663,7 +1663,7 @@ RSpec.describe Petition, type: :model do
         petition.anonymize!("2018-12-31T00:00:00Z".in_time_zone)
       }.to have_enqueued_job(AnonymizePetitionJob)
         .with(petition, "2018-12-31T00:00:00+00:00")
-        .on_queue("high_priority")
+        .on_queue("low_priority")
     end
   end
 


### PR DESCRIPTION
Delivering signature validation emails should take priority.