### PR TITLE
Remove the current_user method from Delayed::Web

### DIFF
--- a/config/initializers/delayed_web.rb
+++ b/config/initializers/delayed_web.rb
@@ -6,6 +6,10 @@ Rails.application.config.to_prepare do
   Delayed::Web::ApplicationController.class_eval do
     include FlashI18n
 
+    rescue_from ActiveRecord::RecordNotFound do
+      redirect_to root_url, notice: t(:notice, scope: 'delayed/web.flashes.jobs.not_found')
+    end
+
     before_action :require_admin
 
     def admin_request?

--- a/config/initializers/delayed_web.rb
+++ b/config/initializers/delayed_web.rb
@@ -18,10 +18,6 @@ Rails.application.config.to_prepare do
       main_app.admin_login_url
     end
 
-    def current_user
-      @current_user ||= warden.authenticate(scope: :user)
-    end
-
     def require_admin
       unless current_user
         redirect_to admin_login_url, alert: :admin_required

--- a/config/locales/delayed_web.en-GB.yml
+++ b/config/locales/delayed_web.en-GB.yml
@@ -34,3 +34,5 @@ en-GB:
         destroyed:
           alert: 'Job cannot be deleted because it is already %{status}'
           notice: 'Job destroyed'
+        not_found:
+          notice: 'Job not found'


### PR DESCRIPTION
The method already exists from the Devise helpers and is public.