### PR TITLE
Improve public pages whilst petition is gathering support and being moderated

### DIFF
--- a/app/mailers/sponsor_mailer.rb
+++ b/app/mailers/sponsor_mailer.rb
@@ -1,7 +1,7 @@
 class SponsorMailer < ApplicationMailer
   def sponsor_signed_email_below_threshold(sponsor)
     @petition, @sponsor = sponsor.petition, sponsor
-    @sponsor_count = @petition.sponsors.validated.count
+    @sponsor_count = @petition.sponsor_count
 
     mail(
       subject: "#{@sponsor.name} supported your petition",
@@ -11,7 +11,7 @@ class SponsorMailer < ApplicationMailer
 
   def sponsor_signed_email_on_threshold(sponsor)
     @petition, @sponsor = sponsor.petition, sponsor
-    @sponsor_count = @petition.sponsors.validated.count
+    @sponsor_count = @petition.sponsor_count
 
     mail(
       subject: "We’re checking your petition",

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -986,7 +986,7 @@ class Petition < ActiveRecord::Base
   end
 
   def has_maximum_sponsors?
-    sponsors.validated.count >= Site.maximum_number_of_sponsors
+    sponsor_count >= Site.maximum_number_of_sponsors
   end
 
   def update_all(updates)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -651,6 +651,14 @@ class Petition < ActiveRecord::Base
     end
   end
 
+  def sponsor_count
+    @sponsor_count ||= sponsors.validated.count
+  end
+
+  def sponsors_required
+    [(Site.minimum_number_of_sponsors - sponsor_count), 0].max
+  end
+
   def signatures_by_country
     super.sort_by(&:name)
   end

--- a/app/views/petitions/gathering_support.html.erb
+++ b/app/views/petitions/gathering_support.html.erb
@@ -1,5 +1,5 @@
 <h1>This petition is gathering support</h1>
 
-<p><%= @petition.creator.name %>’s petition needs <%= Site.minimum_number_of_sponsors %> supporters before we will check that it meets the <%= link_to "petition standards", help_path(anchor: 'standards') %> and publish it.</p>
+<p>This petition needs <%= @petition.sponsors_required %> supporters before we will check that it meets the <%= link_to "petition standards", help_path(anchor: 'standards') %> and publish it.</p>
 
 <p>Please try again in a few days.</p>

--- a/app/views/petitions/moderation_info.html.erb
+++ b/app/views/petitions/moderation_info.html.erb
@@ -1,6 +1,12 @@
 <h1>We’re checking this petition</h1>
 
-<p><%= Site.minimum_number_of_sponsors %> people have already supported <%= @petition.creator.name %>’s petition.</p>
+<p>
+  <%= @petition.sponsor_count %> people have already supported this petition.
+
+  <% if @petition.has_maximum_sponsors? %>
+    No more people can sign this petition until it has been approved.
+  <% end %>
+</p>
 
 <p>We need to check it meets the <%= link_to "petition standards", help_path(anchor: 'standards') %> before we publish it.</p>
 

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -18,6 +18,10 @@ Given(/^an? ?(pending|validated|sponsored|flagged|dormant|open|closed|rejected)?
   @petition = FactoryBot.create(:"#{state || 'open'}_petition", action: action)
 end
 
+Given(/^a (validated|sponsored) petition "(.*?)" with (\d+) supporters$/) do |state, action, sponsor_count|
+  @petition = FactoryBot.create(:"#{state}_petition", action: action, sponsor_count: sponsor_count, sponsors_signed: true)
+end
+
 Given(/^a (sponsored|flagged) petition "(.*?)" reached threshold (\d+) days? ago$/) do |state, action, age|
   @petition = FactoryBot.create(:petition, action: action, state: state, moderation_threshold_reached_at: age.days.ago)
 end

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -4,15 +4,26 @@ Feature: Suzie views a petition
   I want to view a petition of my choice from a list, seeing the vote count, closed and open dates, along with the reason for rejection if applicable
 
   Scenario: Suzie views a petition gathering sponsors
-    Given a validated petition "Spend more money on Defence"
+    Given a validated petition "Spend more money on Defence" with 2 supporters
     When I view the petition
     Then I should see "This petition is gathering support"
+    And I should see "This petition needs 3 supporters before we will check that it meets the petition standards"
     And I should see a link called "petition standards" linking to "/help#standards"
 
   Scenario: Suzie views a petition waiting to be moderated
-    Given a sponsored petition "Spend more money on Defence"
+    Given a sponsored petition "Spend more money on Defence" with 5 supporters
     When I view the petition
     Then I should see "We’re checking this petition"
+    And I should see "5 people have already supported this petition"
+    And I should not see "No more people can sign this petition until it has been approved"
+    And I should see a link called "petition standards" linking to "/help#standards"
+
+  Scenario: Suzie views a petition with the maximum number of supporters waiting to be moderated
+    Given a sponsored petition "Spend more money on Defence" with 20 supporters
+    When I view the petition
+    Then I should see "We’re checking this petition"
+    And I should see "20 people have already supported this petition"
+    And I should see "No more people can sign this petition until it has been approved"
     And I should see a link called "petition standards" linking to "/help#standards"
 
   @allow-rescue

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -3207,11 +3207,11 @@ RSpec.describe Petition, type: :model do
 
   describe '#has_maximum_sponsors?' do
     %w[pending validated sponsored flagged dormant].each do |state|
-      let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: sponor_count, sponsors_signed: sponsors_signed) }
+      let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: sponsor_count, sponsors_signed: sponsors_signed) }
 
       context "when petition is #{state}" do
         context "and has less than the maximum number of sponsors" do
-          let(:sponor_count) { Site.maximum_number_of_sponsors - 1 }
+          let(:sponsor_count) { Site.maximum_number_of_sponsors - 1 }
           let(:sponsors_signed) { true }
 
           it "returns false" do
@@ -3220,7 +3220,7 @@ RSpec.describe Petition, type: :model do
         end
 
         context "and has the maximum number of sponsors, but none have signed" do
-          let(:sponor_count) { Site.maximum_number_of_sponsors }
+          let(:sponsor_count) { Site.maximum_number_of_sponsors }
           let(:sponsors_signed) { false }
 
           it "returns false" do
@@ -3229,7 +3229,7 @@ RSpec.describe Petition, type: :model do
         end
 
         context "and has more than the maximum number of sponsors, but none have signed" do
-          let(:sponor_count) { Site.maximum_number_of_sponsors + 1 }
+          let(:sponsor_count) { Site.maximum_number_of_sponsors + 1 }
           let(:sponsors_signed) { false }
 
           it "returns false" do
@@ -3238,7 +3238,7 @@ RSpec.describe Petition, type: :model do
         end
 
         context "and has the maximum number of sponsors and they have signed" do
-          let(:sponor_count) { Site.maximum_number_of_sponsors }
+          let(:sponsor_count) { Site.maximum_number_of_sponsors }
           let(:sponsors_signed) { true }
 
           it "returns true" do
@@ -3247,7 +3247,7 @@ RSpec.describe Petition, type: :model do
         end
 
         context "and has more than the maximum number of sponsors and they have signed" do
-          let(:sponor_count) { Site.maximum_number_of_sponsors + 1 }
+          let(:sponsor_count) { Site.maximum_number_of_sponsors + 1 }
           let(:sponsors_signed) { true }
 
           it "returns true" do


### PR DESCRIPTION
* Add the number of supporters required to the gathering support page
* Add the number of supporters to the moderation info page
* Add a message to the moderation info page once the maximum number of supporters has been reached
