### PR TITLE
Add specific emails for positive/negative debate outcomes

### DIFF
--- a/app/jobs/archived/deliver_debate_outcome_email_job.rb
+++ b/app/jobs/archived/deliver_debate_outcome_email_job.rb
@@ -2,11 +2,27 @@ module Archived
   class DeliverDebateOutcomeEmailJob < ApplicationJob
     include EmailDelivery
 
+    delegate :positive_debate_outcome?, to: :petition
+
     def create_email
+      positive_debate_outcome? ? positive_outcome_email : negative_outcome_email
+    end
+
+    private
+
+    def positive_outcome_email
       if signature.creator?
-        mailer.notify_creator_of_debate_outcome signature.petition, signature
+        mailer.notify_creator_of_positive_debate_outcome(petition, signature)
       else
-        mailer.notify_signer_of_debate_outcome signature.petition, signature
+        mailer.notify_signer_of_positive_debate_outcome(petition, signature)
+      end
+    end
+
+    def negative_outcome_email
+      if signature.creator?
+        mailer.notify_creator_of_negative_debate_outcome(petition, signature)
+      else
+        mailer.notify_signer_of_negative_debate_outcome(petition, signature)
       end
     end
   end

--- a/app/jobs/deliver_debate_outcome_email_job.rb
+++ b/app/jobs/deliver_debate_outcome_email_job.rb
@@ -1,11 +1,27 @@
 class DeliverDebateOutcomeEmailJob < ApplicationJob
   include EmailDelivery
 
+  delegate :positive_debate_outcome?, to: :petition
+
   def create_email
+    positive_debate_outcome? ? positive_outcome_email : negative_outcome_email
+  end
+
+  private
+
+  def positive_outcome_email
     if signature.creator?
-      mailer.notify_creator_of_debate_outcome signature.petition, signature
+      mailer.notify_creator_of_positive_debate_outcome(petition, signature)
     else
-      mailer.notify_signer_of_debate_outcome signature.petition, signature
+      mailer.notify_signer_of_positive_debate_outcome(petition, signature)
+    end
+  end
+
+  def negative_outcome_email
+    if signature.creator?
+      mailer.notify_creator_of_negative_debate_outcome(petition, signature)
+    else
+      mailer.notify_signer_of_negative_debate_outcome(petition, signature)
     end
   end
 end

--- a/app/mailers/archived/petition_mailer.rb
+++ b/app/mailers/archived/petition_mailer.rb
@@ -89,6 +89,24 @@ module Archived
         list_unsubscribe_post: one_click_unsubscribe
     end
 
+    def notify_signer_of_negative_debate_outcome(petition, signature)
+      @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_signer_of_negative_debate_outcome),
+        list_unsubscribe: unsubscribe_url,
+        list_unsubscribe_post: one_click_unsubscribe
+    end
+
+    def notify_signer_of_positive_debate_outcome(petition, signature)
+      @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_signer_of_positive_debate_outcome),
+        list_unsubscribe: unsubscribe_url,
+        list_unsubscribe_post: one_click_unsubscribe
+    end
+
     def notify_creator_of_debate_outcome(petition, signature)
       @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
 
@@ -99,6 +117,24 @@ module Archived
       end
 
       mail to: @signature.email, subject: subject,
+        list_unsubscribe: unsubscribe_url,
+        list_unsubscribe_post: one_click_unsubscribe
+    end
+
+    def notify_creator_of_negative_debate_outcome(petition, signature)
+      @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_creator_of_negative_debate_outcome),
+        list_unsubscribe: unsubscribe_url,
+        list_unsubscribe_post: one_click_unsubscribe
+    end
+
+    def notify_creator_of_positive_debate_outcome(petition, signature)
+      @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+      mail to: @signature.email,
+        subject: subject_for(:notify_creator_of_positive_debate_outcome),
         list_unsubscribe: unsubscribe_url,
         list_unsubscribe_post: one_click_unsubscribe
     end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -155,6 +155,24 @@ class PetitionMailer < ApplicationMailer
       list_unsubscribe_post: one_click_unsubscribe
   end
 
