### PR TITLE
Fix error handling when fetching constituencies

### DIFF
--- a/app/jobs/fetch_constituencies_job.rb
+++ b/app/jobs/fetch_constituencies_job.rb
@@ -5,9 +5,9 @@ class FetchConstituenciesJob < ApplicationJob
 
   def perform
     constituencies.each do |external_id, name, ons_code, start_date, end_date|
-      begin
-        retried = false
+      retried = false
 
+      begin
         Constituency.for(external_id) do |constituency|
           constituency.name = name
           constituency.ons_code = ons_code
@@ -31,8 +31,9 @@ class FetchConstituenciesJob < ApplicationJob
           constituency.save!
         end
       rescue ActiveRecord::RecordNotUnique => e
-        retry unless retried
+        next if retried
         retried = true
+        retry
       end
     end
   end

--- a/app/views/admin/sites/_features.html.erb
+++ b/app/views/admin/sites/_features.html.erb
@@ -1,5 +1,4 @@
 <%= hidden_field_tag :tab, "features" %>
-<%= hidden_field_tag :"site[features]", "" %>
 
 <div class="grid-row">
   <div class="column-half">


### PR DESCRIPTION
Don't reset the retried flag inside the block being retried.
