### PR TITLE
Allow sysadmin to anonymize creators

### DIFF
--- a/app/controllers/admin/archived/creators_controller.rb
+++ b/app/controllers/admin/archived/creators_controller.rb
@@ -1,0 +1,43 @@
+class Admin::Archived::CreatorsController < Admin::AdminController
+  before_action :require_sysadmin
+  before_action :fetch_petition
+  before_action :fetch_creator
+
+  before_action unless: :hidden_or_removed? do
+    redirect_to admin_archived_petition_url(@petition), alert: :petition_not_hidden_or_removed
+  end
+
+  before_action if: :already_anonymized? do
+    redirect_to admin_archived_petition_url(@petition), alert: :creator_already_anonymized
+  end
+
+  rescue_from ActiveRecord::ActiveRecordError do
+    redirect_to admin_archived_petition_url(@petition), alert: :creator_not_anonymized
+  end
+
+  def destroy
+    @creator.anonymize!(Time.current)
+
+    respond_to do |format|
+      format.html { redirect_to admin_archived_petition_url(@petition), notice: :creator_anonymized }
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = ::Archived::Petition.find(params[:petition_id])
+  end
+
+  def fetch_creator
+    @creator = @petition.creator
+  end
+
+  def hidden_or_removed?
+    @petition.hidden? || @petition.removed?
+  end
+
+  def already_anonymized?
+    @creator.anonymized?
+  end
+end

--- a/app/controllers/admin/creators_controller.rb
+++ b/app/controllers/admin/creators_controller.rb
@@ -1,0 +1,43 @@
+class Admin::CreatorsController < Admin::AdminController
+  before_action :require_sysadmin
+  before_action :fetch_petition
+  before_action :fetch_creator
+
+  before_action unless: :hidden_or_removed? do
+    redirect_to admin_petition_url(@petition), alert: :petition_not_hidden_or_removed
+  end
+
+  before_action if: :already_anonymized? do
+    redirect_to admin_petition_url(@petition), alert: :creator_already_anonymized
+  end
+
+  rescue_from ActiveRecord::ActiveRecordError do
+    redirect_to admin_petition_url(@petition), alert: :creator_not_anonymized
+  end
+
+  def destroy
+    @creator.anonymize!(Time.current)
+
+    respond_to do |format|
+      format.html { redirect_to admin_petition_url(@petition), notice: :creator_anonymized }
+    end
+  end
+
+  private
+
+  def fetch_petition
+    @petition = Petition.find(params[:petition_id])
+  end
+
+  def fetch_creator
+    @creator = @petition.creator
+  end
+
+  def hidden_or_removed?
+    @petition.hidden? || @petition.removed?
+  end
+
+  def already_anonymized?
+    @creator.anonymized?
+  end
+end

--- a/app/views/admin/archived/petitions/_petition_actions.html.erb
+++ b/app/views/admin/archived/petitions/_petition_actions.html.erb
@@ -17,7 +17,7 @@
     </li>
 
     <% unless current_user.is_a_reviewer? %>
-      <% if @petition.moderated? %>
+      <% if @petition.moderated? && @petition.published? %>
         <li class="petition-action">
           <%= render 'petition_action_government_response', petition: @petition %>
         </li>
@@ -33,7 +33,7 @@
         </li>
       <% end %>
 
-      <% if @petition.moderated? %>
+      <% if @petition.moderated? && @petition.published? %>
         <li class="petition-action">
           <%= render 'petition_action_email_petitioners', petition: @petition %>
         </li>

--- a/app/views/admin/archived/petitions/_petition_details.html.erb
+++ b/app/views/admin/archived/petitions/_petition_details.html.erb
@@ -9,18 +9,29 @@
     <dt>Anonymized</dt>
     <dd><%= date_time_format(@petition.anonymized_at) %></dd>
   <% elsif creator = @petition.creator %>
-    <dt>Creator</dt>
-    <dd>
-      <%= creator.name %><br>
-      <%= auto_link(creator.email) %>
-    </dd>
-
-    <% if constituency = creator.constituency %>
-      <dt>Constituency</dt>
+    <% if creator.anonymized? %>
+      <dt>Creator</dt>
+      <dd>Anonymized on <%= date_format(creator.anonymized_at) %></dd>
+    <% else %>
+      <dt>Creator</dt>
       <dd>
