### PR TITLE
Split rejected/hidden emails into separate templates

### DIFF
--- a/app/jobs/notify_creator_that_petition_was_hidden_email_job.rb
+++ b/app/jobs/notify_creator_that_petition_was_hidden_email_job.rb
@@ -1,0 +1,4 @@
+class NotifyCreatorThatPetitionWasHiddenEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_creator_that_petition_was_hidden
+end

--- a/app/jobs/notify_everyone_of_moderation_decision_job.rb
+++ b/app/jobs/notify_everyone_of_moderation_decision_job.rb
@@ -9,8 +9,10 @@ class NotifyEveryoneOfModerationDecisionJob < ApplicationJob
 
     if petition.published?
       notify_everyone_of_publication(creator, sponsors)
-    elsif petition.rejection?
-      notify_everyone_of_rejection(creator, sponsors)
+    elsif petition.hidden?
+      notify_everyone_of_hidden_rejection(creator, sponsors)
+    elsif petition.rejected?
+      notify_everyone_of_public_rejection(creator, sponsors)
     end
   end
 
@@ -24,7 +26,15 @@ class NotifyEveryoneOfModerationDecisionJob < ApplicationJob
     end
   end
 
-  def notify_everyone_of_rejection(creator, sponsors)
+  def notify_everyone_of_hidden_rejection(creator, sponsors)
+    NotifyCreatorThatPetitionWasHiddenEmailJob.perform_later(creator)
+
+    sponsors.each do |sponsor|
+      NotifySponsorThatPetitionWasHiddenEmailJob.perform_later(sponsor)
+    end
+  end
+
+  def notify_everyone_of_public_rejection(creator, sponsors)
     NotifyCreatorThatPetitionWasRejectedEmailJob.perform_later(creator)
 
     sponsors.each do |sponsor|

--- a/app/jobs/notify_sponsor_that_petition_was_hidden_email_job.rb
+++ b/app/jobs/notify_sponsor_that_petition_was_hidden_email_job.rb
@@ -1,0 +1,4 @@
+class NotifySponsorThatPetitionWasHiddenEmailJob < EmailJob
+  self.mailer = PetitionMailer
+  self.email = :notify_sponsor_that_petition_was_hidden
+end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -94,6 +94,20 @@ class PetitionMailer < ApplicationMailer
       subject: subject_for(:notify_sponsor_that_petition_was_rejected)
   end
 
+  def notify_creator_that_petition_was_hidden(signature)
+    @signature, @petition, @rejection = signature, signature.petition, signature.petition.rejection
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_creator_that_petition_was_hidden)
+  end
+
+  def notify_sponsor_that_petition_was_hidden(signature)
+    @signature, @petition, @rejection = signature, signature.petition, signature.petition.rejection
+
+    mail to: @signature.email,
+      subject: subject_for(:notify_sponsor_that_petition_was_hidden)
+  end
+
   def notify_signer_of_threshold_response(petition, signature)
     @petition, @signature, @government_response = petition, signature, petition.government_response
 

--- a/app/previews/petition_mailer_preview.rb
+++ b/app/previews/petition_mailer_preview.rb
@@ -98,8 +98,8 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.notify_creator_that_petition_was_rejected(rejected_creator)
   end
 
-  def notify_creator_that_petition_is_rejected_and_hidden
-    PetitionMailer.notify_creator_that_petition_was_rejected(hidden_creator)
+  def notify_creator_that_petition_is_hidden
+    PetitionMailer.notify_creator_that_petition_was_hidden(hidden_creator)
   end
 
   def notify_sponsor_that_petition_is_published
@@ -110,8 +110,8 @@ class PetitionMailerPreview < ActionMailer::Preview
     PetitionMailer.notify_sponsor_that_petition_was_rejected(rejected_sponsor)
   end
 
-  def notify_sponsor_that_petition_is_rejected_and_hidden
-    PetitionMailer.notify_sponsor_that_petition_was_rejected(hidden_sponsor)
+  def notify_sponsor_that_petition_is_hidden
+    PetitionMailer.notify_sponsor_that_petition_was_hidden(hidden_sponsor)
   end
 
   private

--- a/app/views/petition_mailer/notify_creator_that_petition_was_hidden.html.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_was_hidden.html.erb
@@ -1,0 +1,22 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Sorry, we can’t accept your petition – “<%= @petition.action %>”.
+
+<%= rejection_description(@rejection.code) %>
+<% if @rejection.details? -%>
+
+<p><%= auto_link(h(@rejection.details)) %></p>
+<% end -%>
+<% unless @petition.hidden? -%>
+
+<p>Click this link to see your rejected petition:<br>
+<%= link_to 'View your rejected petition', petition_url(@petition) %></p>
+<% end -%>
+
+<p>We only reject petitions that don’t meet the petition standards:<br>
+<%= link_to nil, help_url(anchor: 'standards') %></p>
+
+<p>If you want to try again, click here to start a petition:<br>
+<%= link_to nil, check_petitions_url %></p>
+
+<%= render "footer" %>

--- a/app/views/petition_mailer/notify_creator_that_petition_was_hidden.text.erb
+++ b/app/views/petition_mailer/notify_creator_that_petition_was_hidden.text.erb
@@ -1,0 +1,22 @@
+Dear <%= @signature.name %>,
+
+Sorry, we can’t accept your petition – "<%= @petition.action %>".
+
+<%= strip_tags(rejection_description(@rejection.code)) %>
+<% if @rejection.details? -%>
+
+<%= @rejection.details %>
+<% end -%>
+<% unless @petition.hidden? -%>
+
+Click this link to see your rejected petition:
+<%= petition_url(@petition) %>
+<% end -%>
+
+We only reject petitions that don’t meet the petition standards:
+<%= help_url(anchor: 'standards') %>
+
+If you want to try again, click here to start a petition:
+<%= check_petitions_url %>
+
+<%= render "footer" %>

