### PR TITLE
Use HTTP caching to reduce load for map data

### DIFF
--- a/app/controllers/constituencies_controller.rb
+++ b/app/controllers/constituencies_controller.rb
@@ -1,9 +1,12 @@
 class ConstituenciesController < ApplicationController
   before_action :set_cors_headers, only: [:index], if: :json_request?
   before_action :fetch_parliament, only: [:index]
+  before_action :fetch_constituencies, only: [:index]
 
   def index
-    @constituencies = @parliament.constituencies.by_ons_code
+    expires_in 1.hour, public: true,
+      stale_while_revalidate: 60.seconds,
+      stale_if_error: 5.minutes
 
     respond_to do |format|
       format.json
@@ -19,5 +22,9 @@ class ConstituenciesController < ApplicationController
     else
       @parliament = Parliament.instance
     end
+  end
+
+  def fetch_constituencies
+    @constituencies = @parliament.constituencies.by_ons_code
   end
 end

--- a/app/controllers/parliaments_controller.rb
+++ b/app/controllers/parliaments_controller.rb
@@ -1,8 +1,12 @@
 class ParliamentsController < ApplicationController
   before_action :set_cors_headers, if: :json_request?
+  before_action :fetch_parliaments, only: [:index]
+  before_action :fetch_parliament, only: [:show]
 
   def index
-    @parliaments = Parliament.archived.order(:period)
+    expires_in 1.hour, public: true,
+      stale_while_revalidate: 60.seconds,
+      stale_if_error: 5.minutes
 
     respond_to do |format|
       format.json
@@ -10,10 +14,22 @@ class ParliamentsController < ApplicationController
   end
 
   def show
-    @parliament = Parliament.archived.find_by!(period: params[:period])
+    expires_in 1.hour, public: true,
+      stale_while_revalidate: 60.seconds,
+      stale_if_error: 5.minutes
 
     respond_to do |format|
      format.json
     end
+  end
+
+  private
+
+  def fetch_parliaments
+    @parliaments = Parliament.archived.order(:period)
+  end
+
+  def fetch_parliament
+    @parliament = Parliament.archived.find_by!(period: params[:period])
   end
 end


### PR DESCRIPTION
The parliament data is pretty much static and the constituency data only changes overnight so reduce the number of requests for this data.