### PR TITLE
Fix flaky specs with WebMock disappearing stubs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,9 @@ jobs:
       - name: ${{ inputs.description }}
         shell: bash
         env:
+          SE_BROWSER_VERSION: "131.0.6778.264"
+          SE_DRIVER_VERSION: "131.0.6778.264"
+          SE_FORCE_BROWSER_DOWNLOAD: "true"
           CUCUMBER_FORMAT: "${{ inputs.cucumber_format }}"
           CUCUMBER_OPTS: "${{ inputs.cucumber_opts }}"
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/epets_test

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -16,8 +16,14 @@ RUN echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesou
     apt-get update
 
 # Install packages
+RUN apt-get install -y --no-install-recommends nodejs postgresql-client-16 libvips-dev
+
+# Install chromium and chromium-driver known good versions
+ARG CHROMIUM_VERSION=131.0.6778.139-1~deb12u1
 RUN apt-get install -y --no-install-recommends \
-    chromium chromium-driver nodejs postgresql-client-16 libvips-dev
+    chromium=$CHROMIUM_VERSION \
+    chromium-common=$CHROMIUM_VERSION \
+    chromium-driver=$CHROMIUM_VERSION
 
 # Create the crash reports directory - without it Chromium complains on startup
 RUN mkdir -p "/root/.config/chromium/Crash Reports/pending/"

--- a/features/support/custom_env.rb
+++ b/features/support/custom_env.rb
@@ -28,9 +28,6 @@ Capybara.register_driver :chrome do |app|
     opts.add_argument('--window-size=1280,960')
     opts.add_argument('--proxy-server=127.0.0.1:8443')
     opts.add_argument('--disable-dev-shm-usage')
-
-    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-    opts.add_argument('--disable-site-isolation-trials')
   end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
@@ -51,9 +48,6 @@ Capybara.register_driver :chrome_headless do |app|
       opts.add_argument('--no-sandbox')
       opts.add_argument('--disable-gpu')
     end
-
-    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-    opts.add_argument('--disable-site-isolation-trials')
   end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -47,7 +47,9 @@ Before do
 end
 
 After do
-  page.driver.options[:headers] = nil
+  if page.driver.options.key?(:headers)
+    page.driver.options[:headers] = nil
+  end
 end
 
 After do
@@ -55,7 +57,7 @@ After do
 end
 
 After do
-   OmniAuth.config.mock_auth[:example] = nil
+  OmniAuth.config.mock_auth[:example] = nil
 end
 
 After do |scenario|


### PR DESCRIPTION
There appears to be a race condition or timing issue where WebMock stubs are disappearing causing tests to fail. To temporarily work around the issue pin the version of chrome/chromium.