### PR TITLE
Add missing require for String#first

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -1,4 +1,5 @@
 require 'tmpdir'
+require 'active_support/core_ext/string/access'
 require 'active_support/core_ext/string/strip'
 require 'aws-sdk-codedeploy'
 require 'aws-sdk-s3'


### PR DESCRIPTION
When we run `rake deploy:<env>` the Rails environment hasn't been loaded so ensure that we load the core extension for `String#first`. Previously it was being implicitly required by another gem.