### PR TITLE
Don't reset the progress bar maximum to the debate threshold

### DIFF
--- a/app/assets/javascripts/modules/signature-counter.js
+++ b/app/assets/javascripts/modules/signature-counter.js
@@ -49,7 +49,7 @@ class SignatureCounter {
     this.signatureCount.textContent = this.format(this.value);
     this.signatureGoal.textContent = this.format(threshold);
     this.progressBar.value = Math.floor(this.value);
-    this.progressBar.max = threshold;
+    this.progressBar.max = Math.max(threshold, this.value);
   }
 
   countTo(currentCount, newCount) {

--- a/app/views/application/_signature_count.html.erb
+++ b/app/views/application/_signature_count.html.erb
@@ -5,7 +5,11 @@
 
   <label class="signature-count-progress">
     <span class="visuallyhidden">Progress of the petition towards its next target:</span>
-    <% if petition.response_threshold_reached_at? || petition.government_response_at? %>
+    <% if petition.debate_threshold_reached_at? %>
+      <%= tag.progress(value: petition.signature_count, max: petition.signature_count) do %>
+        This petition will be considered for a debate in Parliament
+      <% end %>
+    <% elsif petition.response_threshold_reached_at? || petition.government_response_at? %>
       <%= tag.progress(value: petition.signature_count, max: Site.threshold_for_debate) do %>
         <%= number_with_delimiter(petition.signature_count) %> of <%= Site.formatted_threshold_for_debate %> signatures required to be considered for a debate in Parliament
       <% end %>


### PR DESCRIPTION
If the value is greater than the maximum then getting the value is clamped to the maximum value causing the count to restart from 100,000 on every poll.