-        <span class="creator-constituency"><%= constituency.name %></span><br>
-        <small class="creator-constituency-region"><%= constituency.region.name %></small>
+        <%= creator.name %><br>
+        <%= link_to(creator.email, admin_archived_signatures_path(q: creator.email), class: "creator-email") %>
+
+        <% if current_user.can_remove_petitions? && (@petition.hidden? || @petition.removed?) %>
+          <p>
+            <%= button_to "Anonymize", admin_archived_petition_creator_url(@petition), method: :delete, class: "button", data: { confirm: "Anonymize petition creator?" } %>
+          </p>
+        <% end %>
       </dd>
+
+      <% if constituency = creator.constituency %>
+        <dt>Constituency</dt>
+        <dd>
+          <span class="creator-constituency"><%= constituency.name %></span><br>
+          <small class="creator-constituency-region"><%= constituency.region.name %></small>
+        </dd>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -31,17 +31,19 @@
         <%= f.text_area :additional_details, tabindex: increment, rows: 7, class: 'form-control', disabled: @petition.editing_disabled? %>
       <% end %>
 
-      <%= f.fields_for :creator do |c| %>
-        <%= form_row for: [@petition.creator, :name] do %>
-          <%= c.label :name, "Creator", class: 'form-label' %>
-          <%= error_messages_for_field @petition.creator, :name %>
-          <%= c.text_field :name, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
-        <% end %>
+      <% unless @petition.creator.anonymized? %>
+        <%= f.fields_for :creator do |c| %>
+          <%= form_row for: [@petition.creator, :name] do %>
+            <%= c.label :name, "Creator", class: 'form-label' %>
+            <%= error_messages_for_field @petition.creator, :name %>
+            <%= c.text_field :name, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+          <% end %>
 
-        <%= form_row for: [@petition.creator, :email] do %>
-          <%= c.label :email, "Email", class: 'form-label' %>
-          <%= error_messages_for_field @petition.creator, :email %>
-          <%= c.text_field :email, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+          <%= form_row for: [@petition.creator, :email] do %>
+            <%= c.label :email, "Email", class: 'form-label' %>
+            <%= error_messages_for_field @petition.creator, :email %>
+            <%= c.text_field :email, tabindex: increment, class: 'form-control', disabled: @petition.editing_disabled? %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/views/admin/petitions/_petition_actions.html.erb
+++ b/app/views/admin/petitions/_petition_actions.html.erb
@@ -1,6 +1,6 @@
 <nav class="petition-actions" aria-label="Petition actions">
   <ul>
-    <% if @petition.rejection? %>
+    <% if @petition.rejection? && !@petition.creator.anonymized? %>
       <% if current_user.is_a_sysadmin? %>
         <li class="petition-action">
           <%= render 'petition_action_moderation', petition: @petition %>
@@ -39,7 +39,7 @@
       </li>
 
       <% unless current_user.is_a_reviewer? %>
-        <% if @petition.moderated? %>
+        <% if @petition.moderated? && @petition.published? %>
           <li class="petition-action">
             <%= render 'petition_action_government_response', petition: @petition %>
           </li>
@@ -55,7 +55,7 @@
           </li>
         <% end %>
 
-        <% if @petition.moderated? %>
+        <% if @petition.moderated? && @petition.published? %>
           <li class="petition-action">
             <%= render 'petition_action_email_petitioners', petition: @petition %>
           </li>
@@ -66,7 +66,7 @@
             <%= render 'petition_action_take_down', petition: @petition %>
           </li>
 
-        <% elsif @petition.rejection? %>
+        <% elsif @petition.rejection? && !@petition.creator.anonymized? %>
           <li class="petition-action">
             <%= render 'petition_action_change_rejection_status', petition: @petition %>
           </li>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -13,28 +13,39 @@
   <dt>Anonymized</dt>
   <dd><%= date_time_format(@petition.anonymized_at) %></dd>
 <% elsif creator = @petition.creator %>
-  <dt>Creator</dt>
-  <dd>
-    <span class="creator-name"><%= creator.name %></span><br>
-    <%= link_to(creator.email, admin_signatures_path(q: creator.email), class: "creator-email") %>
-  </dd>
-  <% if creator.united_kingdom? %>
-    <dt>Postcode</dt>
+  <% if creator.anonymized? %>
+    <dt>Creator</dt>
+    <dd>Anonymized on <%= date_format(creator.anonymized_at) %></dd>
+  <% else %>
+    <dt>Creator</dt>
     <dd>
-      <%= link_to(creator.formatted_postcode, admin_signatures_path(q: creator.formatted_postcode), class: "creator-postcode") %>
-    </dd>
-  <% end %>
-  <dt>IP address</dt>
-  <dd>
-    <%= link_to(creator.ip_address, admin_signatures_path(q: creator.ip_address), class: "creator-ip-address") %>
-  </dd>
+      <span class="creator-name"><%= creator.name %></span><br>
+      <%= link_to(creator.email, admin_signatures_path(q: creator.email), class: "creator-email") %>
 
