### PR TITLE
Remove redundant require_dependency calls

### DIFF
--- a/app/models/archived/debate_outcome.rb
+++ b/app/models/archived/debate_outcome.rb
@@ -1,5 +1,3 @@
-require_dependency 'archived'
-
 module Archived
   class DebateOutcome < ActiveRecord::Base
     VALID_OTHER_URLS = /\Ahttps?:\/\/(?:[a-z][\-\.a-z0-9]{0,63}\.parliament\.uk|www\.youtube\.com).*\z/

--- a/app/models/archived/government_response.rb
+++ b/app/models/archived/government_response.rb
@@ -1,5 +1,3 @@
-require_dependency 'archived'
-
 module Archived
   class GovernmentResponse < ActiveRecord::Base
     belongs_to :petition, touch: true

--- a/app/models/archived/note.rb
+++ b/app/models/archived/note.rb
@@ -1,5 +1,3 @@
-require_dependency 'archived'
-
 module Archived
   class Note < ActiveRecord::Base
     belongs_to :petition, touch: true

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -1,5 +1,4 @@
 require 'textacular/searchable'
-require_dependency 'archived'
 
 module Archived
   class Petition < ActiveRecord::Base

--- a/app/models/archived/petition/email.rb
+++ b/app/models/archived/petition/email.rb
@@ -1,5 +1,3 @@
-require_dependency 'archived'
-
 module Archived
   class Petition < ActiveRecord::Base
     class Email < ActiveRecord::Base

--- a/app/models/archived/petition/mailshot.rb
+++ b/app/models/archived/petition/mailshot.rb
@@ -1,5 +1,3 @@
-require_dependency 'archived'
-
 module Archived
   class Petition < ActiveRecord::Base
     class Mailshot < ActiveRecord::Base

--- a/app/models/archived/rejection.rb
+++ b/app/models/archived/rejection.rb
@@ -1,5 +1,3 @@
-require_dependency 'archived'
-
 module Archived
   class Rejection < ActiveRecord::Base
     belongs_to :petition, touch: true

--- a/app/models/archived/signature.rb
+++ b/app/models/archived/signature.rb
@@ -1,7 +1,5 @@
 require 'ipaddr'
 
-require_dependency 'archived'
-
 module Archived
   class Signature < ActiveRecord::Base
     include GeoipLookup, Anonymize

--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -1,6 +1,3 @@
-require_dependency 'constituency/api_client'
-require_dependency 'constituency/api_query'
-
 class Constituency < ActiveRecord::Base
   MP_URL = "https://members.parliament.uk/member/%{mp_id}/contact"
   POSTCODE = /\A([A-Z]{1,2}[0-9][0-9A-Z]?)([0-9]|[0-9][A-BD-HJLNP-UW-Z]{2})?\z/i
@@ -102,11 +99,11 @@ class Constituency < ActiveRecord::Base
         current
       end
     end
-  
+
     def between(opening_at, dissolution_at)
       where(arel_table[:start_date].lteq(opening_at).and(arel_table[:end_date].gteq(dissolution_at).or(arel_table[:end_date].eq(nil))))
     end
-  
+
     def external_ids
       pluck(:external_id)
     end


### PR DESCRIPTION
Zeitwerk improvements have removed the necessity of these for nested models.