### PR TITLE
Add a default for DATABASE_URL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: utf8
-  url: <%= ENV.fetch("DATABASE_URL") %>
+  url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost') %>
   pool: 5
 
 development:


### PR DESCRIPTION
This is so we can run `rake deploy:<env>` without a database.