### PR TITLE
Improve inputting of emails

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -803,6 +803,7 @@ class Signature < ActiveRecord::Base
 
   def normalize_email(value)
     return value unless value.present?
+    return value unless value.match?(/\A[^@\s]+@[^@\s]+\z/)
 
     Mail::Address.new(value.strip).yield_self do |address|
       "#{address.local}@#{address.domain.to_s.downcase}"

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -4,7 +4,7 @@
     <%= form_for(@user, as: :user, url: admin_login_path, authenticity_token: form_authenticity_token) do |form| %>
       <div class="form-group">
         <%= form.label :email, "Email", class: "form-label" %>
-        <%= form.text_field :email, class: "form-control", type: "email", autofocus: "autofocus" %>
+        <%= form.text_field :email, class: "form-control", inputmode: "email", autofocus: "autofocus" %>
       </div>
 
       <%= form.submit "Sign in", class: "button" %>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -4,7 +4,7 @@
     <%= form_for(@user, as: :user, url: admin_login_path, authenticity_token: form_authenticity_token) do |form| %>
       <div class="form-group">
         <%= form.label :email, "Email", class: "form-label" %>
-        <%= form.text_field :email, class: "form-control", inputmode: "email", autofocus: "autofocus" %>
+        <%= form.text_field :email, class: "form-control", inputmode: "email", autofocus: "autofocus", autocomplete: "email" %>
       </div>
 
       <%= form.submit "Sign in", class: "button" %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -34,7 +34,7 @@
   <%= form_row for: [@feedback, :email] do %>
     <%= f.label :email, "Email address", class: "form-label" %>
     <%= error_messages_for_field @feedback, :email %>
-    <%= f.text_field :email, inputmode: "email", class: "form-control" %>
+    <%= f.text_field :email, inputmode: "email", class: "form-control", autocomplete: "email" %>
   <% end %>
 
   <%= submit_tag "Send feedback", class: "button" %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -34,7 +34,7 @@
   <%= form_row for: [@feedback, :email] do %>
     <%= f.label :email, "Email address", class: "form-label" %>
     <%= error_messages_for_field @feedback, :email %>
-    <%= f.text_field :email, type: "email", class: "form-control" %>
+    <%= f.text_field :email, inputmode: "email", class: "form-control" %>
   <% end %>
 
   <%= submit_tag "Send feedback", class: "button" %>

--- a/app/views/petitions/create/_creator_stage.html.erb
+++ b/app/views/petitions/create/_creator_stage.html.erb
@@ -24,26 +24,26 @@
 <%= form_row for: [petition, :name] do %>
   <%= form.label :name, class: "form-label" %>
   <%= error_messages_for_field petition, :name %>
-  <%= form.text_field :name, maxlength: 255, size: nil, class: "form-control" %>
+  <%= form.text_field :name, maxlength: 255, size: nil, class: "form-control", autocomplete: "name" %>
   <span class="form-hint">You must use your full name</span>
 <% end %>
 
 <%= form_row for: [petition, :email] do %>
   <%= form.label :email, "Email address", class: "form-label" %>
   <%= error_messages_for_field petition, :email %>
-  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control", autocomplete: "email" %>
 <% end %>
 
 <%= form_row for: [petition, :location_code] do %>
   <%= form.label :location_code, "Location", class: "form-label" %>
   <%= error_messages_for_field petition, :location_code %>
-  <%= form.select :location_code, countries_for_select, {}, class: "form-control" %>
+  <%= form.select :location_code, countries_for_select, {}, class: "form-control", autocomplete: "country" %>
 <% end %>
 
 <%= form_row for: [petition, :postcode], id: "postcode-row" do %>
   <%= form.label :postcode, class: "form-label" %>
   <%= error_messages_for_field petition, :postcode %>
-  <%= form.text_field :postcode, class: "form-control small" %>
+  <%= form.text_field :postcode, class: "form-control small", autocomplete: "postal-code" %>
 <% end %>
 
 <%= form_row for: [petition, :notify_by_email], class: "notify-by-email" do %>

--- a/app/views/petitions/create/_creator_stage.html.erb
+++ b/app/views/petitions/create/_creator_stage.html.erb
@@ -31,7 +31,7 @@
 <%= form_row for: [petition, :email] do %>
   <%= form.label :email, "Email address", class: "form-label" %>
   <%= error_messages_for_field petition, :email %>
-  <%= form.text_field :email, type: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
 <% end %>
 
 <%= form_row for: [petition, :location_code] do %>

--- a/app/views/petitions/create/_replay_email_stage.html.erb
+++ b/app/views/petitions/create/_replay_email_stage.html.erb
@@ -15,7 +15,7 @@
 <%= form_row for: [petition, :email] do %>
   <%= form.label :email, "Email address", class: "form-label" %>
   <%= error_messages_for_field petition, :email %>
-  <%= form.text_field :email, type: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
 <% end %>
 
 <%= form.submit "Yes – this is my email address", name: "move_next", class: "button" %>

--- a/app/views/petitions/create/_replay_email_stage.html.erb
+++ b/app/views/petitions/create/_replay_email_stage.html.erb
@@ -15,7 +15,7 @@
 <%= form_row for: [petition, :email] do %>
   <%= form.label :email, "Email address", class: "form-label" %>
   <%= error_messages_for_field petition, :email %>
