### PR TITLE
Update moderation time windows

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -213,11 +213,11 @@ class Site < ActiveRecord::Base
     end
 
     def moderation_overdue_in_days
-      10.days
+      14.days
     end
 
     def moderation_near_overdue_in_days
-      8.days
+      11.days
     end
 
     def maximum_number_of_signatures

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -115,7 +115,7 @@
                 <% unless recently_in_moderation_untagged_count.zero? %>
                  / <%= recently_in_moderation_untagged_count %>
                 <% end %>
-                <span class="label">0-7 days</span>
+                <span class="label">0-11 days</span>
               <% end %>
             </div>
 
@@ -125,7 +125,7 @@
                 <% unless nearly_overdue_in_moderation_untagged_count.zero? %>
                  / <%= nearly_overdue_in_moderation_untagged_count %>
                 <% end %>
-                <span class="label">8-10 days</span>
+                <span class="label">11-14 days</span>
               <% end %>
             </div>
 
@@ -135,7 +135,7 @@
                 <% unless overdue_in_moderation_untagged_count.zero? %>
                  / <%= overdue_in_moderation_untagged_count %>
                 <% end %>
-                <span class="label">&gt; 10 days</span>
+                <span class="label">&gt; 14 days</span>
               <% end %>
             </div>
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -414,6 +414,10 @@ FactoryBot.define do
       moderation_threshold_reached_at { Site.moderation_overdue_in_days.ago + 5.minutes }
     end
 
+    trait :delayed do
+      moderation_threshold_reached_at { Site.moderation_near_overdue_in_days.ago + 5.minutes }
+    end
+
     trait :recent do
       moderation_threshold_reached_at { Time.current }
     end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -653,12 +653,13 @@ RSpec.describe Petition, type: :model do
     describe ".in_moderation" do
       let!(:open_petition) { FactoryBot.create(:open_petition) }
       let!(:recent_petition) { FactoryBot.create(:sponsored_petition, :recent) }
-      let!(:overdue_petition) { FactoryBot.create(:sponsored_petition, :overdue) }
+      let!(:delayed_petition) { FactoryBot.create(:sponsored_petition, :delayed) }
       let!(:nearly_overdue_petition) { FactoryBot.create(:sponsored_petition, :nearly_overdue) }
+      let!(:overdue_petition) { FactoryBot.create(:sponsored_petition, :overdue) }
 
       context "with no arguments" do
         it "returns all petitions awaiting moderation" do
-          expect(Petition.in_moderation).to include(recent_petition, overdue_petition, nearly_overdue_petition)
+          expect(Petition.in_moderation).to include(recent_petition, delayed_petition, nearly_overdue_petition, overdue_petition)
         end
 
         it "doesn't return petitions in other states" do
@@ -668,47 +669,47 @@ RSpec.describe Petition, type: :model do
 
       context "with a :from argument" do
         it "returns all petitions awaiting moderation after the timestamp" do
-          expect(Petition.in_moderation(from: 7.days.ago)).to include(recent_petition)
+          expect(Petition.in_moderation(from: 11.days.ago)).to include(recent_petition, delayed_petition)
         end
 
         it "doesn't return petitions awaiting moderation before the timestamp" do
-          expect(Petition.in_moderation(from: 7.days.ago)).not_to include(overdue_petition, nearly_overdue_petition)
+          expect(Petition.in_moderation(from: 11.days.ago)).not_to include(nearly_overdue_petition, overdue_petition)
         end
 
         it "doesn't return petitions in other states" do
-          expect(Petition.in_moderation(from: 7.days.ago)).not_to include(open_petition)
+          expect(Petition.in_moderation(from: 11.days.ago)).not_to include(open_petition)
         end
       end
 
       context "with a :to argument" do
         it "returns all petitions awaiting moderation before the timestamp" do
-          expect(Petition.in_moderation(to: 10.days.ago)).to include(overdue_petition)
+          expect(Petition.in_moderation(to: 14.days.ago)).to include(overdue_petition)
         end
 
         it "doesn't return petitions awaiting moderation after the timestamp" do
-          expect(Petition.in_moderation(to: 10.days.ago)).not_to include(recent_petition, nearly_overdue_petition)
+          expect(Petition.in_moderation(to: 14.days.ago)).not_to include(recent_petition, delayed_petition, nearly_overdue_petition)
         end
 
         it "doesn't return petitions in other states" do
-          expect(Petition.in_moderation(to: 10.days.ago)).not_to include(open_petition)
+          expect(Petition.in_moderation(to: 14.days.ago)).not_to include(open_petition)
         end
       end
 
       context "with both a :from and :to argument" do
         it "returns all petitions awaiting moderation between the timestamps" do
-          expect(Petition.in_moderation(from: 10.days.ago, to: 8.days.ago)).to include(nearly_overdue_petition)
+          expect(Petition.in_moderation(from: 14.days.ago, to: 11.days.ago)).to include(nearly_overdue_petition)
         end
 
-        it "doesn't return petitions awaiting moderation before the timestamp" do
-          expect(Petition.in_moderation(from: 10.days.ago, to: 8.days.ago)).not_to include(overdue_petition)
+        it "doesn't return petitions awaiting moderation before the 'from' timestamp" do
+          expect(Petition.in_moderation(from: 14.days.ago, to: 11.days.ago)).not_to include(overdue_petition)
         end
 
-        it "doesn't return petitions awaiting moderation after the timestamp" do
-          expect(Petition.in_moderation(from: 10.days.ago, to: 8.days.ago)).not_to include(recent_petition)
+        it "doesn't return petitions awaiting moderation after the 'to' timestamp" do
+          expect(Petition.in_moderation(from: 14.days.ago, to: 11.days.ago)).not_to include(recent_petition, delayed_petition)
         end
 
         it "doesn't return petitions in other states" do
-          expect(Petition.in_moderation(from: 10.days.ago, to: 8.days.ago)).not_to include(open_petition)
+          expect(Petition.in_moderation(from: 14.days.ago, to: 11.days.ago)).not_to include(open_petition)
         end
       end
     end


### PR DESCRIPTION
The moderation target is 10 working days, so treat it as 14 actual days.