+  def notify_signer_of_negative_debate_outcome(petition, signature)
+    @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_signer_of_negative_debate_outcome),
+      list_unsubscribe: unsubscribe_url,
+      list_unsubscribe_post: one_click_unsubscribe
+  end
+
+  def notify_signer_of_positive_debate_outcome(petition, signature)
+    @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_signer_of_positive_debate_outcome),
+      list_unsubscribe: unsubscribe_url,
+      list_unsubscribe_post: one_click_unsubscribe
+  end
+
   def notify_creator_of_debate_outcome(petition, signature)
     @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
 
@@ -165,6 +183,24 @@ class PetitionMailer < ApplicationMailer
     end
 
     mail to: @signature.email, subject: subject,
+      list_unsubscribe: unsubscribe_url,
+      list_unsubscribe_post: one_click_unsubscribe
+  end
+
+  def notify_creator_of_negative_debate_outcome(petition, signature)
+    @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_creator_of_negative_debate_outcome),
+      list_unsubscribe: unsubscribe_url,
+      list_unsubscribe_post: one_click_unsubscribe
+  end
+
+  def notify_creator_of_positive_debate_outcome(petition, signature)
+    @petition, @debate_outcome, @signature = petition, petition.debate_outcome, signature
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_creator_of_positive_debate_outcome),
       list_unsubscribe: unsubscribe_url,
       list_unsubscribe_post: one_click_unsubscribe
   end

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -407,6 +407,14 @@ module Archived
       end
     end
 
+    def debate_outcome?
+      debate_outcome_at? && debate_outcome
+    end
+
+    def positive_debate_outcome?
+      debate_outcome? && debate_outcome.debated?
+    end
+
     private
 
     def evaluate_debate_state

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -969,6 +969,10 @@ class Petition < ActiveRecord::Base
     debate_outcome_at? && debate_outcome
   end
 
+  def positive_debate_outcome?
+    debate_outcome && debate_outcome.debated?
+  end
+
   def deadline
     open_at && (closed_at || Site.closed_at_for_opening(open_at) + deadline_extension)
   end

--- a/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -3,43 +3,44 @@
 
 <% if @debate_outcome.debated? %>
 <p>Parliament debated your petition – “<%= @petition.action %>”</p>
-<% if @debate_outcome.overview? %>
 
+<% if @debate_outcome.overview? %>
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
 <% end %>
 <% if @debate_outcome.video_url? %>
-
 <p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
 <% end %>
 <% if @debate_outcome.transcript_url? %>
-
 <p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_pack_url? %>
-
 <p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
-
 <p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
-
 <p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
-<% end %>
 
+<% end %>
 <p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
 <% else %>
 <p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+
 <% if @debate_outcome.overview? %>
-
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
-<% end %>
 
+<% end %>
 <p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
 
 <p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
-<% end %>
 
+<% end %>
 <%= render "footer" %>
 <%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -21,12 +21,12 @@ Read the research: <%= @debate_outcome.debate_pack_url %>
 
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
 
-<p>Read what the public said: <%= @debate_outcome.public_engagement_url %></p>
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
 
-<p>Read a summary of the debate: <%= @debate_outcome.debate_summary_url %></p>
 <% end %>
 The petition: <%= archived_petition_url(@petition) %>
 

--- a/app/views/archived/petition_mailer/notify_creator_of_negative_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_negative_debate_outcome.html.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_creator_of_negative_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_negative_debate_outcome.text.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+The Petitions Committee decided not to debate your petition – "<%= @petition.action %>"
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_creator_of_positive_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_positive_debate_outcome.html.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament debated your petition – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+<p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+<p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+<p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
+
+<% end %>
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_creator_of_positive_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_creator_of_positive_debate_outcome.text.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+Parliament debated your petition – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+Read the research: <%= @debate_outcome.debate_pack_url %>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -3,42 +3,44 @@
 
 <% if @debate_outcome.debated? %>
 <p>Parliament debated the petition you signed – “<%= @petition.action %>”</p>
-<% if @debate_outcome.overview? %>
 
+<% if @debate_outcome.overview? %>
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
 <% end %>
 <% if @debate_outcome.video_url? %>
-
 <p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
 <% end %>
 <% if @debate_outcome.transcript_url? %>
-
 <p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_pack_url? %>
+<p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
 
-<p>Read the transcript: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
-
 <p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
-
 <p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
+
 <% end %>
 <p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
 <% else %>
 <p>The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”</p>
