### PR TITLE
Wait for lock requests before finishing a feature

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -46,6 +46,23 @@ Before do
   Parliament.reset!(government: "TBC", opening_at: 2.weeks.ago)
 end
 
+After('@javascript') do
+  javascript = <<~JS
+    (typeof jQuery == 'defined') ? jQuery.active > 0 : false;
+  JS
+
+  begin
+    Timeout.timeout(5) do
+      loop do
+        break unless page.evaluate_script(javascript)
+        sleep 0.1
+      end
+    end
+  rescue Timeout::Error
+    # Ignore timeouts here as it's likely the page is in an invalid state
+  end
+end
+
 After('not @javascript') do
   page.driver.options[:headers] = nil
 end


### PR DESCRIPTION
The lock requests were leaking into the next feature and generating record not found exceptions.