### PR TITLE
Allow moderators to hide petitions manually

### DIFF
--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -19,7 +19,7 @@ class Admin::ModerationController < Admin::AdminController
   end
 
   def moderation_params
-    params.require(:petition).permit(:moderation, rejection: [:code, :details])
+    params.require(:petition).permit(:moderation, rejection: [:code, :details, :hidden])
   end
 
   def send_notifications

--- a/app/controllers/admin/take_down_controller.rb
+++ b/app/controllers/admin/take_down_controller.rb
@@ -30,7 +30,7 @@ class Admin::TakeDownController < Admin::AdminController
   end
 
   def rejection_attributes
-    [ rejection: [:code, :details] ]
+    [ rejection: [:code, :details, :hidden] ]
   end
 
   def send_notifications

--- a/app/helpers/rejection_helper.rb
+++ b/app/helpers/rejection_helper.rb
@@ -30,4 +30,12 @@ module RejectionHelper
       hash[reason.code] = markdown_to_html(reason.description)
     end
   end
+
+  def hidden_rejections
+    @rejection_reasons ||= RejectionReason.all
+
+    @rejection_reasons.each_with_object({}) do |reason, hash|
+      hash[reason.code] = reason.hidden
+    end
+  end
 end

--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -1,6 +1,8 @@
 class Rejection < ActiveRecord::Base
   belongs_to :petition, touch: true
 
+  attribute :hidden, :boolean, default: false
+
   validates :petition, presence: true
   validates :code, presence: true, inclusion: { in: :rejection_codes }
   validates :details, length: { maximum: 4000 }, allow_blank: true
@@ -24,7 +26,7 @@ class Rejection < ActiveRecord::Base
   end
 
   def hide_petition?
-    code.in?(hidden_codes)
+    hidden || code.in?(hidden_codes)
   end
 
   def state_for_petition

--- a/app/views/admin/petitions/_reject.html.erb
+++ b/app/views/admin/petitions/_reject.html.erb
@@ -1,6 +1,7 @@
 <div class="petition-rejection-controls">
   <%= javascript_tag do %>
     var rejection_descriptions = <%= raw json_escape(rejection_descriptions.to_json) %>;
+    var hidden_rejections = <%= raw json_escape(hidden_rejections.to_json) %>;
 
     $().ready(function() {
       // Ensure that we get the onchange event when the users uses the keyboard
@@ -13,6 +14,12 @@
       $('#petition_rejection_code').change(function() {
         $('#rejection_preview').show();
         $('#rejection_preview .content').html(rejection_descriptions[$(this).val()]);
+
+        if (hidden_rejections[$(this).val()]) {
+          $('#hide-petition-option').hide();
+        } else {
+          $('#hide-petition-option').show();
+        }
       });
     });
   <% end -%>
@@ -33,6 +40,14 @@
       <%= r.label :details, 'Additional details (optional)', class: 'form-label' %>
       <%= error_messages_for_field r.object, :details %>
       <%= r.text_area :details, rows: 8, cols: 70, class: 'form-control' %>
+    <% end %>
+
+    <%= form_row for: [r.object, :hidden], id: 'hide-petition-option' do %>
+      <div class="multiple-choice">
+        <%= r.check_box :hidden, tabindex: increment %>
+        <%= r.label :hidden, 'Hide this petition from the public' %>
+      </div>
+      <%= error_messages_for_field r.object, :hidden %>
     <% end %>
   <% end %>
 </div>

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -105,6 +105,15 @@ Feature: Moderator respond to petition
     And the petition is not available for searching or viewing
     But the petition will still show up in the back-end reporting
 
+  Scenario: Moderator rejects petition with a reason code which precludes public searching or viewing manually
+    Given I am logged in as a moderator named "Ben Macintosh"
+    When I look at the next petition on my list
+    And I reject the petition with a reason code "Duplicate petition" and hide it
+    Then I should see "Hidden by Ben Macintosh"
+    And the creator should receive a hidden rejection notification email
+    And the petition is not available for searching or viewing
+    But the petition will still show up in the back-end reporting
+
   Scenario: Moderator rejects petition but with no reason code
     Given I am logged in as a moderator named "Ben Macintosh"
     And a sponsored petition exists with action: "Rupert Murdoch is on the run"
@@ -118,6 +127,15 @@ Feature: Moderator respond to petition
     And a petition "actually libellous" has been rejected with the reason "duplicate"
     When I go to the admin petition page for "actually libellous"
     And I change the rejection status of the petition with a reason code "Confidential, libellous, false, defamatory or references a court case"