+
 <% if @debate_outcome.overview? %>
-
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
-<% end %>
 
+<% end %>
 <p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
 
 <p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
-<% end %>
 
+<% end %>
 <%= render "footer" %>
 <%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -17,18 +17,18 @@ Read the transcript: <%= @debate_outcome.transcript_url %>
 
 <% end %>
 <% if @debate_outcome.debate_pack_url? %>
-Read the transcript: <%= @debate_outcome.debate_pack_url %>
+Read the research: <%= @debate_outcome.debate_pack_url %>
 
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
-<p>Read what the public said: <%= @debate_outcome.public_engagement_url %></p>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
+
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
 
-<p>Read a summary of the debate: <%= @debate_outcome.debate_summary_url %></p>
 <% end %>
 The petition: <%= archived_petition_url(@petition) %>
-
 <% else %>
 The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”
 

--- a/app/views/archived/petition_mailer/notify_signer_of_negative_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_negative_debate_outcome.html.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_signer_of_negative_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_negative_debate_outcome.text.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_signer_of_positive_debate_outcome.html.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_positive_debate_outcome.html.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament debated the petition you signed – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+<p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+<p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+<p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
+
+<% end %>
+<p>The petition: <%= link_to nil, archived_petition_url(@petition) %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/archived/petition_mailer/notify_signer_of_positive_debate_outcome.text.erb
+++ b/app/views/archived/petition_mailer/notify_signer_of_positive_debate_outcome.text.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+Parliament debated the petition you signed – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+Read the research: <%= @debate_outcome.debate_pack_url %>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
+
+<% end %>
+The petition: <%= archived_petition_url(@petition) %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -3,50 +3,44 @@
 
 <% if @debate_outcome.debated? %>
 <p>Parliament debated your petition – “<%= @petition.action %>”</p>
-<% if @debate_outcome.overview? %>
 
+<% if @debate_outcome.overview? %>
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
 <% end %>
 <% if @debate_outcome.video_url? %>
-
 <p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
 <% end %>
 <% if @debate_outcome.transcript_url? %>
-
 <p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_pack_url? %>
-
 <p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
-
 <p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
-
 <p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
-<% end %>
-<% if @debate_outcome.public_engagement_url? %>
 
-<p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
-<% end %>
-<% if @debate_outcome.debate_summary_url? %>
-
-<p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
 <% end %>
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
 <% else %>
 <p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+
 <% if @debate_outcome.overview? %>
-
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
-<% end %>
 
+<% end %>
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
 
 <p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
-<% end %>
 
+<% end %>
 <%= render "footer" %>
 <%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -21,12 +21,12 @@ Read the research: <%= @debate_outcome.debate_pack_url %>
 
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
 
-<p>Read what the public said: <%= @debate_outcome.public_engagement_url %></p>
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
 
-<p>Read a summary of the debate: <%= @debate_outcome.debate_summary_url %></p>
 <% end %>
 The petition: <%= petition_url(@petition) %>
 

--- a/app/views/petition_mailer/notify_creator_of_negative_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_negative_debate_outcome.html.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_creator_of_negative_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_negative_debate_outcome.text.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+The Petitions Committee decided not to debate your petition – "<%= @petition.action %>"
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_creator_of_positive_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_positive_debate_outcome.html.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament debated your petition – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+<p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+<p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+<p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
+
+<% end %>
+<p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_creator_of_positive_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_positive_debate_outcome.text.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+Parliament debated your petition – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+Read the research: <%= @debate_outcome.debate_pack_url %>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
+
+<% end %>
+The petition: <%= petition_url(@petition) %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -3,42 +3,44 @@
 
 <% if @debate_outcome.debated? %>
 <p>Parliament debated the petition you signed – “<%= @petition.action %>”</p>
-<% if @debate_outcome.overview? %>
 
+<% if @debate_outcome.overview? %>
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
 <% end %>
 <% if @debate_outcome.video_url? %>
-
 <p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
 <% end %>
 <% if @debate_outcome.transcript_url? %>
-
 <p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_pack_url? %>
-
 <p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
-
 <p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
-
 <p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
+
 <% end %>
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
 <% else %>
 <p>The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”</p>
+
 <% if @debate_outcome.overview? %>
