### PR TITLE
Restore state when decrementing the signature count

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -598,6 +598,13 @@ class Petition < ActiveRecord::Base
       updates << "response_threshold_reached_at = NULL"
     end
 
+    if below_threshold_for_moderation?
+      if state == 'sponsored'
+        updates << "moderation_threshold_reached_at = NULL"
+        updates << "state = 'validated'"
+      end
+    end
+
     updates << "signature_count = greatest(signature_count - 1, 1)"
     updates << "updated_at = :now"
 
@@ -641,6 +648,12 @@ class Petition < ActiveRecord::Base
   def at_threshold_for_debate?
     unless debate_threshold_reached_at?
       signature_count >= Site.threshold_for_debate
+    end
+  end
+
+  def below_threshold_for_moderation?
+    if moderation_threshold_reached_at?
+      signature_count <= Site.threshold_for_moderation + 1
     end
   end
 


### PR DESCRIPTION
When a petition is in the sponsored state and the signature count is decremented restore the state to be 'validated' and clear the timestamp. We only do this for petitions in the sponsored state and not ones that have been moderated - either published or rejected.