-  <% if constituency = creator.constituency %>
-    <dt>Constituency</dt>
-    <dd>
-      <span class="creator-constituency"><%= constituency.name %></span><br>
-      <small class="creator-constituency-region"><%= constituency.region.name %></small>
+      <% if current_user.can_remove_petitions? && (@petition.hidden? || @petition.removed?) %>
+        <p>
+          <%= button_to "Anonymize", admin_petition_creator_url(@petition), method: :delete, class: "button", data: { confirm: "Anonymize petition creator?" } %>
+        </p>
+      <% end %>
     </dd>
+    <% if creator.united_kingdom? %>
+      <dt>Postcode</dt>
+      <dd>
+        <%= link_to(creator.formatted_postcode, admin_signatures_path(q: creator.formatted_postcode), class: "creator-postcode") %>
+      </dd>
+    <% end %>
+    <dt>IP address</dt>
+    <dd>
+      <%= link_to(creator.ip_address, admin_signatures_path(q: creator.ip_address), class: "creator-ip-address") %>
+    </dd>
+
+    <% if constituency = creator.constituency %>
+      <dt>Constituency</dt>
+      <dd>
+        <span class="creator-constituency"><%= constituency.name %></span><br>
+        <small class="creator-constituency-region"><%= constituency.region.name %></small>
+      </dd>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -36,9 +36,13 @@
 <%= render 'share_petition', petition: petition %>
 
 <ul class="petition-meta">
-  <li class="meta-created-by">
-    <span class="label">Created by</span> <%= petition.creator.name %>
-  </li>
+  <% if creator = petition.creator %>
+    <% unless creator.anonymized? %>
+      <li class="meta-created-by">
+        <span class="label">Created by</span> <%= creator.name %>
+      </li>
+    <% end %>
+  <% end %>
   <li class="meta-deadline">
     <% if petition.closing_early_for_dissolution? %>
       <span class="label">Deadline</span> <%= short_date_time_format Parliament.dissolution_at %>

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -38,6 +38,9 @@ en-GB:
 
     flash:
       admin_required: "You must be logged in as an administrator to view this page"
+      creator_already_anonymized: "Petition creator has already been anonymized"
+      creator_anonymized: "Petition creator has been anonymized"
+      creator_not_anonymized: "Could not anonymize the petition creator - please contact support"
       change_password: "Please change your password before continuing"
       closure_scheduled: "Petitions have been scheduled to close early"
       closure_not_scheduled: "Petitions could not be scheduled to close early - please contact support"
@@ -84,6 +87,7 @@ en-GB:
       missing_tasks: "Please select one or more tasks to execute"
       password_updated: "Password was successfully updated"
       page_updated: "Page updated successfully"
+      petition_not_hidden_or_removed: "The creator can only be anonymized if the petition is hidden or removed"
       petitions_archiving: "Archiving of petitions was successfully started"
       petitions_not_archiving: "Archiving of petitions could not be started - please contact support"
       petitions_anonymizing: "Anonymizing of petitions was successfully started"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
       resources :petitions, only: %i[show index] do
         post :resend, :remove, on: :member
 
+        resource  :creator, only: %i[destroy]
         resources :emails, controller: 'petition_emails', except: %i[index show]
         resource  :lock, only: %i[show create update destroy]
         resource  :moderation, controller: 'moderation', only: %i[update]
@@ -232,6 +233,7 @@ Rails.application.routes.draw do
         root to: redirect('/admin/archived/petitions')
 
         resources :petitions, only: %i[show index] do
+          resource  :creator, only: %i[destroy]
           resources :emails, controller: 'petition_emails', except: %i[index show]
           resource  :lock, only: %i[show create update destroy]
 