-
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
-<% end %>
 
+<% end %>
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
 
 <p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
-<% end %>
 
+<% end %>
 <%= render "footer" %>
 <%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -21,15 +21,14 @@ Read the research: <%= @debate_outcome.debate_pack_url %>
 
 <% end %>
 <% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
 
-<p>Read what the public said: <%= @debate_outcome.public_engagement_url %></p>
 <% end %>
 <% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
 
-<p>Read a summary of the debate: <%= @debate_outcome.debate_summary_url %></p>
 <% end %>
 The petition: <%= petition_url(@petition) %>
-
 <% else %>
 The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”
 

--- a/app/views/petition_mailer/notify_signer_of_negative_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_negative_debate_outcome.html.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_signer_of_negative_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_negative_debate_outcome.text.erb
@@ -1,0 +1,15 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+The petition: <%= petition_url(@petition) %>
+
+Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_signer_of_positive_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_positive_debate_outcome.html.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Parliament debated the petition you signed – “<%= @petition.action %>”</p>
+
+<% if @debate_outcome.overview? %>
+<blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+<p>Watch the debate: <%= auto_link(@debate_outcome.video_url) %></p>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+<p>Read the transcript: <%= auto_link(@debate_outcome.transcript_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+<p>Read the research: <%= auto_link(@debate_outcome.debate_pack_url) %></p>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+<p>Read what the public said: <%= auto_link(@debate_outcome.public_engagement_url) %></p>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+<p>Read a summary of the debate: <%= auto_link(@debate_outcome.debate_summary_url) %></p>
+
+<% end %>
+<p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/app/views/petition_mailer/notify_signer_of_positive_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_positive_debate_outcome.text.erb
@@ -1,0 +1,33 @@
+<%= render "reason" %>
+Dear <%= @signature.name %>,
+
+Parliament debated the petition you signed – “<%= @petition.action %>”
+
+<% if @debate_outcome.overview? %>
+<%= @debate_outcome.overview %>
+
+<% end %>
+<% if @debate_outcome.video_url? %>
+Watch the debate: <%= @debate_outcome.video_url %>
+
+<% end %>
+<% if @debate_outcome.transcript_url? %>
+Read the transcript: <%= @debate_outcome.transcript_url %>
+
+<% end %>
+<% if @debate_outcome.debate_pack_url? %>
+Read the research: <%= @debate_outcome.debate_pack_url %>
+
+<% end %>
+<% if @debate_outcome.public_engagement_url? %>
+Read what the public said: <%= @debate_outcome.public_engagement_url %>
+
+<% end %>
+<% if @debate_outcome.debate_summary_url? %>
+Read a summary of the debate: <%= @debate_outcome.debate_summary_url %>
+
+<% end %>
+The petition: <%= petition_url(@petition) %>
+
+<%= render "footer" %>
+<%= render "unsubscribe" %>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start-server": "bin/rails server -b 0.0.0.0 -p 3000",
-    "test": "mocha",
+    "test": "mocha --timeout 30000",
     "lighthouse:ci": "start-server-and-test start-server http-get://petitions.localhost:3000 test"
   }
 }

--- a/spec/jobs/archived/deliver_debate_outcome_email_job_spec.rb
+++ b/spec/jobs/archived/deliver_debate_outcome_email_job_spec.rb
@@ -29,9 +29,22 @@ RSpec.describe Archived::DeliverDebateOutcomeEmailJob, type: :job do
       allow(signature).to receive(:creator?).and_return(true)
     end
 
