### PR TITLE
Allow petitions that have been taken down to be restored

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -720,7 +720,7 @@ class Petition < ActiveRecord::Base
       when 'dormant'
         update!(state: DORMANT_STATE)
       when 'restore'
-        update!(state: SPONSORED_STATE)
+        update!(state: SPONSORED_STATE, open_at: nil, closed_at: nil)
       else
         errors.add :moderation, :blank
         raise ActiveRecord::RecordNotSaved, "Unable to moderate petition"

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -18,22 +18,22 @@
           <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>
         </div>
       <% end %>
-      <% if f.object.restorable? %>
-        <div class="multiple-choice">
-          <%= f.radio_button :moderation, 'restore' %>
-          <%= f.label :moderation_restore, "Restore", for: "petition_moderation_restore" %>
-        </div>
-      <% end %>
-      <% if f.object.flaggable? %>
-        <div class="multiple-choice">
-          <%= f.radio_button :moderation, 'flag' %>
-          <%= f.label :moderation_flag, "Flag", for: "petition_moderation_flag" %>
-        </div>
-        <div class="multiple-choice">
-          <%= f.radio_button :moderation, 'dormant' %>
-          <%= f.label :moderation_dormant, "Dormant", for: "petition_moderation_dormant" %>
-        </div>
-      <% end %>
+    <% end %>
+    <% if f.object.restorable? %>
+      <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'restore' %>
+        <%= f.label :moderation_restore, "Restore", for: "petition_moderation_restore" %>
+      </div>
+    <% end %>
+    <% if f.object.flaggable? %>
+      <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'flag' %>
+        <%= f.label :moderation_flag, "Flag", for: "petition_moderation_flag" %>
+      </div>
+      <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'dormant' %>
+        <%= f.label :moderation_dormant, "Dormant", for: "petition_moderation_dormant" %>
+      </div>
     <% end %>
   <% end %>
 

--- a/features/admin/takedown.feature
+++ b/features/admin/takedown.feature
@@ -22,3 +22,22 @@ Feature: Terry (or Sheila) takes down a petition
     And I take down the petition with a reason code "Duplicate petition"
     Then the petition is not available for signing
     And I should not be able to take down the petition
+
+  Scenario: A sysadmin can restore a petition that has been taken down
+    Given I am logged in as a sysadmin
+    And a published petition has been taken down
+    When I visit the petition
+    Then the petition can no longer be rejected
+    And the petition can no longer be marked as dormant
+    But it can still be approved
+    And it can still be restored
+    When I restore to a sponsored state
+    Then the creator should not receive a notification email
+    And the petition is not available for searching or viewing
+    But the petition will still show up in the back-end reporting
+
+  Scenario: A moderator can't restore a petition that has been taken down
+    Given I am logged in as a moderator
+    And a published petition has been taken down
+    When I visit the petition
+    Then there are no moderation options

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -104,7 +104,7 @@ Then(/^the petition can no longer be marked as dormant$/) do
   expect(page).to have_no_field('Dormant', visible: false)
 end
 
-When(/^I revisit the petition$/) do
+When(/^I (?:re)?visit the petition$/) do
   visit admin_petition_url(@petition)
 end
 
@@ -203,4 +203,22 @@ end
 
 Then /^the petition should still be unmoderated$/ do
   expect(@petition).not_to be_visible
+end
+
+Given(/^a published petition has been taken down$/) do
+  steps %Q(
+    When I view all petitions
+    And I follow "Mistakenly published petition"
+    And I take down the petition with a reason code "Offensive or a joke"
+    Then the petition is not available for searching or viewing
+    And I should not be able to take down the petition
+  )
+end
+
+Then(/^there are no moderation options$/) do
+  expect(page).to have_no_field('Approve', visible: false)
+  expect(page).to have_no_field('Reject', visible: false)
+  expect(page).to have_no_field('Restore', visible: false)
+  expect(page).to have_no_field('Flag', visible: false)
+  expect(page).to have_no_field('Dormant', visible: false)
 end


### PR DESCRIPTION
Sometime petitions are mistakenly published and then taken down but are fine on further checking so allow them to be republished without the creator having to resubmit the petition again.

Since the restoration process resets the open_at and closed_at timestamps the feature is limited to sysadmins as it could be abused.