### PR TITLE
Don't apply domain allow list to creators, sponsors and feedback

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -34,6 +34,10 @@ class Feedback < ActiveRecord::Base
     nil
   end
 
+  def allowed_domains?
+    false
+  end
+
   private
 
   def rate_limit

--- a/app/models/rate_limit.rb
+++ b/app/models/rate_limit.rb
@@ -93,7 +93,10 @@ class RateLimit < ActiveRecord::Base
     return true if ip_geoblocked?(signature.ip_address)
     return true if domain_blocked?(signature.domain)
     return false if ip_allowed?(signature.ip_address)
-    return false if domain_allowed?(signature.domain)
+
+    if signature.allowed_domains?
+      return false if domain_allowed?(signature.domain)
+    end
 
     if signature.is_a?(Feedback)
       feedback_rate_exceeded?(signature)

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -758,6 +758,10 @@ class Signature < ActiveRecord::Base
     end
   end
 
+  def allowed_domains?
+    !(creator? || sponsor?)
+  end
+
   def update_uuid
     update_column(:uuid, generate_uuid)
   end

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -205,7 +205,7 @@ Scenario: Charlie creates a petition when blocked
 Scenario: Charlie creates a petition when his IP address is rate limited
   Given the creator rate limit is 1 per hour
   And there are no allowed IPs
-  And there are no blocked IPs
+  And the domain "wimbledon.com" is allowed
   And there are 2 petitions created from this IP address
   And I start a new petition
   And I fill in the petition details

--- a/features/laura_signs_charlies_petition_as_a_sponsor.feature
+++ b/features/laura_signs_charlies_petition_as_a_sponsor.feature
@@ -90,7 +90,7 @@ Feature: As Laura, a sponsor of my friend Charlie's petition
   Scenario: Laura does not get an email when IP address is rate limited
     Given the sponsor rate limit is 1 per hour
     And there are no allowed IPs
-    And there are no allowed domains
+    And the domain "example.com" is allowed
     And there is a sponsor already from this IP address
     When I visit the "sponsor this petition" url I was given
     And I fill in my details as a sponsor

--- a/features/user_sends_feedback.feature
+++ b/features/user_sends_feedback.feature
@@ -36,7 +36,7 @@ Feature: User sends feedback
   Scenario: User is blocked by IP address rate limiting
     Given the feedback rate limit is 1 per hour
     And there are no allowed IPs
-    And there are no allowed domains
+    And the domain "example.com" is allowed
     And there are 2 feedbacks created from this IP address
     And I am on the feedback page
     When I fill in "Comments" with "I must protest"


### PR DESCRIPTION
It's easy to create a handful of gmail.com, etc. addresses required to sponsor a petition so don't skip rate-limiting those for creators, sponsors and feedback messages. They're easy to spot during moderation but better that they don't appear in the moderation queue.