### PR TITLE
Add recent petitions list

### DIFF
--- a/app/assets/stylesheets/petitions/views/_search.scss
+++ b/app/assets/stylesheets/petitions/views/_search.scss
@@ -47,3 +47,19 @@
     @include bold-24();
   }
 }
+
+.list-header {
+  .text-secondary {
+    margin-top: -$gutter-one-quarter;
+    @include core-16;
+
+    @media (max-width: 280px){
+      // The Samsung Galaxy Fold is super narrow when folded
+      @include core-14;
+    }
+
+    a {
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/helpers/petition_helper.rb
+++ b/app/helpers/petition_helper.rb
@@ -23,7 +23,7 @@ module PetitionHelper
   end
 
   def petition_list_header
-    @_petition_list_header ||= t(@petitions.scope, scope: :"petitions.list_headers", default: "")
+    @_petition_list_header ||= t(:"#{@petitions.scope}_html", scope: :"petitions.list_headers", query: @petitions.url_safe_query, default: "")
   end
 
   def petition_list_header?

--- a/app/models/concerns/browseable.rb
+++ b/app/models/concerns/browseable.rb
@@ -160,6 +160,10 @@ module Browseable
       @query ||= params[:q].to_s
     end
 
+    def url_safe_query
+      Rack::Utils.escape(query)
+    end
+
     def page_size
       @page_size ||= [[sanitized_page_size, max_page_size].min, 1].max
     end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -52,6 +52,7 @@ class Petition < ActiveRecord::Base
 
   facet :all,      -> { by_most_popular }
   facet :open,     -> { open_state.by_most_popular }
+  facet :recent,   -> { open_state.by_most_recently_published }
   facet :rejected, -> { rejected_state.by_most_recent }
   facet :closed,   -> { closed_state.by_most_popular }
   facet :hidden,   -> { hidden_state.by_most_recent }
@@ -150,6 +151,10 @@ class Petition < ActiveRecord::Base
 
     def by_most_recent
       reorder(created_at: :desc)
+    end
+
+    def by_most_recently_published
+      reorder(open_at: :desc)
     end
 
     def by_most_recent_debate_outcome

--- a/app/views/petitions/index.html.erb
+++ b/app/views/petitions/index.html.erb
@@ -16,7 +16,9 @@
 <h1 class="page-title"><%= t(@petitions.scope, scope: :"petitions.page_titles") %></h1>
 
 <% if petition_list_header? %>
-  <p class="text-secondary"><%= petition_list_header %></p>
+  <div class="list-header">
+    <%= petition_list_header %>
+  </div>
 <% end %>
 
 <%= form_tag petitions_path, method: 'get', enforce_utf8: false do %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -10,6 +10,7 @@ en-GB:
     page_titles:
       all: "All petitions"
       open: "Open petitions"
+      recent: "Recent petitions"
       closed: "Closed petitions"
       rejected: "Rejected petitions"
       published: "Published petitions"
@@ -34,6 +35,7 @@ en-GB:
     lists:
       all: "All petitions (%{quantity})"
       open: "Open petitions (%{quantity})"
+      recent: "Recent petitions (%{quantity})"
       closed: "Closed petitions (%{quantity})"
       published: "Published petitions (%{quantity})"
       rejected: "Rejected petitions (%{quantity})"
@@ -44,7 +46,20 @@ en-GB:
       awaiting_debate: "Awaiting a debate in Parliament (%{quantity})"
 
     list_headers:
-      not_debated: "The Petitions Committee decided not to debate these petitions"
+      open_html: |-
+        <p class="text-secondary">
+          These petitions are sorted by popularity.
+          <a href="/petitions?state=recent&amp;q=%{query}">Sort them by date of publishing</a>.
+        </p>
+      recent_html: |-
+        <p class="text-secondary">
+          These petitions are sorted by date of publishing.
+          <a href="/petitions?state=open&amp;q=%{query}">Sort them by popularity</a>.
+        </p>
+      not_debated_html: |-
+        <p class="text-secondary">
+          The Petitions Committee decided not to debate these petitions
+        </p>
 
     facets:
       archived:
@@ -57,6 +72,7 @@ en-GB:
       public:
         - :all
         - :open
+        - :recent
         - :closed
         - :rejected
         - :awaiting_response

--- a/features/arnold_searches_from_home_page.feature
+++ b/features/arnold_searches_from_home_page.feature
@@ -6,20 +6,20 @@ Feature: Arnold searches from the home page
 Background:
     Given a pending petition exists with action: "Wombles are great"
     And a validated petition exists with action: "The Wombles of Wimbledon"
-    And an open petition exists with action: "Uncle Bulgaria", additional_details: "The Wombles are here", closed_at: "1 minute from now"
-    And an open petition exists with action: "Common People", background: "The Wombles belong to us all", closed_at: "11 days from now"
-    And an open petition exists with action: "Overthrow the Wombles", closed_at: "1 year from now"
+    And an open petition exists with action: "Uncle Bulgaria", additional_details: "The Wombles are here", closed_at: "1 minute from now", signature_count: 23
+    And an open petition exists with action: "Common People", background: "The Wombles belong to us all", closed_at: "11 days from now", signature_count: 19
+    And an open petition exists with action: "Overthrow the Wombles", closed_at: "3 months from now", signature_count: 17
     And a closed petition exists with action: "The Wombles will rock Glasto", closed_at: "1 minute ago"
     And a rejected petition exists with action: "Eavis vs the Wombles"
     And a hidden petition exists with action: "The Wombles are profane"
-    And an open petition exists with action: "Wombles", closed_at: "10 days from now"
+    And an open petition exists with action: "Wombles", closed_at: "10 days from now", signature_count: 13
     And the following archived petitions exist:
-      | action                   | state    | signature_count| opened_at  | closed_at  | created_at |
-      | Rivers are great         | closed   | 835            | 2012-01-01 | 2013-01-01 | 2012-01-01 |
-      | More rivers please       | closed   | 243            | 2011-04-01 | 2012-04-01 | 2011-04-01 |
-      | Cry me a river           | closed   | 639            | 2014-10-01 | 2015-03-31 | 2014-10-01 |
-      | Also Rivers              | rejected |                |            |            | 2011-01-01 |
-      | River Island             | hidden   |                |            |            | 2011-01-01 |
+      | action                   | state    | signature_count | opened_at  | closed_at  | created_at |
+      | Rivers are great         | closed   | 835             | 2012-01-01 | 2013-01-01 | 2012-01-01 |
+      | More rivers please       | closed   | 243             | 2011-04-01 | 2012-04-01 | 2011-04-01 |
+      | Cry me a river           | closed   | 639             | 2014-10-01 | 2015-03-31 | 2014-10-01 |
+      | Also Rivers              | rejected |                 |            |            | 2011-01-01 |
+      | River Island             | hidden   |                 |            |            | 2011-01-01 |
 
 Scenario: Arnold searches for petitions when parliament is opened
   Given I am on the home page
@@ -31,10 +31,10 @@ Scenario: Arnold searches for petitions when parliament is opened
   And I should see my search term "Wombles" filled in the search field
   And I should see "4 results"
   And I should see the following search results:
-    | Wombles                            | 1 signature             |
-    | Overthrow the Wombles              | 1 signature             |
-    | Uncle Bulgaria                     | 1 signature             |
-    | Common People                      | 1 signature             |
+    | Uncle Bulgaria        | 23 signatures |
+    | Common People         | 19 signatures |
+    | Overthrow the Wombles | 17 signatures |
+    | Wombles               | 13 signatures |
 
 Scenario: Arnold searches for petitions when parliament is dissolving
   Given Parliament is dissolving
@@ -47,10 +47,10 @@ Scenario: Arnold searches for petitions when parliament is dissolving
   And I should see my search term "Wombles" filled in the search field
   And I should see "4 results"
   And I should see the following search results:
-    | Wombles                            | 1 signature             |
-    | Overthrow the Wombles              | 1 signature             |
-    | Uncle Bulgaria                     | 1 signature             |
-    | Common People                      | 1 signature             |
+    | Uncle Bulgaria        | 23 signatures |
+    | Common People         | 19 signatures |
+    | Overthrow the Wombles | 17 signatures |
+    | Wombles               | 13 signatures |
 
 Scenario: Arnold searches for petitions when parliament is dissolved
   Given Parliament is dissolved
@@ -64,11 +64,11 @@ Scenario: Arnold searches for petitions when parliament is dissolved
   And I should see my search term "Wombles" filled in the search field
   And I should see "5 results"
   And I should see the following search results:
-    | Wombles                            | 1 signature |
-    | Overthrow the Wombles              | 1 signature |
-    | Uncle Bulgaria                     | 1 signature |
-    | Common People                      | 1 signature |
-    | The Wombles will rock Glasto       | 1 signature |
+    | Uncle Bulgaria               | 23 signatures |
+    | Common People                | 19 signatures |
+    | Overthrow the Wombles        | 17 signatures |
+    | Wombles                      | 13 signatures |
+    | The Wombles will rock Glasto | 1 signature   |
 
 Scenario: Arnold searches for petitions when parliament is pending
   Given Parliament is pending
@@ -81,6 +81,6 @@ Scenario: Arnold searches for petitions when parliament is pending
   And I should see my search term "Rivers" filled in the search field
   And I should see "3 results"
   And I should see the following search results:
-    | More rivers please       | 243 signatures   |
-    | Rivers are great         | 835 signatures   |
-    | Cry me a river           | 639 signatures   |
+    | Rivers are great         | 835 signatures |
+    | Cry me a river           | 639 signatures |
+    | More rivers please       | 243 signatures |

--- a/features/joe_searches_for_an_archived_petition.feature
+++ b/features/joe_searches_for_an_archived_petition.feature
@@ -6,11 +6,11 @@ Feature: Joe searches for an archived petition
 
   Background:
     Given the following archived petitions exist:
-      | action                   | state    | signature_count| opened_at  | closed_at  | created_at |
-      | Wombles are great        | closed   | 835            | 2012-01-01 | 2013-01-01 | 2012-01-01 |
-      | The Wombles of Wimbledon | closed   | 243            | 2011-04-01 | 2012-04-01 | 2011-04-01 |
-      | Common People            | closed   | 639            | 2014-10-01 | 2015-03-31 | 2014-10-01 |
-      | Eavis vs the Wombles     | rejected |                |            |            | 2011-01-01 |
+      | action                   | state    | signature_count | opened_at  | closed_at  | created_at |
+      | Wombles are great        | closed   | 835             | 2012-01-01 | 2013-01-01 | 2012-01-01 |
+      | The Wombles of Wimbledon | closed   | 243             | 2011-04-01 | 2012-04-01 | 2011-04-01 |
+      | Common People            | closed   | 639             | 2014-10-01 | 2015-03-31 | 2014-10-01 |
+      | Eavis vs the Wombles     | rejected |                 |            |            | 2011-01-01 |
 
   Scenario: Searching for petitions
     When I go to the archived petitions page
@@ -19,8 +19,8 @@ Feature: Joe searches for an archived petition
     Then I should be on the archived petitions page
     But I should see the following search results:
       | Eavis vs the Wombles           | Rejected       |
-      | The Wombles of Wimbledon       | 243 signatures |
       | Wombles are great              | 835 signatures |
+      | The Wombles of Wimbledon       | 243 signatures |
     And the markup should be valid
 
   Scenario: Paging through archived petitions

--- a/features/step_definitions/inspection_steps.rb
+++ b/features/step_definitions/inspection_steps.rb
@@ -63,9 +63,11 @@ end
 ### Tables...
 
 Then(/^I should see the following search results:$/) do |values_table|
-  values_table.raw.each do |row|
-    row.each do |column|
-      expect(page).to have_content(column)
+  values_table.raw.each_with_index do |row, idx|
+    expect(page).to have_selector(:css, ".search-results ol li:nth-child(#{idx+1}) h2", text: row[0]);
+
+    if row[1].present?
+      expect(page).to have_selector(:css, ".search-results ol li:nth-child(#{idx+1}) p", text: row[1]);
     end
   end
 end

--- a/features/step_definitions/pickle_steps.rb
+++ b/features/step_definitions/pickle_steps.rb
@@ -46,8 +46,8 @@ Then(/^a admin user should not exist with email: "([^"]*)"$/) do |email|
   expect(AdminUser.where(email: email)).not_to exist
 end
 
-Given(/^an open petition exists with action: "([^"]*)"$/) do |action|
-  @petition = FactoryBot.create(:open_petition, action: action)
+Given(/^an open petition exists with action: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, validated_signatures: signature_count)
 end
 
 Given(/^a referred petition exists with action: "([^"]*)"$/) do |action|