+    Then I should see "Hidden by Ben Macintosh"
+    And the petition is not available for searching or viewing
+    But the petition will still show up in the back-end reporting
+
+  Scenario: Moderator rejects and hides previously rejected (and public) petition manually
+    Given I am logged in as a moderator named "Ben Macintosh"
+    And a petition "actually libellous" has been rejected with the reason "duplicate"
+    When I go to the admin petition page for "actually libellous"
+    And I hide the petition manually
     Then I should see "Hidden by Ben Macintosh"
     And the petition is not available for searching or viewing
     But the petition will still show up in the back-end reporting

--- a/features/admin/takedown.feature
+++ b/features/admin/takedown.feature
@@ -23,6 +23,22 @@ Feature: Terry (or Sheila) takes down a petition
     Then the petition is not available for signing
     And I should not be able to take down the petition
 
+  Scenario: A moderator can take down a petition and hide it
+    Given I am logged in as a moderator
+    When I view all petitions
+    And I follow "Mistakenly published petition"
+    And I take down the petition with a reason code "Confidential, libellous, false, defamatory or references a court case"
+    Then the petition is not available for searching or viewing
+    And I should not be able to take down the petition
+
+  Scenario: A moderator can take down a petition and hide it manually
+    Given I am logged in as a moderator
+    When I view all petitions
+    And I follow "Mistakenly published petition"
+    And I take down the petition with a reason code "Duplicate petition" and hide it
+    Then the petition is not available for searching or viewing
+    And I should not be able to take down the petition
+
   Scenario: A sysadmin can restore a petition that has been taken down
     Given I am logged in as a sysadmin
     And a published petition has been taken down

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -38,6 +38,20 @@ When(/^I reject the petition with a reason code "([^"]*)" and some explanatory t
   click_button "Email petition creator"
 end
 
+When('I reject the petition with a reason code {string} and hide it') do |reason_code|
+  choose "Reject"
+  select reason_code, :from => :petition_rejection_code
+  fill_in :petition_rejection_details, :with => "See guidelines at http://direct.gov.uk"
+  check 'Hide this petition from the public'
+  click_button "Email petition creator"
+end
+
+When('I hide the petition manually') do
+  click_on 'Change rejection reason'
+  check 'Hide this petition from the public'
+  click_button "Email petition creator"
+end
+
 Then /^the petition is not available for signing$/ do
   visit petition_url(@petition)
   expect(page).not_to have_css("a", :text => "Sign")
@@ -142,7 +156,7 @@ Then(/^the creator should not receive a notification email$/) do
   step %{"#{@petition.creator.email}" should receive no email with subject "We published your petition"}
 end
 
-Then(/^the creator should receive a (libel\/profanity )?rejection notification email$/) do |petition_is_libellous|
+Then(/^the creator should receive a (libel\/profanity |hidden )?rejection notification email$/) do |petition_is_hidden|
   @petition.reload
   steps %Q(
     Then "#{@petition.creator.email}" should receive an email
@@ -151,7 +165,7 @@ Then(/^the creator should receive a (libel\/profanity )?rejection notification e
     And they should see "#{strip_tags(rejection_description(@petition.rejection.code)).split("\n").first}" in the email body
     And they should see /We rejected your petition/ in the email subject
   )
-  if petition_is_libellous
+  if petition_is_hidden
     step %{they should not see "#{petition_url(@petition)}" in the email body}
   else
     step %{they should see "#{petition_url(@petition)}" in the email body}

--- a/features/step_definitions/takedown_steps.rb
+++ b/features/step_definitions/takedown_steps.rb
@@ -4,6 +4,13 @@ When(/^I take down the petition with a reason code "([^"]*)"$/) do |reason_code|
   click_button "Email petition creator"
 end
 
+When(/^I take down the petition with a reason code "([^"]*)" and hide it$/) do |reason_code|
+  click_on 'Take this petition down'
+  select reason_code, :from => :petition_rejection_code
+  check "Hide this petition from the public"
+  click_button "Email petition creator"
+end
+
 Then(/^I should not be able to take down the petition$/) do
   visit admin_petition_url(@petition)
   expect(page).to have_no_content("Take this petition down")


### PR DESCRIPTION
Sometimes a petition needs to be hidden even though the moderation decision is for a non-hidden reason such as 'Duplicate petition'.