### PR TITLE
Add the number of subscribers to the petition stats

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -66,7 +66,7 @@ class Admin::PetitionsController < Admin::AdminController
   end
 
   def preload_scope(current)
-    current.preload(:creator, :rejection, :government_response, :debate_outcome, :note)
+    current.preload(:creator, :rejection, :government_response, :debate_outcome, :note, :statistics)
   end
 
   def scope

--- a/app/models/petition/statistics.rb
+++ b/app/models/petition/statistics.rb
@@ -1,5 +1,7 @@
 class Petition < ActiveRecord::Base
   class Statistics < ActiveRecord::Base
+    include ActiveSupport::NumberHelper
+
     belongs_to :petition
 
     after_commit on: :create do
@@ -10,12 +12,37 @@ class Petition < ActiveRecord::Base
       update!(
         refreshed_at: now,
         duplicate_emails: refresh_duplicate_emails,
-        pending_rate: refresh_pending_rate
+        pending_rate: refresh_pending_rate,
+        subscribers: refresh_subscribers
       )
     end
 
     def refreshed?
       refreshed_at?
+    end
+
+    def subscribers?
+      if refreshed? && petition.published?
+        super
+      end
+    end
+
+    def subscribers
+      if refreshed? && petition.published?
+        super
+      end
+    end
+
+    def subscriber_count
+      if refreshed? && petition.published?
+        number_to_delimited(subscribers)
+      end
+    end
+
+    def subscription_rate
+      if refreshed? && petition.published?
+        number_to_percentage(Rational(subscribers, petition.signature_count) * 100, precision: 1)
+      end
     end
 
     private
@@ -26,6 +53,10 @@ class Petition < ActiveRecord::Base
 
       def refresh_pending_rate
         petition.signatures.pending_rate
+      end
+
+      def refresh_subscribers
+        petition.signatures.subscribers
       end
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -125,6 +125,10 @@ class Signature < ActiveRecord::Base
       (Rational(pending.count, total.count) * 100).to_d(2)
     end
 
+    def subscribers
+      validated.subscribed.count
+    end
+
     def similar(id, email)
       where(canonical_email: email).where.not(id: id)
     end

--- a/app/presenters/petition_csv_presenter.rb
+++ b/app/presenters/petition_csv_presenter.rb
@@ -6,7 +6,7 @@ class PetitionCSVPresenter
   include Rails.application.routes.url_helpers
 
   def self.fields
-    urls + attributes + timestamps + [:notes]
+    urls + attributes + timestamps + [:notes, :subscriber_count, :subscription_rate]
   end
 
   def initialize(petition)
@@ -56,6 +56,18 @@ class PetitionCSVPresenter
 
   def notes
     petition.note.details if petition.note
+  end
+
+  def subscriber_count
+    if petition.statistics.refreshed?
+      csv_escape petition.statistics.subscriber_count
+    end
+  end
+
+  def subscription_rate
+    if petition.statistics.refreshed?
+      csv_escape petition.statistics.subscription_rate
+    end
   end
 
   attributes.each do |attribute|

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -101,6 +101,14 @@
           –
         <% end %>
       </dd>
+      <dt>Subscribers</dt>
+      <dd>
+        <% if @petition.statistics.subscribers? %>
+          <%= @petition.statistics.subscriber_count %> / <%= @petition.statistics.subscription_rate %>
+        <% else %>
+          –
+        <% end %>
+      </dd>
     <% end %>
 
     <dt>Trending IP addresses</dt>