@@ -94,8 +94,8 @@ Given(/^an sponsored petition exists with action: "([^"]*)"$/) do |action|
   @petition = FactoryBot.create(:sponsored_petition, action: action)
 end
 
-Given(/^an open petition exists with action: "([^"]*)", background: "([^"]*)"$/) do |action, background|
-  @petition = FactoryBot.create(:open_petition, action: action, background: background)
+Given(/^an open petition exists with action: "([^"]*)", background: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, background, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, background: background, validated_signatures: signature_count)
 end
 
 Given(/^a closed petition exists with action: "([^"]*)"$/) do |action|
@@ -114,16 +114,16 @@ Given(/^a validated petition exists with action: "([^"]*)"$/) do |action|
   @petition = FactoryBot.create(:validated_petition, action: action)
 end
 
-Given(/^an open petition exists with action: "([^"]*)", additional_details: "([^"]*)", closed_at: "([^"]*)"$/) do |action, additional_details, closed_at|
-  @petition = FactoryBot.create(:open_petition, action: action, additional_details: additional_details, closed_at: closed_at)
+Given(/^an open petition exists with action: "([^"]*)", additional_details: "([^"]*)", closed_at: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, additional_details, closed_at, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, additional_details: additional_details, closed_at: closed_at, validated_signatures: signature_count)
 end
 
-Given(/^an open petition exists with action: "([^"]*)", background: "([^"]*)", closed_at: "([^"]*)"$/) do |action, background, closed_at|
-  @petition = FactoryBot.create(:open_petition, action: action, background: background, closed_at: closed_at)
+Given(/^an open petition exists with action: "([^"]*)", background: "([^"]*)", closed_at: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, background, closed_at, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, background: background, closed_at: closed_at, validated_signatures: signature_count)
 end
 
-Given(/^an open petition exists with action: "([^"]*)", closed_at: "([^"]*)"$/) do |action, closed_at|
-  @petition = FactoryBot.create(:open_petition, action: action, closed_at: closed_at)
+Given(/^an open petition exists with action: "([^"]*)", closed_at: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, closed_at, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, closed_at: closed_at, validated_signatures: signature_count)
 end
 
 Given(/^a referred petition exists with action: "([^"]*)", closed_at: "([^"]*)"$/) do |action, closed_at|
@@ -152,12 +152,12 @@ Given(/^(\d+) open petitions exist with action: "([^"]*)"$/) do |number, action|
   end
 end
 