-  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control", autocomplete: "email" %>
 <% end %>
 
 <%= form.submit "Yes – this is my email address", name: "move_next", class: "button" %>

--- a/app/views/signatures/_email_form.html.erb
+++ b/app/views/signatures/_email_form.html.erb
@@ -9,7 +9,7 @@
 <%= form_row for: [signature, :email] do %>
   <%= form.label :email, "Email address", class: "form-label visuallyhidden" %>
   <%= error_messages_for_field signature, :email %>
-  <%= form.text_field :email, type: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
 <% end %>
 
 <%= form.submit "Yes – this is my email address", class: "button" %>

--- a/app/views/signatures/_email_form.html.erb
+++ b/app/views/signatures/_email_form.html.erb
@@ -9,7 +9,7 @@
 <%= form_row for: [signature, :email] do %>
   <%= form.label :email, "Email address", class: "form-label visuallyhidden" %>
   <%= error_messages_for_field signature, :email %>
-  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control", autocomplete: "email" %>
 <% end %>
 
 <%= form.submit "Yes – this is my email address", class: "button" %>

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -14,25 +14,25 @@
 <%= form_row for: [signature, :name] do %>
   <%= form.label :name, class: "form-label" %>
   <%= error_messages_for_field signature, :name %>
-  <%= form.text_field :name, maxlength: 255, size: nil, class: "form-control"  %>
+  <%= form.text_field :name, maxlength: 255, size: nil, class: "form-control", autocomplete: "name"  %>
 <% end %>
 
 <%= form_row for: [signature, :email] do %>
   <%= form.label :email, "Email address", class: "form-label" %>
   <%= error_messages_for_field signature, :email %>
-  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control", autocomplete: "email" %>
 <% end %>
 
 <%= form_row for: [signature, :location_code] do %>
   <%= form.label :location_code, "Location", class: "form-label" %>
   <%= error_messages_for_field signature, :location_code %>
-  <%= form.select :location_code, countries_for_select, {}, class: "form-control" %>
+  <%= form.select :location_code, countries_for_select, {}, class: "form-control", autocomplete: "country" %>
 <% end %>
 
 <%= form_row for: [signature, :postcode], id: "postcode-row" do %>
   <%= form.label :postcode, class: "form-label" %>
   <%= error_messages_for_field signature, :postcode %>
-  <%= form.text_field :postcode, class: "form-control small" %>
+  <%= form.text_field :postcode, class: "form-control small", autocomplete: "postal-code" %>
 <% end %>
 
 <%= form_row for: [signature, :notify_by_email], class: "notify-by-email" do %>
@@ -49,7 +49,6 @@
   <p>The personal data you provide is necessary for the operation of the e-petitions website and the work of the House of Commons Petitions Committee.</p>
   <p>We will manage your personal data as set out in our <%= link_to "privacy notice", privacy_path, target: "_blank" %>, which includes details of your rights under data protection legislation.</p>
 </section>
-
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -20,7 +20,7 @@
 <%= form_row for: [signature, :email] do %>
   <%= form.label :email, "Email address", class: "form-label" %>
   <%= error_messages_for_field signature, :email %>
-  <%= form.text_field :email, type: "email", class: "form-control" %>
+  <%= form.text_field :email, inputmode: "email", class: "form-control" %>
 <% end %>
 
 <%= form_row for: [signature, :location_code] do %>

--- a/lib/domain_autocorrect.rb
+++ b/lib/domain_autocorrect.rb
@@ -22,8 +22,11 @@ class DomainAutocorrect
     /\A([^@]+)@(yahoo\.co(?:m|n)?)\z/ => 'yahoo.com'
   }
 
+  EMAIL_FORMAT = /\A[^@\s]+@[^@\s]+\z/
+
   def self.call(email)
     return email if email.blank?
+    return email unless email.match?(EMAIL_FORMAT)
 
     RULES.each do |pattern, domain|
       if data = pattern.match(email)

--- a/spec/lib/domain_autocorrect_spec.rb
+++ b/spec/lib/domain_autocorrect_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe DomainAutocorrect do
       ).to eq("")
     end
 
+    it "returns the original email if it is invalid" do
+      expect(
+        described_class.call("foo")
+      ).to eq("foo")
+    end
+
     context "with typos for the domain 'aol.com'" do
       it "doesn't change a correct email address" do
         expect(

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -58,21 +58,29 @@ RSpec.describe Signature, type: :model do
         signature.postcode = " N1  1TY  "
         expect(signature.postcode).to eq "N11TY"
       end
+
       it "upcases the postcode" do
         signature.postcode = "n11ty "
         expect(signature.postcode).to eq "N11TY"
       end
+
       it "removes whitespaces and upcase the postcode" do
         signature.postcode = "   N1  1ty "
         expect(signature.postcode).to eq "N11TY"
       end
     end
+
     describe "#email=" do
       let(:signature) { FactoryBot.build(:signature) }
 
       it "downcases the email domain" do
         signature.email = "JOE@PUBLIC.COM"
         expect(signature.email).to eq "JOE@public.com"
+      end
+
+      it "doesn't normalize invalid values" do
+        signature.email = "foo"
+        expect(signature.email).to eq "foo"
       end
     end
   end


### PR DESCRIPTION
* Prefer `inputmode="email"` over `type="email"`
* Don't append a `@` to emails without a domain
* Add `autocomplete` attributes to signature forms
