### PR TITLE
Optimize performance of anonymization jobs

### DIFF
--- a/app/jobs/anonymize_petition_job.rb
+++ b/app/jobs/anonymize_petition_job.rb
@@ -16,7 +16,7 @@ class AnonymizePetitionJob < ApplicationJob
 
     Appsignal.without_instrumentation do
       if petition.signatures.not_anonymized.exists?
-        signatures = petition.signatures.not_anonymized.batch(limit: limit)
+        signatures = petition.signatures.not_anonymized.take(limit)
 
         signatures.each do |signature|
           signature.anonymize!(time)

--- a/app/jobs/archived/anonymize_petition_job.rb
+++ b/app/jobs/archived/anonymize_petition_job.rb
@@ -17,7 +17,7 @@ module Archived
 
       Appsignal.without_instrumentation do
         if petition.signatures.not_anonymized.exists?
-          signatures = petition.signatures.not_anonymized.batch(limit: limit)
+          signatures = petition.signatures.not_anonymized.take(limit)
 
           signatures.each do |signature|
             signature.anonymize!(time)

--- a/app/models/concerns/anonymize.rb
+++ b/app/models/concerns/anonymize.rb
@@ -14,27 +14,25 @@ module Anonymize
   def anonymize!(timestamp)
     return if anonymized?
 
-    with_lock do
-      self.name = "Signature #{id}"
-      self.email = "signature-#{id}@example.com"
-      self.ip_address = "192.168.1.1"
-      self.anonymized_at = timestamp
+    self.name = "Signature #{id}"
+    self.email = "signature-#{id}@example.com"
+    self.ip_address = "192.168.1.1"
+    self.anonymized_at = timestamp
 
-      if constituency_id && constituency
-        self.postcode = constituency.example_postcode
-      else
-        self.postcode = nil
-      end
-
-      if postcode.blank? && united_kingdom?
-        # Validations require a postcode for the UK so use the NHS
-        # 'address not known' pseudo-postcode when we didn't find
-        # an example postcode for the constituency:
-        # https://adoxoblog.wordpress.com/2012/01/21/the-hitchhikers-guide-to-the-nhs/
-        self.postcode = "ZZ993WZ"
-      end
-
-      save!
+    if constituency_id && constituency
+      self.postcode = constituency.example_postcode
+    else
+      self.postcode = nil
     end
+
+    if postcode.blank? && united_kingdom?
+      # Validations require a postcode for the UK so use the NHS
+      # 'address not known' pseudo-postcode when we didn't find
+      # an example postcode for the constituency:
+      # https://adoxoblog.wordpress.com/2012/01/21/the-hitchhikers-guide-to-the-nhs/
+      self.postcode = "ZZ993WZ"
+    end
+
+    save!
   end
 end

--- a/db/migrate/20220306110716_reverse_anonymized_at_index_column_order.rb
+++ b/db/migrate/20220306110716_reverse_anonymized_at_index_column_order.rb
@@ -1,0 +1,17 @@
+class ReverseAnonymizedAtIndexColumnOrder < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    %i[signatures archived_signatures].each do |table|
+      add_index table, %i[petition_id anonymized_at], algorithm: :concurrently, if_not_exists: true
+      remove_index table, %i[anonymized_at petition_id], algorithm: :concurrently, if_exists: true
+    end
+  end
+
+  def down
+    %i[signatures archived_signatures].each do |table|
+      add_index table, %i[anonymized_at petition_id], algorithm: :concurrently, if_not_exists: true
+      remove_index table, %i[petition_id anonymized_at], algorithm: :concurrently, if_exists: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_25_141800) do
+ActiveRecord::Schema.define(version: 2022_03_06_110716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -226,12 +226,12 @@ ActiveRecord::Schema.define(version: 2022_02_25_141800) do
     t.index "\"substring\"((email)::text, (\"position\"((email)::text, '@'::text) + 1))", name: "index_archived_signatures_on_domain"
     t.index "lower((email)::text)", name: "index_archived_signatures_on_lower_email"
     t.index "lower((name)::text)", name: "index_archived_signatures_on_name"
-    t.index ["anonymized_at", "petition_id"], name: "index_archived_signatures_on_anonymized_at_and_petition_id"
     t.index ["constituency_id"], name: "index_archived_signatures_on_constituency_id"
     t.index ["created_at", "ip_address", "petition_id"], name: "index_archived_signatures_on_creation_ip_and_petition_id"
     t.index ["email", "petition_id", "name"], name: "index_archived_signatures_on_email_and_petition_id_and_name", unique: true
     t.index ["invalidation_id"], name: "index_archived_signatures_on_invalidation_id"
     t.index ["ip_address", "petition_id"], name: "index_archived_signatures_on_ip_address_and_petition_id"
+    t.index ["petition_id", "anonymized_at"], name: "index_archived_signatures_on_petition_id_and_anonymized_at"
     t.index ["petition_id", "location_code"], name: "index_archived_signatures_on_petition_id_and_location_code"
     t.index ["petition_id"], name: "index_archived_signatures_on_petition_id"
     t.index ["petition_id"], name: "index_archived_signatures_on_petition_id_where_creator_is_true", unique: true, where: "(creator = true)"
@@ -659,7 +659,6 @@ ActiveRecord::Schema.define(version: 2022_02_25_141800) do
     t.index "\"substring\"((email)::text, (\"position\"((email)::text, '@'::text) + 1))", name: "index_signatures_on_domain"
     t.index "lower((email)::text)", name: "index_signatures_on_lower_email"
     t.index "lower((name)::text)", name: "index_signatures_on_name"
-    t.index ["anonymized_at", "petition_id"], name: "index_signatures_on_anonymized_at_and_petition_id"
     t.index ["archived_at", "petition_id"], name: "index_signatures_on_archived_at_and_petition_id"
     t.index ["canonical_email"], name: "index_signatures_on_canonical_email"
     t.index ["constituency_id"], name: "index_signatures_on_constituency_id"
@@ -667,6 +666,7 @@ ActiveRecord::Schema.define(version: 2022_02_25_141800) do
     t.index ["email", "petition_id", "name"], name: "index_signatures_on_email_and_petition_id_and_name", unique: true
     t.index ["invalidation_id"], name: "index_signatures_on_invalidation_id"
     t.index ["ip_address", "petition_id"], name: "index_signatures_on_ip_address_and_petition_id"
+    t.index ["petition_id", "anonymized_at"], name: "index_signatures_on_petition_id_and_anonymized_at"
     t.index ["petition_id", "location_code"], name: "index_signatures_on_petition_id_and_location_code"
     t.index ["petition_id"], name: "index_signatures_on_petition_id"
     t.index ["petition_id"], name: "index_signatures_on_petition_id_where_creator_is_true", unique: true, where: "(creator = true)"


### PR DESCRIPTION
The ORDER BY clause from the `batch` method was causing a full table index scan on the primary key so reverse the index column order and use `take`. This is possible since the order of anonymization isn't important and the call to `anonymize!` on the signature is idempotent.