### PR TITLE
Remove check for editing being disabled

### DIFF
--- a/app/views/admin/archived/debate_outcomes/_petition_action_debate_outcome.html.erb
+++ b/app/views/admin/archived/debate_outcomes/_petition_action_debate_outcome.html.erb
@@ -49,13 +49,13 @@
     <%= form_row for: [f.object, :public_engagement_url] do %>
       <%= f.label :public_engagement_url, 'Public Engagement URL', class: 'form-label' %>
       <%= error_messages_for_field f.object, :public_engagement_url %>
-      <%= f.url_field :public_engagement_url, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+      <%= f.url_field :public_engagement_url, tabindex: increment, class: 'form-control' %>
     <% end %>
 
     <%= form_row for: [f.object, :debate_summary_url] do %>
       <%= f.label :debate_summary_url, 'Debate Summary URL', class: 'form-label' %>
       <%= error_messages_for_field f.object, :debate_summary_url %>
-      <%= f.url_field :debate_summary_url, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+      <%= f.url_field :debate_summary_url, tabindex: increment, class: 'form-control' %>
     <% end %>
 
     <%= form_row for: [f.object, :image] do %>

--- a/features/admin/providing_debate_outcome_information.feature
+++ b/features/admin/providing_debate_outcome_information.feature
@@ -4,7 +4,7 @@ Feature: Providing debate outcome information
   As an admin user
   I want to store information about debates on the petition
 
-  Scenario: Adding debate outcome infromation
+  Scenario: Adding debate outcome information
     Given an open petition "Ban Badger Baiting" with some signatures
     And I am logged in as a sysadmin
     When I am on the admin all petitions page
@@ -20,3 +20,20 @@ Feature: Providing debate outcome information
     Then the petition should have the debate details I provided
     And the petition creator should have been emailed about the debate
     And all the signatories of the petition should have been emailed about the debate
+
+  Scenario: Adding debate outcome information to an archived petition
+    Given an archived petition "Ban Badger Baiting" with some signatures
+    And I am logged in as a sysadmin
+    When I am on the admin archived petitions page
+    And I follow "Ban Badger Baiting"
+    And I follow "Debate outcome"
+    Then I should be on the admin archived debate outcomes form page for "Ban Badger Baiting"
+    And the markup should be valid
+    When I press "Email 6 petitioners"
+    Then the petition should not have debate details
+    And I should see an error
+    When I fill in the debate outcome details
+    And press "Email 6 petitioners"
+    Then the petition should have the debate details I provided
+    And the archived petition creator should have been emailed about the debate
+    And all the signatories of the archived petition should have been emailed about the debate

--- a/features/step_definitions/debate_outcome_steps.rb
+++ b/features/step_definitions/debate_outcome_steps.rb
@@ -103,6 +103,17 @@ Then(/^the petition creator should have been emailed about the debate$/) do
   )
 end
 
+Then(/^the archived petition creator should have been emailed about the debate$/) do
+  @petition.reload
+  steps %Q(
+    Then "#{@petition.creator.email}" should receive an email
+    When they open the email
+    Then they should see "Parliament debated your petition" in the email body
+    When they follow "#{archived_petition_url(@petition)}" in the email
+    Then I should be on the archived petition page for "#{@petition.action}"
+  )
+end
+
 Then(/^all the signatories of the petition should have been emailed about the debate$/) do
   @petition.reload
   @petition.signatures.validated.subscribed.where.not(id: @petition.creator.id).each do |signatory|
@@ -112,6 +123,19 @@ Then(/^all the signatories of the petition should have been emailed about the de
       Then they should see "Parliament debated the petition you signed" in the email body
       When they follow "#{petition_url(@petition)}" in the email
       Then I should be on the petition page for "#{@petition.action}"
+    )
+  end
+end
+
+Then(/^all the signatories of the archived petition should have been emailed about the debate$/) do
+  @petition.reload
+  @petition.signatures.validated.subscribed.where.not(id: @petition.creator.id).each do |signatory|
+    steps %Q(
+      Then "#{signatory.email}" should receive an email
+      When they open the email
+      Then they should see "Parliament debated the petition you signed" in the email body
+      When they follow "#{archived_petition_url(@petition)}" in the email
+      Then I should be on the archived petition page for "#{@petition.action}"
     )
   end
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -422,6 +422,11 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some (fraudulent)? ?sig
   5.times { FactoryBot.create(:"#{signature_state}_signature", petition: @petition) }
 end
 
+Given(/^an archived petition "(.*?)" with some signatures$/) do |petition_action|
+  @petition = FactoryBot.create(:archived_petition, :creator, action: petition_action, signature_count: 6)
+  5.times { FactoryBot.create(:archived_signature, petition: @petition) }
+end
+
 Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|
   Site.instance.update!(threshold_for_debate: amount)
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -113,6 +113,9 @@ module NavigationHelpers
     when /^debate outcomes form page for "([^\"]*)"$/
       admin_petition_debate_outcome_url(Petition.find_by(action: $1))
 
+    when /^archived debate outcomes form page for "([^\"]*)"$/
+      admin_archived_petition_debate_outcome_url(Archived::Petition.find_by(action: $1))
+
     when /^email petitioners form page for "([^\"]*)"$/
       new_admin_petition_email_url(Petition.find_by(action: $1))
 
@@ -121,6 +124,9 @@ module NavigationHelpers
 
     when /^petition edit details page for "([^\"]*)"$/
       admin_petition_details_url(Petition.find_by(action: $1))
+
+    when /^archived petitions page$/
+      admin_archived_petitions_url
 
     when /^archived petition page for "([^\"]*)"$/
       admin_archived_petition_url(Archived::Petition.find_by(action: $1))


### PR DESCRIPTION
The editing of petitions is only disabled when the archiving process is running so isn't relevant for archived petitions.