### PR TITLE
Don't run tasks when parliament has dissolved

### DIFF
--- a/lib/tasks/epets.rake
+++ b/lib/tasks/epets.rake
@@ -74,6 +74,7 @@ namespace :epets do
     desc "Start the signature count updater if it's not running"
     task :signature_counts => :environment do
       Task.run("epets:site:signature_counts", 10.minutes) do
+        break if Parliament.closed?(48.hours.ago)
         break unless Site.update_signature_counts
 
         unless Site.signature_count_updated_at > 15.minutes.ago
@@ -85,6 +86,8 @@ namespace :epets do
     desc "Track trending domains"
     task :trending_domains => :environment do
       Task.run("epets:site:trending_domains", 30.minutes) do
+        break if Parliament.closed?(48.hours.ago)
+
         TrendingDomainsByPetitionJob.perform_later
       end
     end
@@ -92,6 +95,8 @@ namespace :epets do
     desc "Track trending IP addresses"
     task :trending_ips => :environment do
       Task.run("epets:site:trending_ips", 30.minutes) do
+        break if Parliament.closed?(48.hours.ago)
+
         TrendingIpsByPetitionJob.perform_later
       end
     end

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -12,6 +12,8 @@ namespace :epets do
     desc "Add a task to the queue to close petitions at midnight"
     task :close => :environment do
       Task.run("epets:petitions:close") do
+        break if Parliament.closed?(48.hours.ago)
+
         time = Date.tomorrow.beginning_of_day
         ClosePetitionsJob.set(wait_until: time).perform_later(time.iso8601)
       end
@@ -20,6 +22,8 @@ namespace :epets do
     desc "Add a task to the queue to validate petition counts"
     task :count => :environment do
       Task.run("epets:petitions:count") do
+        break if Parliament.closed?(48.hours.ago)
+
         PetitionCountJob.perform_later
       end
     end
@@ -27,6 +31,8 @@ namespace :epets do
     desc "Add a task to the queue to mark petitions as debated at midnight"
     task :debated => :environment do
       Task.run("epets:petitions:debated") do
+        break if Parliament.closed?(48.hours.ago)
+
         date = Date.tomorrow
         DebatedPetitionsJob.set(wait_until: date.beginning_of_day).perform_later(date.iso8601)
       end
@@ -35,6 +41,8 @@ namespace :epets do
     desc "Add a task to the queue to extend petition deadlines at midnight"
     task :extend_deadline => :environment do
       Task.run("epets:petitions:extend_deadline") do
+        break if Parliament.closed?(48.hours.ago)
+
         ExtendPetitionDeadlinesJob.set(wait_until: Date.tomorrow.beginning_of_day).perform_later
       end
     end
@@ -42,6 +50,8 @@ namespace :epets do
     desc "Add a task to the queue to update petition statistics"
     task :update_statistics => :environment do
       Task.run("epets:petitions:update_statistics", 12.hours) do
+        break if Parliament.closed?(48.hours.ago)
+
         EnqueuePetitionStatisticsUpdatesJob.perform_later(24.hours.ago.iso8601)
       end
     end

--- a/spec/models/parliament_spec.rb
+++ b/spec/models/parliament_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Parliament, type: :model do
           FactoryBot.build(:parliament, opening_at: 2.years.ago, dissolution_at: nil)
         end
 
-        it "return false" do
+        it "returns false" do
           expect(parliament.closed?).to eq(false)
         end
       end
@@ -379,7 +379,7 @@ RSpec.describe Parliament, type: :model do
           FactoryBot.build(:parliament, opening_at: 2.years.ago, dissolution_at: 1.day.from_now)
         end
 
-        it "return false" do
+        it "returns false" do
           expect(parliament.closed?).to eq(false)
         end
       end
@@ -389,8 +389,20 @@ RSpec.describe Parliament, type: :model do
           FactoryBot.build(:parliament, opening_at: 2.years.ago, dissolution_at: 1.day.ago)
         end
 
-        it "return true" do
+        it "returns true" do
           expect(parliament.closed?).to eq(true)
