### PR TITLE
Limit response to current constituencies

### DIFF
--- a/app/controllers/constituencies_controller.rb
+++ b/app/controllers/constituencies_controller.rb
@@ -2,7 +2,7 @@ class ConstituenciesController < ApplicationController
   before_action :set_cors_headers, only: [:index], if: :json_request?
 
   def index
-    @constituencies = Constituency.by_ons_code
+    @constituencies = Constituency.current.by_ons_code
 
     respond_to do |format|
       format.json


### PR DESCRIPTION
The `/constituencies.json` response returns all constituencies. This change limits the response to the new constituencies only.