### PR TITLE
Increase subject size for archive emails/mailshots

### DIFF
--- a/app/models/archived/petition/email.rb
+++ b/app/models/archived/petition/email.rb
@@ -6,7 +6,7 @@ module Archived
       belongs_to :petition, touch: true
 
       validates :petition, presence: true
-      validates :subject, presence: true, length: { maximum: 100 }
+      validates :subject, presence: true, length: { maximum: 150 }
       validates :body, presence: true, length: { maximum: 10000 }
 
       class << self

--- a/app/models/archived/petition/mailshot.rb
+++ b/app/models/archived/petition/mailshot.rb
@@ -6,7 +6,7 @@ module Archived
       belongs_to :petition, touch: true
 
       validates :petition, presence: true
-      validates :subject, presence: true, length: { maximum: 100 }
+      validates :subject, presence: true, length: { maximum: 150 }
       validates :body, presence: true, length: { maximum: 10000 }
 
       class << self

--- a/spec/models/archived/petition/email_spec.rb
+++ b/spec/models/archived/petition/email_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Archived::Petition::Email, type: :model do
 
     it { is_expected.to validate_presence_of(:petition) }
     it { is_expected.to validate_presence_of(:subject) }
-    it { is_expected.to validate_length_of(:subject).is_at_most(100) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(150) }
     it { is_expected.to validate_presence_of(:body) }
     it { is_expected.to validate_length_of(:body).is_at_most(10000) }
   end

--- a/spec/models/archived/petition/mailshot_spec.rb
+++ b/spec/models/archived/petition/mailshot_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Archived::Petition::Mailshot, type: :model do
 
     it { is_expected.to validate_presence_of(:petition) }
     it { is_expected.to validate_presence_of(:subject) }
-    it { is_expected.to validate_length_of(:subject).is_at_most(100) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(150) }
     it { is_expected.to validate_presence_of(:body) }
     it { is_expected.to validate_length_of(:body).is_at_most(10000) }
   end


### PR DESCRIPTION
Otherwise we'll get validation errors when the petition is archived.