### PR TITLE
Underline links to external resources

### DIFF
--- a/app/assets/stylesheets/petitions/views/_home.scss
+++ b/app/assets/stylesheets/petitions/views/_home.scss
@@ -140,6 +140,10 @@ a.threshold-panel:hover, a.threshold-panel:focus {
   .pull-quote:before, .pull-quote p {
     color: $black;
   }
+
+  a[rel=external] {
+    text-decoration: underline;
+  }
 }
 
 .get-involved,


### PR DESCRIPTION
This is for accessibility reasons.