### PR TITLE
Ignore Faraday::TimeoutError exceptions

### DIFF
--- a/app/models/constituency/api_query.rb
+++ b/app/models/constituency/api_query.rb
@@ -13,6 +13,16 @@ class Constituency < ActiveRecord::Base
     MP_START   = './StartDate'
     MP_END     = './EndDate'
 
+    IGNORE_EXCEPTIONS = [
+      Faraday::ResourceNotFound,
+      Faraday::ClientError,
+      Faraday::TimeoutError
+    ]
+
+    NOTIFY_EXCEPTIONS = [
+      Faraday::Error
+    ]
+
     def fetch(postcode)
       response = client.call(postcode)
 
@@ -21,9 +31,9 @@ class Constituency < ActiveRecord::Base
       else
         []
       end
-    rescue Faraday::ResourceNotFound, Faraday::ClientError => e
+    rescue *IGNORE_EXCEPTIONS => e
       return []
-    rescue Faraday::Error => e
+    rescue *NOTIFY_EXCEPTIONS => e
       Appsignal.send_exception(e)
       return []
     end

--- a/spec/models/constituency/api_query_spec.rb
+++ b/spec/models/constituency/api_query_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Constituency::ApiQuery, type: :model do
         end
 
         it "returns an empty array" do
+          expect(Appsignal).not_to receive(:send_exception)
           expect(query.fetch("N1")).to eq([])
         end
       end
@@ -120,6 +121,7 @@ RSpec.describe Constituency::ApiQuery, type: :model do
         end
 
         it "returns an empty array" do
+          expect(Appsignal).not_to receive(:send_exception)
           expect(query.fetch("N1")).to eq([])
         end
       end
@@ -130,6 +132,7 @@ RSpec.describe Constituency::ApiQuery, type: :model do
         end
 
         it "returns an empty array" do
+          expect(Appsignal).not_to receive(:send_exception)
           expect(query.fetch("N1")).to eq([])
         end
       end
@@ -140,6 +143,7 @@ RSpec.describe Constituency::ApiQuery, type: :model do
         end
 
         it "returns an empty array" do
+          expect(Appsignal).not_to receive(:send_exception)
           expect(query.fetch("N1")).to eq([])
         end
       end
@@ -150,6 +154,7 @@ RSpec.describe Constituency::ApiQuery, type: :model do
         end
 
         it "returns an empty array" do
+          expect(Appsignal).to receive(:send_exception)
           expect(query.fetch("N1")).to eq([])
         end
       end


### PR DESCRIPTION
Faraday moved the Faraday::TimeoutError from a client error to a server error which meant that it was no longer being ignored.

This commit restores the previous behaviour by explicitly rescuing the Faraday::TimeoutError subclass.