### PR TITLE
Upgrade redcarpet Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redcarpet (3.5.1)
+    redcarpet (3.6.0)
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)


### PR DESCRIPTION
This fixes warnings on Ruby 3.2.