--- a/db/migrate/20230306174959_add_subscribers_to_petition_statistics.rb
+++ b/db/migrate/20230306174959_add_subscribers_to_petition_statistics.rb
@@ -1,0 +1,5 @@
+class AddSubscribersToPetitionStatistics < ActiveRecord::Migration[6.1]
+  def change
+    add_column :petition_statistics, :subscribers, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_13_172652) do
+ActiveRecord::Schema.define(version: 2023_03_06_174959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -495,6 +495,7 @@ ActiveRecord::Schema.define(version: 2023_01_13_172652) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.decimal "pending_rate"
+    t.integer "subscribers"
     t.index ["petition_id"], name: "index_petition_statistics_on_petition_id", unique: true
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -359,6 +359,12 @@ FactoryBot.define do
         petition.tags = [tag.id]
       end
     end
+
+    trait :with_statistics do
+      after(:create) do |petition, evaluator|
+        petition.statistics.refresh!
+      end
+    end
   end
 
   factory :pending_petition, :parent => :petition do

--- a/spec/models/petition/statistics_spec.rb
+++ b/spec/models/petition/statistics_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Petition::Statistics, type: :model do
   end
 
   describe "#refresh!" do
-    let!(:petition) { FactoryBot.create(:open_petition) }
+    let!(:petition) { FactoryBot.create(:open_petition, creator_attributes: { notify_by_email: false }) }
     let!(:statistics) { FactoryBot.create(:petition_statistics, petition: petition, refreshed_at: nil) }
 
     it "updates the refreshed_at timestamp" do
@@ -118,6 +118,34 @@ RSpec.describe Petition::Statistics, type: :model do
         }.to change {
           statistics.reload.pending_rate
         }.from(nil).to(50)
+      end
+    end
+
+    context "when there are no subscribed signatures" do
+      before do
+        FactoryBot.create(:validated_signature, petition: petition, notify_by_email: false)
+      end
+
+      it "updates the subscribers value" do
+        expect {
+          statistics.refresh!
+        }.to change {
+          statistics.reload.subscribers
+        }.from(nil).to(0)
+      end
+    end
+
+    context "when there are subscribed signatures" do
+      before do
+        FactoryBot.create(:validated_signature, petition: petition, notify_by_email: true)
+      end
+
+      it "updates the subscribers value" do
+        expect {
+          statistics.refresh!
+        }.to change {
+          statistics.reload.subscribers
+        }.from(nil).to(1)
       end
     end
   end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -1133,6 +1133,30 @@ RSpec.describe Signature, type: :model do
     end
   end
 
+  describe ".subscribers" do
+    let!(:petition) { FactoryBot.create(:open_petition, creator_attributes: { notify_by_email: false }) }
+
+    context "when there are no subscribed signatures" do
+      before do
+        FactoryBot.create(:validated_signature, petition: petition, notify_by_email: false)
+      end
+
+      it "returns zero" do
+        expect(petition.signatures.subscribers).to eq(0)
+      end
+    end
+
+    context "when there are subscribed signatures" do
+      before do
+        FactoryBot.create(:validated_signature, petition: petition, notify_by_email: true)
+      end
+
+      it "returns the number of duplicate emails" do
+        expect(petition.signatures.subscribers).to eq(1)
+      end
+    end
+  end
+
   describe ".not_anonymized" do
     subject do
       described_class.not_anonymized

--- a/spec/presenters/petition_csv_presenter_spec.rb
+++ b/spec/presenters/petition_csv_presenter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PetitionCSVPresenter do
 
     Petition::STATES.each do |state_name|
       context "with a #{state_name} petition" do
-        let!(:petition) { FactoryBot.create "#{state_name}_petition" }
+        let!(:petition) { FactoryBot.create "#{state_name}_petition", :with_statistics }
 
         specify { is_expected.to eq(csvd_petition petition) }
       end
@@ -62,7 +62,9 @@ RSpec.describe PetitionCSVPresenter do
       timestampify(petition.moderation_threshold_reached_at),
       timestampify(petition.government_response_created_at),
       timestampify(petition.government_response_updated_at),
-      petition.note.try(:details)
+      petition.note.try(:details),
+      petition.statistics.subscribers,
+      petition.statistics.subscription_rate
     ].join(",") + "\n"
   end
 end


### PR DESCRIPTION
This allows the moderators to get an idea of how many emails will be sent.