### PR TITLE
Replace without_instrumentation with ignore_instrumentation_events

### DIFF
--- a/app/jobs/anonymize_petition_job.rb
+++ b/app/jobs/anonymize_petition_job.rb
@@ -14,7 +14,7 @@ class AnonymizePetitionJob < ApplicationJob
       worker.call
     end
 
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       if petition.signatures.not_anonymized.exists?
         signatures = petition.signatures.not_anonymized.take(limit)
 

--- a/app/jobs/archive_petitions_job.rb
+++ b/app/jobs/archive_petitions_job.rb
@@ -2,7 +2,7 @@ class ArchivePetitionsJob < ApplicationJob
   queue_as :high_priority
 
   def perform
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       Petition.find_each do |petition|
         next if petition.archived?
 

--- a/app/jobs/archive_signatures_job.rb
+++ b/app/jobs/archive_signatures_job.rb
@@ -9,7 +9,7 @@ class ArchiveSignaturesJob < ApplicationJob
       worker.call
     end
 
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       if petition.signatures.unarchived.exists?
         signatures = petition.signatures.unarchived.batch(limit: limit)
 

--- a/app/jobs/archived/anonymize_petition_job.rb
+++ b/app/jobs/archived/anonymize_petition_job.rb
@@ -15,7 +15,7 @@ module Archived
         worker.call
       end
 
-      Appsignal.without_instrumentation do
+      Appsignal.ignore_instrumentation_events do
         if petition.signatures.not_anonymized.exists?
           signatures = petition.signatures.not_anonymized.take(limit)
 

--- a/app/jobs/concerns/email_all_petition_signatories.rb
+++ b/app/jobs/concerns/email_all_petition_signatories.rb
@@ -75,7 +75,7 @@ module EmailAllPetitionSignatories
   # Batches the signataries to send emails to in groups of 1000
   # and enqueues a job to do the actual sending
   def enqueue_send_email_jobs
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       run_callbacks :enqueue_send_email_jobs do
         signatures_to_email.find_each do |signature|
           email_delivery_job_class.perform_later(**mailer_arguments(signature))

--- a/app/jobs/email_privacy_policy_update_job.rb
+++ b/app/jobs/email_privacy_policy_update_job.rb
@@ -9,7 +9,7 @@ class EmailPrivacyPolicyUpdateJob < ApplicationJob
       worker.call
     end
 
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       petition.signatures.validated.find_each do |signature|
         privacy_notification = PrivacyNotification.create!(
           id: signature.uuid,

--- a/app/jobs/notify_petition_that_parliament_is_dissolving_job.rb
+++ b/app/jobs/notify_petition_that_parliament_is_dissolving_job.rb
@@ -2,7 +2,7 @@ class NotifyPetitionThatParliamentIsDissolvingJob < ApplicationJob
   queue_as :low_priority
 
   def perform(petition)
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       signatures_to_email(petition).find_each do |signature|
         begin
           enqueue_notification(create_record(signature))

--- a/app/models/invalidation.rb
+++ b/app/models/invalidation.rb
@@ -174,7 +174,7 @@ class Invalidation < ActiveRecord::Base
       counted_at: Time.current
     )
 
-    Appsignal.without_instrumentation do
+    Appsignal.ignore_instrumentation_events do
       matching_signatures.find_in_batches(batch_size: 100) do |signatures|
         signatures.each do |signature|
           signature.invalidate!(Time.current, id)


### PR DESCRIPTION
The former method has been deprecated by Appsignal.