### PR TITLE
Update sequences for the re-opening of the petitions website

### DIFF
--- a/app/models/invalidation.rb
+++ b/app/models/invalidation.rb
@@ -22,7 +22,7 @@ class Invalidation < ActiveRecord::Base
 
   validates :summary, presence: true, length: { maximum: 255 }
   validates :details, length: { maximum: 10000 }
-  validates :petition_id, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 300000 }
+  validates :petition_id, numericality: { only_integer: true, allow_blank: true, greater_than_or_equal_to: 700000 }
   validates :name, length: { maximum: 255, allow_blank: true }
   validates :postcode, length: { maximum: 255, allow_blank: true }
   validates :ip_address, length: { maximum: 20 }, format: { with: /\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/ }, allow_blank: true

--- a/db/migrate/20240712025302_alter_sequence_types_to_big_int.rb
+++ b/db/migrate/20240712025302_alter_sequence_types_to_big_int.rb
@@ -1,0 +1,63 @@
+class AlterSequenceTypesToBigInt < ActiveRecord::Migration[7.1]
+  BIGINT_SEQUENCES = %w[
+    active_storage_attachments_id_seq
+    active_storage_blobs_id_seq
+    active_storage_variant_records_id_seq
+    admin_users_id_seq
+    archived_debate_outcomes_id_seq
+    archived_government_responses_id_seq
+    archived_notes_id_seq
+    archived_petition_emails_id_seq
+    archived_petition_mailshots_id_seq
+    archived_rejections_id_seq
+    archived_signatures_id_seq
+    constituencies_id_seq
+    constituency_petition_journals_id_seq
+    country_petition_journals_id_seq
+    debate_outcomes_id_seq
+    delayed_jobs_id_seq
+    domains_id_seq
+    email_requested_receipts_id_seq
+    feedback_id_seq
+    government_responses_id_seq
+    holidays_id_seq
+    invalidations_id_seq
+    locations_id_seq
+    notes_id_seq
+    parliaments_id_seq
+    petition_emails_id_seq
+    petition_mailshots_id_seq
+    petition_statistics_id_seq
+    petitions_id_seq
+    rate_limits_id_seq
+    regions_id_seq
+    rejection_reasons_id_seq
+    rejections_id_seq
+    signatures_id_seq
+    sites_id_seq
+    tasks_id_seq
+    trending_domains_id_seq
+    trending_ips_id_seq
+    parliament_constituencies_id_seq
+  ]
+
+  INTEGER_SEQUENCES = %w[
+    departments_id_seq
+    tags_id_seq
+    topics_id_seq
+  ]
+
+  def change
+    up_only do
+      BIGINT_SEQUENCES.each do |sequence|
+        execute "ALTER SEQUENCE #{sequence} AS bigint MAXVALUE 9223372036854775807"
+      end
+
+      INTEGER_SEQUENCES.each do |sequence|
+        execute "ALTER SEQUENCE #{sequence} AS integer MAXVALUE 2147483647"
+      end
+
+      execute "ALTER SEQUENCE archived_petitions_id_seq AS bigint MAXVALUE 299999"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_15_110144) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_12_025302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
   enable_extension "plpgsql"

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -11,13 +11,13 @@ RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key 
 # Add apt repositories
 RUN echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main' \
     > /etc/apt/sources.list.d/nodesource.list && \
-    echo 'deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' \
+    echo 'deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' \
     > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update
 
 # Install packages
 RUN apt-get install -y --no-install-recommends \
-    chromium chromium-driver nodejs postgresql-client-12
+    chromium chromium-driver nodejs postgresql-client-16
 
 # Create the crash reports directory - without it Chromium complains on startup
 RUN mkdir -p "/root/.config/chromium/Crash Reports/pending/"

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -3,11 +3,11 @@ namespace :epets do
     task :alter => :environment do
       ActiveRecord::Base.connection_pool.with_connection do |connection|
         connection.execute <<~SQL
-          ALTER SEQUENCE archived_petitions_id_seq MAXVALUE 299999
+          ALTER SEQUENCE archived_petitions_id_seq MAXVALUE 699999
         SQL
 
         connection.execute <<~SQL
-          ALTER SEQUENCE petitions_id_seq START WITH 300000 RESTART WITH 300000 MINVALUE 300000
+          ALTER SEQUENCE petitions_id_seq START WITH 700000 RESTART WITH 700000 MINVALUE 700000
         SQL
       end
     end

--- a/spec/models/invalidation_spec.rb
+++ b/spec/models/invalidation_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Invalidation, type: :model do
     it { is_expected.to validate_presence_of(:summary) }
     it { is_expected.to validate_length_of(:summary).is_at_most(255) }
     it { is_expected.to validate_length_of(:details).is_at_most(10000) }
-    it { is_expected.to validate_numericality_of(:petition_id).only_integer.is_greater_than_or_equal_to(300000) }
+    it { is_expected.to validate_numericality_of(:petition_id).only_integer.is_greater_than_or_equal_to(700000) }
     it { is_expected.to validate_length_of(:name).is_at_most(255) }
     it { is_expected.to validate_length_of(:postcode).is_at_most(255) }
     it { is_expected.to validate_length_of(:ip_address).is_at_most(20) }

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -3425,8 +3425,8 @@ RSpec.describe Petition, type: :model do
   describe "#id" do
     let(:petition){ FactoryBot.create(:petition) }
 
-    it "is greater than or equal to 300000" do
-      expect(petition.id).to be >= 300000
+    it "is greater than or equal to 700000" do
+      expect(petition.id).to be >= 700000
     end
   end
 

--- a/spec/support/sequences.rb
+++ b/spec/support/sequences.rb
@@ -2,11 +2,11 @@ RSpec.configure do |config|
   config.before(:suite) do
     ActiveRecord::Base.connection_pool.with_connection do |connection|
       connection.execute <<~SQL
-        ALTER SEQUENCE archived_petitions_id_seq MAXVALUE 299999
+        ALTER SEQUENCE archived_petitions_id_seq MAXVALUE 699999
       SQL
 
       connection.execute <<~SQL
-        ALTER SEQUENCE petitions_id_seq START WITH 300000 RESTART WITH 300000 MINVALUE 300000
+        ALTER SEQUENCE petitions_id_seq START WITH 700000 RESTART WITH 700000 MINVALUE 700000
       SQL
     end
   end


### PR DESCRIPTION
When we start a new parliament we restart the petition id sequence at a nice round number to make it clear to the moderators whether a petition is in a previous parliament or not.