### PR TITLE
Add migration to update constituencies end date

### DIFF
--- a/db/migrate/20240611085936_add_end_date_to_constituencies.rb
+++ b/db/migrate/20240611085936_add_end_date_to_constituencies.rb
@@ -1,0 +1,8 @@
+class AddEndDateToConstituencies < ActiveRecord::Migration[7.1]
+  def change
+    up_only do
+      Constituency.update_all(end_date: "2024/05/30")
+      FetchConstituenciesJob.perform_now
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_162307) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_085936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
   enable_extension "plpgsql"


### PR DESCRIPTION
We need to ensure that all constituencies that existed before the June 2024 change have an end date applied before we fetch the list of new constituencies.