--- a/app/views/petition_mailer/notify_sponsor_that_petition_was_hidden.html.erb
+++ b/app/views/petition_mailer/notify_sponsor_that_petition_was_hidden.html.erb
@@ -1,0 +1,19 @@
+<p>Dear <%= @signature.name %>,</p>
+
+<p>Sorry, we can’t accept the petition you supported – “<%= @petition.action %>”.
+
+<%= rejection_description(@rejection.code) %>
+<% if @rejection.details? -%>
+
+<p><%= auto_link(h(@rejection.details)) %></p>
+<% end -%>
+<% unless @petition.hidden? -%>
+
+<p>Click this link to see the rejected petition:<br>
+<%= link_to 'View the rejected petition', petition_url(@petition) %></p>
+<% end -%>
+
+<p>We only reject petitions that don’t meet the petition standards:<br>
+<%= link_to nil, help_url(anchor: 'standards') %></p>
+
+<%= render "footer" %>

--- a/app/views/petition_mailer/notify_sponsor_that_petition_was_hidden.text.erb
+++ b/app/views/petition_mailer/notify_sponsor_that_petition_was_hidden.text.erb
@@ -1,0 +1,19 @@
+Dear <%= @signature.name %>,
+
+Sorry, we can’t accept the petition you supported  – "<%= @petition.action %>".
+
+<%= strip_tags(rejection_description(@rejection.code)) %>
+<% if @rejection.details? -%>
+
+<%= @rejection.details %>
+<% end -%>
+<% unless @petition.hidden? -%>
+
+Click this link to see the rejected petition:
+<%= petition_url(@petition) %>
+<% end -%>
+
+We only reject petitions that don’t meet the petition standards:
+<%= help_url(anchor: 'standards') %>
+
+<%= render "footer" %>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -190,6 +190,10 @@ en-GB:
           We published your petition “%{action}”
         notify_sponsor_that_petition_is_published: |-
           We published the petition “%{action}” that you supported
+        notify_creator_that_petition_was_hidden: |-
+          We rejected your petition “%{action}”
+        notify_sponsor_that_petition_was_hidden: |-
+          We rejected the petition “%{action}” that you supported
         notify_creator_that_petition_was_rejected: |-
           We rejected your petition “%{action}”
         notify_sponsor_that_petition_was_rejected: |-

--- a/spec/jobs/email_job_spec.rb
+++ b/spec/jobs/email_job_spec.rb
@@ -429,12 +429,38 @@ RSpec.describe NotifyCreatorThatPetitionWasRejectedEmailJob, type: :job do
   end
 end
 
+RSpec.describe NotifyCreatorThatPetitionWasHiddenEmailJob, type: :job do
+  let(:petition) { FactoryBot.create(:hidden_petition) }
+  let(:signature) { FactoryBot.create(:signature, petition: petition) }
+
+  it "sends the PetitionMailer#notify_creator_that_petition_was_hidden email" do
+    expect(PetitionMailer).to receive(:notify_creator_that_petition_was_hidden).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
 RSpec.describe NotifySponsorThatPetitionWasRejectedEmailJob, type: :job do
   let(:petition) { FactoryBot.create(:rejected_petition) }
   let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
 
   it "sends the PetitionMailer#notify_sponsor_that_petition_was_rejected email" do
     expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_rejected).with(signature).and_call_original
+
+    perform_enqueued_jobs do
+      described_class.perform_later(signature)
+    end
+  end
+end
+
+RSpec.describe NotifySponsorThatPetitionWasHiddenEmailJob, type: :job do
+  let(:petition) { FactoryBot.create(:hidden_petition) }
+  let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+
+  it "sends the PetitionMailer#notify_sponsor_that_petition_was_hidden email" do
+    expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_hidden).with(signature).and_call_original
 
     perform_enqueued_jobs do
       described_class.perform_later(signature)

--- a/spec/jobs/notify_everyone_of_moderation_decision_job_spec.rb
+++ b/spec/jobs/notify_everyone_of_moderation_decision_job_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
     end
 
     it "notifies the creator" do
-      expect(PetitionMailer).to receive(:notify_creator_that_petition_was_rejected).with(creator).and_call_original
+      expect(PetitionMailer).to receive(:notify_creator_that_petition_was_hidden).with(creator).and_call_original
 
       perform_enqueued_jobs do
         described_class.perform_later(petition)
@@ -80,7 +80,7 @@ RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
     end
 
     it "notifies the validated sponsors" do
-      expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_rejected).with(validated_sponsor).and_call_original
+      expect(PetitionMailer).to receive(:notify_sponsor_that_petition_was_hidden).with(validated_sponsor).and_call_original
 
       perform_enqueued_jobs do
         described_class.perform_later(petition)
@@ -88,7 +88,7 @@ RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
     end
 
     it "doesn't notify the pending sponsors" do
-      expect(PetitionMailer).not_to receive(:notify_sponsor_that_petition_was_rejected).with(pending_sponsor)
+      expect(PetitionMailer).not_to receive(:notify_sponsor_that_petition_was_hidden).with(pending_sponsor)
 
       perform_enqueued_jobs do
         described_class.perform_later(petition)


### PR DESCRIPTION
This is so it's easier to edit when we render templates from the database.