### PR TITLE
Lowercase admin user email addresses

### DIFF
--- a/db/migrate/20240227155037_lowercase_admin_user_emails.rb
+++ b/db/migrate/20240227155037_lowercase_admin_user_emails.rb
@@ -1,0 +1,11 @@
+class LowercaseAdminUserEmails < ActiveRecord::Migration[6.1]
+  class AdminUser < ActiveRecord::Base; end
+
+  def change
+    up_only do
+      AdminUser.find_each do |user|
+        user.email = user.email.downcase
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_29_152626) do
+ActiveRecord::Schema.define(version: 2024_02_27_155037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"


### PR DESCRIPTION
This is to ensure that we don't have duplicate accounts.