### PR TITLE
Fix dynamic signature counter

### DIFF
--- a/app/assets/javascripts/auto-updater.js.erb
+++ b/app/assets/javascripts/auto-updater.js.erb
@@ -5,7 +5,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
 
   for (const counter of counters) {
     new PETS.SignatureCounter(
-      container,
+      counter,
       <%= Site.threshold_for_response %>,
       <%= Site.threshold_for_debate %>,
       10000

--- a/app/assets/javascripts/modules/signature-counter.js
+++ b/app/assets/javascripts/modules/signature-counter.js
@@ -2,7 +2,8 @@ class SignatureCounter {
   constructor(container, responseThreshold, debateThreshold, interval) {
     this.responseThreshold = responseThreshold;
     this.debateThreshold = debateThreshold;
-    this.jsonUrl = window.location.href + '/count.json';
+    this.baseUrl = window.location.origin + window.location.pathname;
+    this.jsonUrl = this.baseUrl + '/count.json';
     this.signatureCount = container.querySelector('.signature-count-number .count');
     this.signatureGoal = container.querySelector('.signature-count-goal');
     this.progressBar = container.querySelector('progress');


### PR DESCRIPTION
This was broken when #1238 was deployed last week.

1. Didn't take account of anything in the query/fragment when changing from location.pathname to location.href as required by fetch vs. jQuery.get.

2. Changed the for loop variable name from container to counter and didn't confirm it was still working.