### PR TITLE
Allow running the app under sysv and systemd control scripts

### DIFF
--- a/lib/package_builder/scripts/after_install.sh
+++ b/lib/package_builder/scripts/after_install.sh
@@ -18,4 +18,8 @@ if [ ${SERVER_TYPE} = "worker" ] ; then cd /home/deploy/epetitions/current && bu
 EOF
 
 # Enable services if they have not been previously enabled
-/lib/systemd/systemd-sysv-install is-enabled epetitions || /lib/systemd/systemd-sysv-install enable epetitions
+if [ -f "/etc/init.d/epetitions" ]; then
+  /lib/systemd/systemd-sysv-install is-enabled epetitions || /lib/systemd/systemd-sysv-install enable epetitions
+else
+  systemctl is-active --quiet epetitions.service || systemctl enable epetitions.service
+fi


### PR DESCRIPTION
We need to migrate to systemd to upgrade to Puma 5.x but we can't do both at the same time so we need a deployed revision that supports both to allow the instances to be refreshed successfully.