--- a/spec/controllers/admin/archived/creators_controller_spec.rb
+++ b/spec/controllers/admin/archived/creators_controller_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Archived::CreatorsController, type: :controller, admin: true do
+  context "when not logged in" do
+    [
+      ["DELETE", "/admin/archived/petitions/:petition_id/creator", :destroy, { petition_id: 1 }]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method: method, params: params }
+
+        it "redirects to the login page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a moderator" do
+    let(:moderator) { FactoryBot.create(:moderator_user) }
+    before { login_as(moderator) }
+
+    [
+      ["DELETE", "/admin/archived/petitions/:petition_id/creator", :destroy, { petition_id: 1 }]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method: method, params: params }
+
+        it "redirects to the admin hub page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a sysadmin" do
+    let(:sysadmin) { FactoryBot.create(:sysadmin_user) }
+    let(:creator) { petition.creator }
+
+    before { login_as(sysadmin) }
+    before { allow(Archived::Petition).to receive(:find).with(petition.to_param).and_return(petition) }
+
+    shared_examples "a petition that can't have its creator anonymized" do
+      before { delete :destroy, params: { petition_id: petition.id } }
+
+      it "redirects to the petition show page" do
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}")
+      end
+
+      it "sets the flash alert message" do
+        expect(flash[:alert]).to eq("The creator can only be anonymized if the petition is hidden or removed")
+      end
+    end
+
+    shared_examples "a petition that can have its creator anonymized" do
+      context "and the creator has already been anonymized" do
+        before do
+          creator.anonymize!(Time.current)
+
+          expect(Archived::Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:creator).and_return(creator)
+          expect(creator).not_to receive(:anonymize!)
+
+          delete :destroy, params: { petition_id: petition.id }
+        end
+
+        it "redirects to the petition show page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Petition creator has already been anonymized")
+        end
+      end
+
+      context "and the anonymization fails" do
+        let(:exception) { ActiveRecord::RecordNotSaved.new("Unable anonymize creator") }
+
+        before do
+          expect(Archived::Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:creator).and_return(creator)
+          expect(creator).to receive(:anonymize!).and_raise(exception)
+
+          delete :destroy, params: { petition_id: petition.id }
+        end
+
+        it "redirects to the petition show page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Could not anonymize the petition creator - please contact support")
+        end
+
+        it "hasn't anonymized the creator" do
+          expect(creator.reload).not_to be_anonymized
+        end
+      end
+
+      context "and the anonymization succeeds" do
+        before do
+          expect(Archived::Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:creator).and_return(creator)
+          expect(creator).to receive(:anonymize!).and_call_original
+
+          delete :destroy, params: { petition_id: petition.id }
+        end
+
+        it "redirects to the petition show page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/archived/petitions/#{petition.id}")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Petition creator has been anonymized")
+        end
+
+        it "has anonymized the creator" do
+          expect(creator.reload).to be_anonymized
+        end
+      end
+    end
+
+    describe "DELETE /admin/archived/petitions/:petition_id/creator" do
+      (Archived::Petition::STATES - %w[hidden removed]).each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:archived_petition, state.to_sym, :creator) }
+
+          it_behaves_like "a petition that can't have its creator anonymized"
+        end
+      end
+
+      %w[hidden removed].each do |state|
+        context "when the petition has been #{state}" do
+          let(:petition) { FactoryBot.create(:archived_petition, state.to_sym, :creator) }
+
+          it_behaves_like "a petition that can have its creator anonymized"
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/creators_controller_spec.rb
+++ b/spec/controllers/admin/creators_controller_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe Admin::CreatorsController, type: :controller, admin: true do
+  context "when not logged in" do
+    [
+      ["DELETE", "/admin/petitions/:petition_id/creator", :destroy, { petition_id: 1 }]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method: method, params: params }
+
+        it "redirects to the login page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/login")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a moderator" do
+    let(:moderator) { FactoryBot.create(:moderator_user) }
+    before { login_as(moderator) }
+
+    [
+      ["DELETE", "/admin/petitions/:petition_id/creator", :destroy, { petition_id: 1 }]
+    ].each do |method, path, action, params|
+
+      describe "#{method} #{path}" do
+        before { process action, method: method, params: params }
+
+        it "redirects to the admin hub page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin")
+        end
+      end
+
+    end
+  end
+
+  context "when logged in as a sysadmin" do
+    let(:sysadmin) { FactoryBot.create(:sysadmin_user) }
+    let(:creator) { petition.creator }
+
+    before { login_as(sysadmin) }
+    before { allow(Petition).to receive(:find).with(petition.to_param).and_return(petition) }
+
+    shared_examples "a petition that can't have its creator anonymized" do
+      before { delete :destroy, params: { petition_id: petition.id } }
+
+      it "redirects to the petition show page" do
+        expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
+      end
+
+      it "sets the flash alert message" do
+        expect(flash[:alert]).to eq("The creator can only be anonymized if the petition is hidden or removed")
+      end
+    end
+
+    shared_examples "a petition that can have its creator anonymized" do
+      context "and the creator has already been anonymized" do
+        before do
+          creator.anonymize!(Time.current)
+
+          expect(Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:creator).and_return(creator)
+          expect(creator).not_to receive(:anonymize!)
+
+          delete :destroy, params: { petition_id: petition.id }
+        end
+
+        it "redirects to the petition show page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Petition creator has already been anonymized")
+        end
+      end
+
+      context "and the anonymization fails" do
+        let(:exception) { ActiveRecord::RecordNotSaved.new("Unable anonymize creator") }
+
+        before do
+          expect(Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:creator).and_return(creator)
+          expect(creator).to receive(:anonymize!).and_raise(exception)
+
+          delete :destroy, params: { petition_id: petition.id }
+        end
+
+        it "redirects to the petition show page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
+        end
+
+        it "sets the flash alert message" do
+          expect(flash[:alert]).to eq("Could not anonymize the petition creator - please contact support")
+        end
+
+        it "hasn't anonymized the creator" do
+          expect(creator.reload).not_to be_anonymized
+        end
+      end
+
+      context "and the anonymization succeeds" do
+        before do
+          expect(Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:creator).and_return(creator)
+          expect(creator).to receive(:anonymize!).and_call_original
+
+          delete :destroy, params: { petition_id: petition.id }
+        end
+
+        it "redirects to the petition show page" do
+          expect(response).to redirect_to("https://moderate.petition.parliament.uk/admin/petitions/#{petition.id}")
+        end
+
+        it "sets the flash notice message" do
+          expect(flash[:notice]).to eq("Petition creator has been anonymized")
+        end
+
+        it "has anonymized the creator" do
+          expect(creator.reload).to be_anonymized
+        end
+      end
+    end
+
+    describe "DELETE /admin/petitions/:petition_id/creator" do
+      (Petition::STATES - %w[hidden removed]).each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it_behaves_like "a petition that can't have its creator anonymized"
+        end
+      end
+
+      %w[hidden removed].each do |state|
+        context "when the petition has been #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it_behaves_like "a petition that can have its creator anonymized"
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/admin/archived/creator_spec.rb
+++ b/spec/routing/admin/archived/creator_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "routes for admin archived petition creator", type: :routes, admin: true do
+  it "doesn't route GET /admin/archived/petitions/1/creator/new" do
+    expect(get("/admin/archived/petitions/1/creator/new")).not_to be_routable
+  end
+
+  it "doesn't route POST /admin/archived/petitions/1/creator" do
+    expect(post("/admin/archived/petitions/1/creator")).not_to be_routable
+  end
+
+  it "doesn't route GET /admin/archived/petitions/1/creator" do
+    expect(get("/admin/archived/petitions/1/creator")).not_to be_routable
+  end
+
+  it "doesn't route GET /admin/archived/petitions/1/creator/edit" do
+    expect(post("/admin/archived/petitions/1/creator/edit")).not_to be_routable
+  end
+
+  it "doesn't route PATCH /admin/archived/petitions/1/creator" do
+    expect(patch("/admin/archived/petitions/1/creator")).not_to be_routable
+  end
+
+  it "routes DELETE /admin/archived/petitions/1/creator to admin/creators#destroy" do
+    expect(delete("/admin/archived/petitions/1/creator")).to route_to('admin/archived/creators#destroy', petition_id: '1')
+  end
+end