-Given(/^an open petition exists with action: "([^"]*)", additional_details: "([^"]*)"$/) do |action, additional_details|
-  @petition = FactoryBot.create(:open_petition, action: action, additional_details: additional_details)
+Given(/^an open petition exists with action: "([^"]*)", additional_details: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, additional_details, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, additional_details: additional_details, validated_signatures: signature_count)
 end
 
-Given(/^an open petition exists with action: "([^"]*)", committee_note: "([^"]*)"$/) do |action, committee_note|
-  @petition = FactoryBot.create(:open_petition, action: action, committee_note: committee_note)
+Given(/^an open petition exists with action: "([^"]*)", committee_note: "([^"]*)"(?:, signature_count: (\d+))?$/) do |action, committee_note, signature_count|
+  @petition = FactoryBot.create(:open_petition, action: action, committee_note: committee_note, validated_signatures: signature_count)
 end
 
 Given(/^the following archived petitions exist:$/) do |table|

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -7,13 +7,13 @@ Feature: Suzy Singer searches by free text
     Given the date is the "21 April 2011 12:00"
     And a pending petition exists with action: "Wombles are great"
     And a validated petition exists with action: "The Wombles of Wimbledon"
-    And an open petition exists with action: "Uncle Bulgaria", additional_details: "The Wombles are here", closed_at: "1 minute from now"
-    And an open petition exists with action: "Common People", background: "The Wombles belong to us all", closed_at: "11 days from now"
-    And an open petition exists with action: "Overthrow the Wombles", closed_at: "1 year from now"
+    And an open petition exists with action: "Uncle Bulgaria", additional_details: "The Wombles are here", closed_at: "1 minute from now", signature_count: 23
+    And an open petition exists with action: "Common People", background: "The Wombles belong to us all", closed_at: "11 days from now", signature_count: 19
+    And an open petition exists with action: "Overthrow the Wombles", closed_at: "3 months from now", signature_count: 17
     And a closed petition exists with action: "The Wombles will rock Glasto", closed_at: "1 minute ago"
     And a rejected petition exists with action: "Eavis vs the Wombles"
     And a hidden petition exists with action: "The Wombles are profane"
-    And an open petition exists with action: "Wombles", closed_at: "10 days from now"
+    And an open petition exists with action: "Wombles", closed_at: "10 days from now", signature_count: 13
 
     # waiting for governments response
     And a petition "Force supermarkets to give unsold food to charities" exists and passed the threshold for a response 1 day ago
@@ -32,25 +32,42 @@ Feature: Suzy Singer searches by free text
     Then I should see my search term "Wombles" filled in the search field
     And I should see "6 results"
     And I should see the following search results:
-      | Wombles                            | 1 signature             |
-      | Overthrow the Wombles              | 1 signature             |
-      | Uncle Bulgaria                     | 1 signature             |
-      | Common People                      | 1 signature             |
-      | The Wombles will rock Glasto       | 1 signature, now closed |
-      | Eavis vs the Wombles               | Rejected                |
+      | Uncle Bulgaria               | 23 signatures           |
+      | Common People                | 19 signatures           |
+      | Overthrow the Wombles        | 17 signatures           |
+      | Wombles                      | 13 signatures           |
+      | The Wombles will rock Glasto | 1 signature, now closed |
+      | Eavis vs the Wombles         | Rejected                |
     And the markup should be valid
 
   Scenario: Search for open petitions
     When I search for "Open petitions" with "Wombles"
     Then I should see my search term "Wombles" filled in the search field
+    And I should see "These petitions are sorted by popularity"
+    And I should see a link called "Sort them by date of publishing" linking to "/petitions?state=recent&q=Wombles"
     And I should see "4 results"
     And I should not see "Wombles are great"
     And I should not see "The Wombles of Wimbledon"
     But I should see the following search results:
-      | Wombles                            | 1 signature |
-      | Overthrow the Wombles              | 1 signature |
-      | Uncle Bulgaria                     | 1 signature |
-      | Common People                      | 1 signature |
+      | Uncle Bulgaria        | 23 signatures |
+      | Common People         | 19 signatures |
+      | Overthrow the Wombles | 17 signatures |
+      | Wombles               | 13 signatures |
+    And the markup should be valid
+
+  Scenario: Search for recent petitions
+    When I search for "Recent petitions" with "Wombles"
+    Then I should see my search term "Wombles" filled in the search field
+    And I should see "These petitions are sorted by date of publishing"
+    And I should see a link called "Sort them by popularity" linking to "/petitions?state=open&q=Wombles"
+    And I should see "4 results"
+    And I should not see "Wombles are great"
+    And I should not see "The Wombles of Wimbledon"
+    But I should see the following search results:
+      | Overthrow the Wombles | 17 signatures |
+      | Common People         | 19 signatures |
+      | Wombles               | 13 signatures |
+      | Uncle Bulgaria        | 23 signatures |
     And the markup should be valid
 
   Scenario: See search counts
@@ -58,13 +75,14 @@ Feature: Suzy Singer searches by free text
     And I fill in "Wombles" as my search term
     And I press "Search"
     Then I should see an "open" petition count of 10
+    Then I should see an "recent" petition count of 10
     Then I should see a "closed" petition count of 1
     Then I should see a "rejected" petition count of 1
 
   Scenario: Search for open petitions using multiple search terms
     When I search for "Open petitions" with "overthrow the"
     Then I should see the following search results:
-      | Overthrow the Wombles | 1 signature |
+      | Overthrow the Wombles | 17 signatures |
 
   Scenario: Search for rejected petitions
     When I search for "Rejected petitions" with "WOMBLES"
@@ -84,12 +102,12 @@ Feature: Suzy Singer searches by free text
   Scenario: Search for petitions having a government response
     When I search for "Government responses" with "foxes"
     Then I should see the following search results:
-      | Save the city foxes            | 1 signature |
+      | Save the city foxes | 1 signature |
 
   Scenario: Search for petitions debated in Parliament
     When I search for "Debated in Parliament" with "EU"
     Then I should see the following search results:
-      | Leave EU                        | 1 signature |
+      | Leave EU | 1 signature |
 
   Scenario: Paginate through open petitions
     Given 51 open petitions exist with action: "International development spending"


### PR DESCRIPTION
To allow regular visitors to see recently added petitions add a list that shows open petitions by date of publishing and not signature count.

Rather than add a UX element for sorting which would be confusing to show/hide depending on which list was selected we leverage the existing lists UX and add a header that allows toggling between the two views of open petitions.

This is the prompt when viewing the 'Open petitions' list:

![image](https://user-images.githubusercontent.com/6321/227911151-07d06861-4b50-4f38-adc5-e6ec0e7af731.png)

This is the prompt when viewing the 'Recent petitions' list:

![image](https://user-images.githubusercontent.com/6321/227911294-392c3de2-9f4d-4167-af55-15b6eeeb701b.png)

The search parameter `q` is maintained when toggling between the two views unlike the lists at the top and bottom of the page.