+        end
+
+        context "and passed a timestamp before the dissolution time" do
+          it "returns false" do
+            expect(parliament.closed?(48.hours.ago)).to eq(false)
+          end
+        end
+
+        context "and passed a timestamp after the dissolution time" do
+          it "returns true" do
+            expect(parliament.closed?(12.hours.ago)).to eq(true)
+          end
         end
       end
     end
@@ -400,7 +412,7 @@ RSpec.describe Parliament, type: :model do
         FactoryBot.build(:parliament, opening_at: nil, dissolution_at: nil)
       end
 
-      it "return true" do
+      it "returns true" do
         expect(parliament.closed?).to eq(true)
       end
     end

--- a/spec/tasks/epets/petitions/close_spec.rb
+++ b/spec/tasks/epets/petitions/close_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe "epets:petitions:close", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+  let(:midnight) { Date.tomorrow.beginning_of_day }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the ClosePetitionsJob to run at midnight" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        ClosePetitionsJob
+      ).on_queue(:high_priority).at(midnight).with(midnight.iso8601)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the ClosePetitionsJob to run at midnight" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        ClosePetitionsJob
+      ).on_queue(:high_priority).at(midnight).with(midnight.iso8601)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the ClosePetitionsJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        ClosePetitionsJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/petitions/count_spec.rb
+++ b/spec/tasks/epets/petitions/count_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe "epets:petitions:count", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the PetitionCountJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        PetitionCountJob
+      ).on_queue(:highest_priority)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the PetitionCountJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        PetitionCountJob
+      ).on_queue(:highest_priority)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the PetitionCountJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        PetitionCountJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/petitions/debated_spec.rb
+++ b/spec/tasks/epets/petitions/debated_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "epets:petitions:debated", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+  let(:tomorrow) { Date.tomorrow }
+  let(:midnight) { tomorrow.beginning_of_day }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the DebatedPetitionsJob to run at midnight" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        DebatedPetitionsJob
+      ).on_queue(:high_priority).at(midnight).with(tomorrow.iso8601)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the DebatedPetitionsJob to run at midnight" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        DebatedPetitionsJob
+      ).on_queue(:high_priority).at(midnight).with(tomorrow.iso8601)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the DebatedPetitionsJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        DebatedPetitionsJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/petitions/extend_deadline_spec.rb
+++ b/spec/tasks/epets/petitions/extend_deadline_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe "epets:petitions:extend_deadline", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+  let(:midnight) { Date.tomorrow.beginning_of_day }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the ExtendPetitionDeadlinesJob to run at midnight" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        ExtendPetitionDeadlinesJob
+      ).on_queue(:high_priority).at(midnight)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the ExtendPetitionDeadlinesJob to run at midnight" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        ExtendPetitionDeadlinesJob
+      ).on_queue(:high_priority).at(midnight)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the ExtendPetitionDeadlinesJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        ExtendPetitionDeadlinesJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/petitions/update_statistics_spec.rb
+++ b/spec/tasks/epets/petitions/update_statistics_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe "epets:petitions:update_statistics", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the EnqueuePetitionStatisticsUpdatesJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        EnqueuePetitionStatisticsUpdatesJob
+      ).on_queue(:low_priority).with(24.hours.ago.iso8601)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the EnqueuePetitionStatisticsUpdatesJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        EnqueuePetitionStatisticsUpdatesJob
+      ).on_queue(:low_priority).with(24.hours.ago.iso8601)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the EnqueuePetitionStatisticsUpdatesJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        EnqueuePetitionStatisticsUpdatesJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/site/signature_counts_spec.rb
+++ b/spec/tasks/epets/site/signature_counts_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+RSpec.describe "epets:site:signature_counts", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+  let(:site) { Site.instance }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    context "and signature counting is enabled" do
+      before do
+        allow(site).to receive(:update_signature_counts).and_return(true)
+      end
+
+      context "and the last count was less than 15 minutes ago" do
+        before do
+          allow(site).to receive(:signature_count_updated_at).and_return(10.minutes.ago)
+        end
+
+        it "doesn't enqueue the UpdateSignatureCountsJob" do
+          expect {
+            subject.invoke
+          }.not_to have_enqueued_job(
+            UpdateSignatureCountsJob
+          )
+        end
+      end
+
+      context "and the last count was more than 15 minutes ago" do
+        before do
+          allow(site).to receive(:signature_count_updated_at).and_return(20.minutes.ago)
+        end
+
+        it "enqueues the UpdateSignatureCountsJob" do
+          expect {
+            subject.invoke
+          }.to have_enqueued_job(
+            UpdateSignatureCountsJob
+          ).on_queue(:highest_priority)
+        end
+      end
+    end
+
+    context "and signature counting is disabled" do
+      before do
+        allow(site).to receive(:update_signature_counts).and_return(false)
+        allow(site).to receive(:signature_count_updated_at).and_return(30.minutes.ago)
+      end
+
+      it "doesn't enqueue the UpdateSignatureCountsJob" do
+        expect {
+          subject.invoke
+        }.not_to have_enqueued_job(
+          UpdateSignatureCountsJob
+        )
+      end
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    context "and signature counting is enabled" do
+      before do
+        allow(site).to receive(:update_signature_counts).and_return(true)
+      end
+
+      context "and the last count was less than 15 minutes ago" do
+        before do
+          allow(site).to receive(:signature_count_updated_at).and_return(10.minutes.ago)
+        end
+
+        it "doesn't enqueue the UpdateSignatureCountsJob" do
+          expect {
+            subject.invoke
+          }.not_to have_enqueued_job(
+            UpdateSignatureCountsJob
+          )
+        end
+      end
+
+      context "and the last count was more than 15 minutes ago" do
+        before do
+          allow(site).to receive(:signature_count_updated_at).and_return(20.minutes.ago)
+        end
+
+        it "enqueues the UpdateSignatureCountsJob" do
+          expect {
+            subject.invoke
+          }.to have_enqueued_job(
+            UpdateSignatureCountsJob
+          ).on_queue(:highest_priority)
+        end
+      end
+    end
+
+    context "and signature counting is disabled" do
+      before do
+        allow(site).to receive(:update_signature_counts).and_return(false)
+        allow(site).to receive(:signature_count_updated_at).and_return(30.minutes.ago)
+      end
+
+      it "doesn't enqueue the UpdateSignatureCountsJob" do
+        expect {
+          subject.invoke
+        }.not_to have_enqueued_job(
+          UpdateSignatureCountsJob
+        )
+      end
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+      allow(site).to receive(:update_signature_counts).and_return(true)
+      allow(site).to receive(:signature_count_updated_at).and_return(30.minutes.ago)
+    end
+
+    it "doesn't enqueue the UpdateSignatureCountsJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        UpdateSignatureCountsJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/site/trending_domains_spec.rb
+++ b/spec/tasks/epets/site/trending_domains_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe "epets:site:trending_domains", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the TrendingDomainsByPetitionJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        TrendingDomainsByPetitionJob
+      ).on_queue(:default)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the TrendingDomainsByPetitionJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        TrendingDomainsByPetitionJob
+      ).on_queue(:default)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the TrendingDomainsByPetitionJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        TrendingDomainsByPetitionJob
+      )
+    end
+  end
+end

--- a/spec/tasks/epets/site/trending_ips_spec.rb
+++ b/spec/tasks/epets/site/trending_ips_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe "epets:site:trending_ips", type: :task do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  let(:parliament) { Parliament.instance }
+
+  context "when parliament is open" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(nil)
+    end
+
+    it "enqueues the TrendingIpsByPetitionJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        TrendingIpsByPetitionJob
+      ).on_queue(:default)
+    end
+  end
+
+  context "when parliament has dissolved less than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(24.hours.ago)
+    end
+
+    it "enqueues the TrendingIpsByPetitionJob" do
+      expect {
+        subject.invoke
+      }.to have_enqueued_job(
+        TrendingIpsByPetitionJob
+      ).on_queue(:default)
+    end
+  end
+
+  context "when parliament has dissolved more than 48 hours ago" do
+    before do
+      allow(parliament).to receive(:dissolution_at).and_return(72.hours.ago)
+    end
+
+    it "doesn't enqueue the TrendingIpsByPetitionJob" do
+      expect {
+        subject.invoke
+      }.not_to have_enqueued_job(
+        TrendingIpsByPetitionJob
+      )
+    end
+  end
+end


### PR DESCRIPTION
When parliament has dissolved there is no need to run maintenance tasks.