--- a/spec/routing/admin/petitions/creator_spec.rb
+++ b/spec/routing/admin/petitions/creator_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "routes for admin petition creator", type: :routes, admin: true do
+  it "doesn't route GET /admin/petitions/1/creator/new" do
+    expect(get("/admin/petitions/1/creator/new")).not_to be_routable
+  end
+
+  it "doesn't route POST /admin/petitions/1/creator" do
+    expect(post("/admin/petitions/1/creator")).not_to be_routable
+  end
+
+  it "doesn't route GET /admin/petitions/1/creator" do
+    expect(get("/admin/petitions/1/creator")).not_to be_routable
+  end
+
+  it "doesn't route GET /admin/petitions/1/creator/edit" do
+    expect(post("/admin/petitions/1/creator/edit")).not_to be_routable
+  end
+
+  it "doesn't route PATCH /admin/petitions/1/creator" do
+    expect(patch("/admin/petitions/1/creator")).not_to be_routable
+  end
+
+  it "routes DELETE /admin/petitions/1/creator to admin/creators#destroy" do
+    expect(delete("/admin/petitions/1/creator")).to route_to('admin/creators#destroy', petition_id: '1')
+  end
+end


### PR DESCRIPTION
Sometimes people request to have their details removed from a petition before the anonymization process kicks in after the parliament has been archived. This would be done by removing the petition from public view but their details still remain within the system. To avoid manual support requests add a button for petitions that have been hidden or removed to anonymize the creator details. Once the creator has been anonymized a hidden petition can't have its moderation decision changed.