### PR TITLE
Fix redirect loop with unknown requested content types

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   end
 
   def unknown_format?
-    request.format.nil?
+    request.format.nil? && request.path.match(/\.\w+$/)
   end
 
   def url_without_format

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -1,11 +1,29 @@
 require 'rails_helper'
 
-RSpec.describe 'Requests for an unknown format', type: :request, show_exceptions: true do
-  before do
-    get "/petitions/100001.please"
+RSpec.describe "Requests for an unknown format", type: :request, show_exceptions: true do
+  let!(:petition) { FactoryBot.create(:open_petition, id: 100001) }
+
+  context "when the url has an extension" do
+    before do
+      get "/petitions/100001.please"
+    end
+
+    it "redirect to the path without the extension" do
+      expect(response).to redirect_to("/petitions/100001")
+
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
-  it "redirect to the path without the extension" do
-    expect(response).to redirect_to('/petitions/100001')
+  context "when the url has no extension" do
+    before do
+      get "/petitions/100001", headers: { "Accept" => "application/please" }
+    end
+
+    it "responds with 406 Not Acceptable" do
+      expect(response).to have_http_status(:not_acceptable)
+    end
   end
 end


### PR DESCRIPTION
Back in 2015 when the site relaunched after the general election there were a lot of 406 Not Acceptable requests where social media was interpreting the run-on of a petition url at the end of a sentence with the first word as the file extension, e.g.

```
... sign petition.parliament.uk/petitions/100001.The ...
```

To improve the user experience we redirected to the url without the extension if it wasn't one of our recognised types, e.g. HTML, JSON or CSV. However in doing so we created a redirect loop where a bot sends a request with an unregistered content type as it would redirect back to the url it just requested.

To fix this we only redirect when the url has an extension.