### PR TITLE
Make signature counting more robust

### DIFF
--- a/app/jobs/concerns/session_advisory_lock.rb
+++ b/app/jobs/concerns/session_advisory_lock.rb
@@ -1,0 +1,36 @@
+require 'zlib'
+
+module SessionAdvisoryLock
+  extend ActiveSupport::Concern
+
+  class LockFailedError < RuntimeError; end
+
+  included do
+    delegate :connection, to: :"ActiveRecord::Base"
+    delegate :select_value, to: :connection
+
+    lock_id = Zlib.crc32(self.name)
+    lock_sql = "SELECT pg_try_advisory_lock(#{lock_id})"
+    unlock_sql = "SELECT pg_advisory_unlock(#{lock_id})"
+
+    define_method :get_advisory_lock do
+      select_value(lock_sql)
+    end
+
+    define_method :release_advisory_lock do
+      select_value(unlock_sql)
+    end
+  end
+
+  private
+
+  def with_lock
+    unless locked = get_advisory_lock
+      raise LockFailedError, "Unable to obtain advisory lock, check for concurrent #{self.class.name} jobs"
+    end
+
+    yield
+  ensure
+    release_advisory_lock if locked
+  end
+end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -10,6 +10,7 @@ module Delayed
     module ActiveRecord
       class Job < ::ActiveRecord::Base
         QUEUE_PRIORITIES = {
+          "counter"          => 0,
           "highest_priority" => 0,
           "high_priority"    => 10,
           "low_priority"     => 50

--- a/spec/jobs/update_signature_counts_job_spec.rb
+++ b/spec/jobs/update_signature_counts_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
     it "reschedules another job" do
       expect {
         described_class.perform_now(current_time.iso8601)
-      }.to have_enqueued_job(described_class).on_queue("highest_priority").at(scheduled_time)
+      }.to have_enqueued_job(described_class).on_queue("counter").at(scheduled_time)
     end
 
     describe "updating" do
@@ -392,6 +392,65 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
               constituency_journal.reload.signature_count
             }.by(5)
           end
+        end
+      end
+
+      shared_examples_for "it notifies Appsignal and doesn't retry" do
+        before do
+          allow(Appsignal).to receive(:send_exception)
+          described_class.perform_now(current_time.iso8601)
+        end
+
+        it "notifies Appsignal" do
+          expect(Appsignal).to have_received(:send_exception).with(an_instance_of(exception_class))
+        end
+
+        it "doesn't reschedule a job" do
+          expect(described_class).not_to have_been_enqueued
+        end
+      end
+
+      context "when a connection error occurs" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:exception_class) { PG::ConnectionBad }
+
+        before do
+          expect(Signature).to receive(:petition_ids_signed_since).and_raise(exception_class)
+        end
+
+        include_examples "it notifies Appsignal and doesn't retry"
+      end
+
+      context "when an advisory lock error occurs" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:exception_class) { SessionAdvisoryLock::LockFailedError }
+        let(:connection) { ActiveRecord::Base.connection }
+        let(:query) { a_string_matching(/pg_try_advisory_lock/) }
+
+        before do
+          expect(connection).to receive(:select_value).with(query).and_return(false)
+        end
+
+        include_examples "it notifies Appsignal and doesn't retry"
+      end
+
+      context "when multiple jobs are enqueued" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:worker) { Delayed::Worker.new }
+
+        around do |example|
+          without_test_adapter { example.run }
+        end
+
+        before do
+          described_class.perform_later((current_time - 15.seconds).iso8601)
+          described_class.perform_later((current_time - 10.seconds).iso8601)
+        end
+
+        it "ensures that there is only one job running" do
+          expect {
+            worker.work_off
+          }.to change(Delayed::Job, :count).from(2).to(1)
         end
       end
     end

--- a/spec/tasks/epets/site/signature_counts_spec.rb
+++ b/spec/tasks/epets/site/signature_counts_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "epets:site:signature_counts", type: :task do
             subject.invoke
           }.to have_enqueued_job(
             UpdateSignatureCountsJob
-          ).on_queue(:highest_priority)
+          ).on_queue(:counter)
         end
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe "epets:site:signature_counts", type: :task do
             subject.invoke
           }.to have_enqueued_job(
             UpdateSignatureCountsJob
-          ).on_queue(:highest_priority)
+          ).on_queue(:counter)
         end
       end
     end


### PR DESCRIPTION
When the RDS service did a security update the inability of delayed_job to recover from connection errors led to two instances of the counting job being enqueued as there's a task that runs every 15 minutes to ensure it's running. When delayed_job was restarted after log rotation this unlocked the original job and resulted in both jobs being processed and signatures being double counted for a short period.

This commit tries to prevent this from reoccurring in the future by using PostgreSQL advisory locks to ensure that two jobs can't run concurrently in the same way Active Record uses them to prevent migrations from being run concurrently. Given this restriction we can put the count job onto it's own queue and if we detect there is more than one job on the queue then skip processing and don't requeue.

We also change the job to send exceptions to Appsignal as the problem went unnoticed for a couple of hours - it's not expected that this job will be continually raising errors so anything occurring should be addressed as a matter of priority.

This change has been running in production since 2021 on Scottish Petitions and since 2022 on Welsh Petitions with no adverse effects observed during the increased demand from the 20mph petition in Wales.

The problem hasn't been observed on the UK site since the change to using systemd scripts which is probably due to improved handling of errors.