### PR TITLE
Add parliament details to archived_petition json

### DIFF
--- a/app/views/archived/petitions/_petition.json.jbuilder
+++ b/app/views/archived/petitions/_petition.json.jbuilder
@@ -5,6 +5,13 @@ json.links do
   json.self archived_petition_url(petition, format: :json)
 end if defined?(is_collection)
 
+json.parliament do
+  json.period petition.parliament.period
+  json.government petition.parliament.government
+  json.response_threshold petition.parliament.threshold_for_response
+  json.debate_threshold petition.parliament.threshold_for_debate
+end
+
 json.attributes do
   json.action petition.action
   json.background petition.background

--- a/app/views/archived/petitions/_petition.json.jbuilder
+++ b/app/views/archived/petitions/_petition.json.jbuilder
@@ -8,6 +8,7 @@ end if defined?(is_collection)
 json.parliament do
   json.period petition.parliament.period
   json.government petition.parliament.government
+  json.dissolution_at petition.parliament.dissolution_at
   json.response_threshold petition.parliament.threshold_for_response
   json.debate_threshold petition.parliament.threshold_for_debate
 end

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
           "updated_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z])
         )
       )
+
+      expect(JSON.parse(response.body)["data"]["parliament"]).to match(
+                              a_hash_including(
+                                "period" => a_string_matching(petition.parliament.period),
+                                "government" => a_string_matching(petition.parliament.government),
+                                "response_threshold" => a_string_matching(petition.parliament.threshold_for_response),
+                                "debate_threshold" => a_string_matching(petition.parliament.threshold_for_debate),
+                              )
+                            )
     end
 
     it "doesn't include the rejection section for non-rejected petitions" do

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
                               a_hash_including(
                                 "period" => a_string_matching(petition.parliament.period),
                                 "government" => a_string_matching(petition.parliament.government),
+                                "dissolution_at" => a_string_matching(petition.parliament.dissolution_at),
                                 "response_threshold" => a_string_matching(petition.parliament.threshold_for_response),
                                 "debate_threshold" => a_string_matching(petition.parliament.threshold_for_debate),
                               )


### PR DESCRIPTION
This PR adds the details of the parliament in which the petition was raised to the `archived/petitions/:id.json` view only.