### PR TITLE
Allow sponsoring of flagged petitions

### DIFF
--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -23,7 +23,7 @@ class SponsorsController < SignaturesController
   def retrieve_petition
     @petition = Petition.not_hidden.find(petition_id)
 
-    if @petition.flagged? || @petition.dormant? || @petition.stopped?
+    if @petition.dormant? || @petition.stopped?
       raise ActiveRecord::RecordNotFound, "Unable to find Petition with id: #{petition_id}"
     end
 
@@ -36,7 +36,7 @@ class SponsorsController < SignaturesController
     @signature = Signature.sponsors.find(signature_id)
     @petition = @signature.petition
 
-    if @petition.flagged? || @petition.dormant? || @petition.hidden? || @petition.stopped?
+    if @petition.dormant? || @petition.hidden? || @petition.stopped?
       raise ActiveRecord::RecordNotFound, "Unable to find Signature with id: #{signature_id}"
     end
   end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2109,9 +2109,23 @@ RSpec.describe Petition, type: :model do
       it "records changes the state from 'pending' to 'validated'" do
         expect {
           petition.increment_signature_count!
-        }.to change{
+        }.to change {
           petition.state
         }.from(Petition::PENDING_STATE).to(Petition::VALIDATED_STATE)
+      end
+
+      context "and the petition is flagged" do
+        before do
+          petition.update!(state: "flagged")
+        end
+
+        it "doesn't change the state" do
+          expect {
+            petition.increment_signature_count!
+          }.not_to change {
+            petition.state
+          }.from(Petition::FLAGGED_STATE)
+        end
       end
     end
 
@@ -2147,6 +2161,20 @@ RSpec.describe Petition, type: :model do
             petition.state
           }.from(Petition::VALIDATED_STATE).to(Petition::SPONSORED_STATE)
         end
+
+        context "and the petition is flagged" do
+          before do
+            petition.update!(state: "flagged")
+          end
+
+          it "doesn't change the state" do
+            expect {
+              petition.increment_signature_count!
+            }.not_to change {
+              petition.state
+            }.from(Petition::FLAGGED_STATE)
+          end
+        end
       end
 
       context "without having been validated by a sponsor yet" do
@@ -2172,6 +2200,20 @@ RSpec.describe Petition, type: :model do
           }.to change {
             petition.state
           }.from(Petition::PENDING_STATE).to(Petition::SPONSORED_STATE)
+        end
+
+        context "and the petition is flagged" do
+          before do
+            petition.update!(state: "flagged")
+          end
+
+          it "doesn't change the state" do
+            expect {
+              petition.increment_signature_count!
+            }.not_to change {
+              petition.state
+            }.from(Petition::FLAGGED_STATE)
+          end
         end
       end
     end


### PR DESCRIPTION
Once a petition has entered the moderation queue the fact that it's been flagged shouldn't prevent more sponsors up to the maximum number.