-    it "uses the correct mailer method to generate the email" do
-      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_outcome).with(petition, signature).and_return double.as_null_object
-      subject.perform(**arguments)
+    context "and the petition is debated" do
+      let(:petition) { FactoryBot.create(:archived_petition, :debated) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_creator_of_positive_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
+    end
+
+    context "and the petition is not debated" do
+      let(:petition) { FactoryBot.create(:archived_petition, :not_debated) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_creator_of_negative_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
     end
   end
 
@@ -40,9 +53,22 @@ RSpec.describe Archived::DeliverDebateOutcomeEmailJob, type: :job do
       allow(signature).to receive(:creator?).and_return(false)
     end
 
-    it "uses the correct mailer method to generate the email" do
-      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_outcome).with(petition, signature).and_return double.as_null_object
-      subject.perform(**arguments)
+    context "and the petition is debated" do
+      let(:petition) { FactoryBot.create(:archived_petition, :debated) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_signer_of_positive_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
+    end
+
+    context "and the petition is not debated" do
+      let(:petition) { FactoryBot.create(:archived_petition, :not_debated) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_signer_of_negative_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
     end
   end
 end

--- a/spec/jobs/deliver_debate_outcome_email_job_spec.rb
+++ b/spec/jobs/deliver_debate_outcome_email_job_spec.rb
@@ -29,9 +29,22 @@ RSpec.describe DeliverDebateOutcomeEmailJob, type: :job do
       allow(signature).to receive(:creator?).and_return(true)
     end
 
-    it "uses the correct mailer method to generate the email" do
-      expect(subject).to receive_message_chain(:mailer, :notify_creator_of_debate_outcome).with(petition, signature).and_return double.as_null_object
-      subject.perform(**arguments)
+    context "and the petition is debated" do
+      let(:petition) { FactoryBot.create(:debated_petition) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_creator_of_positive_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
+    end
+
+    context "and the petition is not debated" do
+      let(:petition) { FactoryBot.create(:not_debated_petition) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_creator_of_negative_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
     end
   end
 
@@ -40,9 +53,22 @@ RSpec.describe DeliverDebateOutcomeEmailJob, type: :job do
       allow(signature).to receive(:creator?).and_return(false)
     end
 
-    it "uses the correct mailer method to generate the email" do
-      expect(subject).to receive_message_chain(:mailer, :notify_signer_of_debate_outcome).with(petition, signature).and_return double.as_null_object
-      subject.perform(**arguments)
+    context "and the petition is debated" do
+      let(:petition) { FactoryBot.create(:debated_petition) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_signer_of_positive_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
+    end
+
+    context "and the petition is not debated" do
+      let(:petition) { FactoryBot.create(:not_debated_petition) }
+
+      it "uses the correct mailer method to generate the email" do
+        expect(subject).to receive_message_chain(:mailer, :notify_signer_of_negative_debate_outcome).with(petition, signature).and_return double.as_null_object
+        subject.perform(**arguments)
+      end
     end
   end
 end

--- a/spec/lighthouse/navigation/accessibility-page.spec.mjs
+++ b/spec/lighthouse/navigation/accessibility-page.spec.mjs
@@ -5,8 +5,8 @@ describe('the accessibility page', function () {
     report = await lighthouse(this, 'http://petitions.localhost:3000/accessibility');
   });
 
-  it('should have an performance score greater than or equal to 95', () => {
-    expect(performanceScore(report), 'to be greater than or equal to', 95);
+  it('should have an performance score greater than or equal to 90', () => {
+    expect(performanceScore(report), 'to be greater than or equal to', 90);
   });
 
   it('should have an accessibility score of 100', () => {

--- a/spec/lighthouse/navigation/cookies-page.spec.mjs
+++ b/spec/lighthouse/navigation/cookies-page.spec.mjs
@@ -5,8 +5,8 @@ describe('the cookies page', function () {
     report = await lighthouse(this, 'http://petitions.localhost:3000/cookies');
   });
 
-  it('should have an performance score greater than or equal to 95', () => {
-    expect(performanceScore(report), 'to be greater than or equal to', 95);
+  it('should have an performance score greater than or equal to 90', () => {
+    expect(performanceScore(report), 'to be greater than or equal to', 90);
   });
 
   it('should have an accessibility score of 100', () => {

--- a/spec/lighthouse/navigation/help-page.spec.mjs
+++ b/spec/lighthouse/navigation/help-page.spec.mjs
@@ -5,8 +5,8 @@ describe('the help page', function () {
     report = await lighthouse(this, 'http://petitions.localhost:3000/help');
   });
 
-  it('should have an performance score greater than or equal to 95', () => {
-    expect(performanceScore(report), 'to be greater than or equal to', 95);
+  it('should have an performance score greater than or equal to 90', () => {
+    expect(performanceScore(report), 'to be greater than or equal to', 90);
   });
 
   it('should have an accessibility score of 100', () => {

--- a/spec/lighthouse/navigation/home-page.spec.mjs
+++ b/spec/lighthouse/navigation/home-page.spec.mjs
@@ -5,8 +5,8 @@ describe('the home page', function () {
     report = await lighthouse(this, 'http://petitions.localhost:3000');
   });
 
-  it('should have an performance score greater than or equal to 95', () => {
-    expect(performanceScore(report), 'to be greater than or equal to', 95);
+  it('should have an performance score greater than or equal to 90', () => {
+    expect(performanceScore(report), 'to be greater than or equal to', 90);
   });
 
   it('should have an accessibility score of 100', () => {

--- a/spec/lighthouse/navigation/privacy-page.spec.mjs
+++ b/spec/lighthouse/navigation/privacy-page.spec.mjs
@@ -5,8 +5,8 @@ describe('the privacy page', function () {
     report = await lighthouse(this, 'http://petitions.localhost:3000/privacy');
   });
 
-  it('should have an performance score greater than or equal to 95', () => {
-    expect(performanceScore(report), 'to be greater than or equal to', 95);
+  it('should have an performance score greater than or equal to 90', () => {
+    expect(performanceScore(report), 'to be greater than or equal to', 90);
   });
 
   it('should have an accessibility score of 100', () => {

--- a/spec/mailers/archived/petition_mailer_spec.rb
+++ b/spec/mailers/archived/petition_mailer_spec.rb
@@ -489,6 +489,348 @@ RSpec.describe Archived::PetitionMailer, type: :mailer do
     end
   end
 
+  describe "notifying signature of a negative debate outcome" do
+    context "when the signature is the creator" do
+      let(:signature) { creator }
+      subject(:mail) { described_class.notify_creator_of_negative_debate_outcome(petition, signature) }
+
+      shared_examples_for "a debate outcome email" do
+        it "addresses the signatory by name" do
+          expect(mail).to have_body_text("Dear Barry Butler,")
+        end
+
+        it "sends it only to the creator" do
+          expect(mail.to).to eq(%w[bazbutler@gmail.com])
+          expect(mail.cc).to be_blank
+          expect(mail.bcc).to be_blank
+        end
+
+        it "includes a link to the petition page" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+        end
+
+        it "includes the petition action" do
+          expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+        end
+
+        it "includes an unsubscribe link" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+        end
+
+        it "has a List-Unsubscribe header" do
+          expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+        end
+
+        it "has a List-Unsubscribe-Post header" do
+          expect(mail).to have_header("List-Unsubscribe-Post", "List-Unsubscribe=One-Click")
+        end
+      end
+
+      shared_examples_for "a negative debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject('Parliament didn’t debate “Allow organic vegetable vans to use red diesel”')
+        end
+
+        it "has the negative message in the body" do
+          expect(mail).to have_body_text("The Petitions Committee decided not to debate your petition")
+        end
+      end
+
+      context "when the debate outcome is not filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :not_debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a negative debate outcome email"
+      end
+
+      context "when the debate outcome is filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :not_debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables",
+            overview: "Discussion of the 2015 Christmas Adjournment"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a negative debate outcome email"
+
+        it "includes the debate outcome overview" do
+          expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+        end
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { signer }
+      subject(:mail) { described_class.notify_signer_of_negative_debate_outcome(petition, signature) }
+
+      shared_examples_for "a debate outcome email" do
+        it "addresses the signatory by name" do
+          expect(mail).to have_body_text("Dear Laura Palmer,")
+        end
+
+        it "sends it only to the signatory" do
+          expect(mail.to).to eq(%w[laurapalmer@hotmail.com])
+          expect(mail.cc).to be_blank
+          expect(mail.bcc).to be_blank
+        end
+
+        it "includes a link to the petition page" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+        end
+
+        it "includes the petition action" do
+          expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+        end
+
+        it "includes an unsubscribe link" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+        end
+
+        it "has a List-Unsubscribe header" do
+          expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+        end
+
+        it "has a List-Unsubscribe-Post header" do
+          expect(mail).to have_header("List-Unsubscribe-Post", "List-Unsubscribe=One-Click")
+        end
+      end
+
+      shared_examples_for "a negative debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament didn’t debate “Allow organic vegetable vans to use red diesel”")
+        end
+
+        it "has the negative message in the body" do
+          expect(mail).to have_body_text("The Petitions Committee decided not to debate the petition you signed")
+        end
+      end
+
+      context "when the debate outcome is not filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :not_debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a negative debate outcome email"
+      end
+
+      context "when the debate outcome is filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :not_debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables",
+            overview: "Discussion of the 2015 Christmas Adjournment"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a negative debate outcome email"
+
+        it "includes the debate outcome overview" do
+          expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+        end
+      end
+    end
+  end
+
+  describe "notifying signature of a positive debate outcome" do
+    context "when the signature is the creator" do
+      let(:signature) { creator }
+      subject(:mail) { described_class.notify_creator_of_positive_debate_outcome(petition, signature) }
+
+      shared_examples_for "a debate outcome email" do
+        it "addresses the signatory by name" do
+          expect(mail).to have_body_text("Dear Barry Butler,")
+        end
+
+        it "sends it only to the creator" do
+          expect(mail.to).to eq(%w[bazbutler@gmail.com])
+          expect(mail.cc).to be_blank
+          expect(mail.bcc).to be_blank
+        end
+
+        it "includes a link to the petition page" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+        end
+
+        it "includes the petition action" do
+          expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+        end
+
+        it "includes an unsubscribe link" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+        end
+
+        it "has a List-Unsubscribe header" do
+          expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+        end
+
+        it "has a List-Unsubscribe-Post header" do
+          expect(mail).to have_header("List-Unsubscribe-Post", "List-Unsubscribe=One-Click")
+        end
+      end
+
+      shared_examples_for "a positive debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament debated “Allow organic vegetable vans to use red diesel”")
+        end
+
+        it "has the positive message in the body" do
+          expect(mail).to have_body_text("Parliament debated your petition")
+        end
+      end
+
+      context "when the debate outcome is not filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a positive debate outcome email"
+      end
+
+      context "when the debate outcome is filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables",
+            debated_on: "2015-09-24",
+            overview: "Discussion of the 2015 Christmas Adjournment",
+            transcript_url: "http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001",
+            video_url: "http://parliamentlive.tv/event/index/20150924000001",
+            debate_pack_url: "http://researchbriefings.parliament.uk/ResearchBriefing/Summary/CDP-2015-0001",
+            public_engagement_url: "https://committees.parliament.uk/public-engagement",
+            debate_summary_url: "https://ukparliament.shorthandstories.com/about-a-petition",
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a positive debate outcome email"
+
+        it "includes the debate outcome overview" do
+          expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+        end
+
+        it "includes a link to the transcript of the debate" do
+          expect(mail).to have_body_text(%r[http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001])
+        end
+
+        it "includes a link to the video of the debate" do
+          expect(mail).to have_body_text(%r[http://parliamentlive.tv/event/index/20150924000001])
+        end
+      end
+    end
+
+    context "when the signature is not the creator" do
+      let(:signature) { signer }
+      subject(:mail) { described_class.notify_signer_of_positive_debate_outcome(petition, signature) }
+
+      shared_examples_for "a debate outcome email" do
+        it "addresses the signatory by name" do
+          expect(mail).to have_body_text("Dear Laura Palmer,")
+        end
+
+        it "sends it only to the signatory" do
+          expect(mail.to).to eq(%w[laurapalmer@hotmail.com])
+          expect(mail.cc).to be_blank
+          expect(mail.bcc).to be_blank
+        end
+
+        it "includes a link to the petition page" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/petitions/#{petition.id}])
+        end
+
+        it "includes the petition action" do
+          expect(mail).to have_body_text(%r[Allow organic vegetable vans to use red diesel])
+        end
+
+        it "includes an unsubscribe link" do
+          expect(mail).to have_body_text(%r[https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe\?token=#{signature.unsubscribe_token}])
+        end
+
+        it "has a List-Unsubscribe header" do
+          expect(mail).to have_header("List-Unsubscribe", "<https://petition.parliament.uk/archived/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}>")
+        end
+
+        it "has a List-Unsubscribe-Post header" do
+          expect(mail).to have_header("List-Unsubscribe-Post", "List-Unsubscribe=One-Click")
+        end
+      end
+
+      shared_examples_for "a positive debate outcome email" do
+        it "has the correct subject" do
+          expect(mail).to have_subject("Parliament debated “Allow organic vegetable vans to use red diesel”")
+        end
+
+        it "has the positive message in the body" do
+          expect(mail).to have_body_text("Parliament debated the petition you signed")
+        end
+      end
+
+      context "when the debate outcome is not filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a positive debate outcome email"
+      end
+
+      context "when the debate outcome is filled out" do
+        let :petition do
+          FactoryBot.create(:archived_petition, :debated,
+            action: "Allow organic vegetable vans to use red diesel",
+            background: "Add vans to permitted users of red diesel",
+            additional_details: "To promote organic vegetables",
+            debated_on: "2015-09-24",
+            overview: "Discussion of the 2015 Christmas Adjournment",
+            transcript_url: "http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001",
+            video_url: "http://parliamentlive.tv/event/index/20150924000001",
+            debate_pack_url: "http://researchbriefings.parliament.uk/ResearchBriefing/Summary/CDP-2015-0001"
+          )
+        end
+
+        it_behaves_like "a debate outcome email"
+        it_behaves_like "a positive debate outcome email"
+
+        it "includes the debate outcome overview" do
+          expect(mail).to have_body_text(%r[Discussion of the 2015 Christmas Adjournment])
+        end
+
+        it "includes a link to the transcript of the debate" do
+          expect(mail).to have_body_text(%r[http://www.publications.parliament.uk/pa/cm201509/cmhansrd/cm20150924/debtext/20150924-0003.htm#2015092449#000001])
+        end
+
+        it "includes a link to the video of the debate" do
+          expect(mail).to have_body_text(%r[http://parliamentlive.tv/event/index/20150924000001])
+        end
+      end
+    end
+  end
+
   describe "emailing a signature" do
     let :petition do
       FactoryBot.create(:archived_petition,

--- a/spec/mailers/previews/archived/petition_mailer_preview.rb
+++ b/spec/mailers/previews/archived/petition_mailer_preview.rb
@@ -66,28 +66,28 @@ module Archived
       petition = Archived::Petition.debated.last
       signature = petition.signatures.validated.last
 
-      Archived::PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+      Archived::PetitionMailer.notify_signer_of_positive_debate_outcome(petition, signature)
     end
 
     def notify_creator_of_positive_debate_outcome
       petition = Archived::Petition.debated.last
       signature = petition.creator
 
-      Archived::PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+      Archived::PetitionMailer.notify_creator_of_positive_debate_outcome(petition, signature)
     end
 
     def notify_signer_of_negative_debate_outcome
       petition = Archived::Petition.not_debated.last
       signature = petition.signatures.validated.last
 
-      Archived::PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+      Archived::PetitionMailer.notify_signer_of_negative_debate_outcome(petition, signature)
     end
 
     def notify_creator_of_negative_debate_outcome
       petition = Archived::Petition.not_debated.last
       signature = petition.creator
 
-      Archived::PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+      Archived::PetitionMailer.notify_creator_of_negative_debate_outcome(petition, signature)
     end
   end
 end

--- a/spec/mailers/previews/petition_mailer_preview.rb
+++ b/spec/mailers/previews/petition_mailer_preview.rb
@@ -113,28 +113,28 @@ class PetitionMailerPreview < ActionMailer::Preview
     petition = Petition.debated.last
     signature = petition.signatures.validated.last
 
-    PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+    PetitionMailer.notify_signer_of_positive_debate_outcome(petition, signature)
   end
 
   def debated_petition_creator_notification
     petition = Petition.debated.last
     signature = petition.creator
 
-    PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+    PetitionMailer.notify_creator_of_positive_debate_outcome(petition, signature)
   end
 
   def not_debated_petition_signer_notification
     petition = Petition.not_debated.last
     signature = petition.signatures.validated.last
 
-    PetitionMailer.notify_signer_of_debate_outcome(petition, signature)
+    PetitionMailer.notify_signer_of_negative_debate_outcome(petition, signature)
   end
 
   def not_debated_petition_creator_notification
     petition = Petition.not_debated.last
     signature = petition.signatures.validated.last
 
-    PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
+    PetitionMailer.notify_creator_of_negative_debate_outcome(petition, signature)
   end
 
   def privacy_policy_update_email


### PR DESCRIPTION
Doing this means not having conditional logic for email subjects.
