### PR TITLE
Add debate_scheduled_at timestamp

### DIFF
--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -383,6 +383,14 @@ module Archived
 
     def update_debate_state
       self.debate_state = evaluate_debate_state
+
+      if scheduled_debate_date?
+        if scheduled_debate_date.future?
+          self.debate_scheduled_at ||= Time.current
+        end
+      else
+        self.debate_scheduled_at = nil
+      end
     end
 
     def update_lock!(user, now = Time.current)

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -1077,6 +1077,14 @@ class Petition < ActiveRecord::Base
 
   def update_debate_state
     self.debate_state = evaluate_debate_state
+
+    if scheduled_debate_date?
+      if scheduled_debate_date.future?
+        self.debate_scheduled_at ||= Time.current
+      end
+    else
+      self.debate_scheduled_at = nil
+    end
   end
 
   def evaluate_debate_state

--- a/app/views/archived/petitions/_petition.json.jbuilder
+++ b/app/views/archived/petitions/_petition.json.jbuilder
@@ -30,6 +30,7 @@ json.attributes do
   json.response_threshold_reached_at api_date_format(petition.response_threshold_reached_at)
   json.government_response_at api_date_format(petition.government_response_at)
   json.debate_threshold_reached_at api_date_format(petition.debate_threshold_reached_at)
+  json.debate_scheduled_at api_date_format(petition.debate_scheduled_at)
   json.scheduled_debate_date api_date_format(petition.scheduled_debate_date)
   json.debate_outcome_at api_date_format(petition.debate_outcome_at)
 

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -22,6 +22,7 @@ json.attributes do
   json.response_threshold_reached_at api_date_format(petition.response_threshold_reached_at)
   json.government_response_at api_date_format(petition.government_response_at)
   json.debate_threshold_reached_at api_date_format(petition.debate_threshold_reached_at)
+  json.debate_scheduled_at api_date_format(petition.debate_scheduled_at)
   json.scheduled_debate_date api_date_format(petition.scheduled_debate_date)
   json.debate_outcome_at api_date_format(petition.debate_outcome_at)
 

--- a/db/migrate/20251112194603_add_debate_scheduled_at_to_petitions.rb
+++ b/db/migrate/20251112194603_add_debate_scheduled_at_to_petitions.rb
@@ -1,0 +1,5 @@
+class AddDebateScheduledAtToPetitions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :petitions, :debate_scheduled_at, :datetime, precision: nil, if_not_exists: true
+  end
+end

--- a/db/migrate/20251112194716_backfill_petitions_debate_scheduled_at.rb
+++ b/db/migrate/20251112194716_backfill_petitions_debate_scheduled_at.rb
@@ -1,0 +1,15 @@
+class BackfillPetitionsDebateScheduledAt < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    up_only do
+      execute <<~SQL
+        UPDATE petitions AS p
+        SET debate_scheduled_at = e.debate_scheduled
+        FROM email_requested_receipts AS e
+        WHERE p.id = e.petition_id
+        AND e.debate_scheduled IS NOT NULL
+      SQL
+    end
+  end
+end

--- a/db/migrate/20251112194737_add_debate_scheduled_at_to_archived_petitions.rb
+++ b/db/migrate/20251112194737_add_debate_scheduled_at_to_archived_petitions.rb
@@ -1,0 +1,5 @@
+class AddDebateScheduledAtToArchivedPetitions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :archived_petitions, :debate_scheduled_at, :datetime, precision: nil, if_not_exists: true
+  end
+end

--- a/db/migrate/20251112194807_backfill_archived_petitions_debate_scheduled_at.rb
+++ b/db/migrate/20251112194807_backfill_archived_petitions_debate_scheduled_at.rb
@@ -1,0 +1,13 @@
+class BackfillArchivedPetitionsDebateScheduledAt < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    up_only do
+      execute <<~SQL
+        UPDATE archived_petitions
+        SET debate_scheduled_at = email_requested_for_debate_scheduled_at
+        WHERE debate_state IN ('scheduled', 'debated')
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_12_120752) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_12_194807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
   enable_extension "plpgsql"
@@ -174,6 +174,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_12_120752) do
     t.halfvec "embedding", limit: 1024
     t.datetime "published_at", precision: nil
     t.string "response_state", limit: 30, default: "pending", null: false
+    t.datetime "debate_scheduled_at", precision: nil
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "index_archived_petitions_on_action", using: :gin
     t.index "to_tsvector('english'::regconfig, (background)::text)", name: "index_archived_petitions_on_background", using: :gin
     t.index "to_tsvector('english'::regconfig, additional_details)", name: "index_archived_petitions_on_additional_details", using: :gin
@@ -583,6 +584,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_12_120752) do
     t.halfvec "embedding", limit: 1024
     t.datetime "published_at", precision: nil
     t.string "response_state", limit: 30, default: "pending", null: false
+    t.datetime "debate_scheduled_at", precision: nil
     t.index "((last_signed_at > signature_count_validated_at))", name: "index_petitions_on_validated_at_and_signed_at"
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "index_petitions_on_action", using: :gin
     t.index "to_tsvector('english'::regconfig, (background)::text)", name: "index_petitions_on_background", using: :gin

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -122,6 +122,7 @@ FactoryBot.define do
     end
 
     trait :scheduled_for_debate do
+      debate_scheduled_at { 1.day.ago }
       scheduled_debate_date { 1.week.from_now }
       debate_state { "scheduled" }
     end
@@ -349,6 +350,7 @@ FactoryBot.define do
     end
 
     trait :scheduled_for_debate do
+      debate_scheduled_at { 1.day.ago }
       scheduled_debate_date { 10.days.from_now }
     end
 
@@ -552,6 +554,7 @@ FactoryBot.define do
 
   factory :scheduled_debate_petition, :parent => :open_petition do
     debate_threshold_reached_at { 1.week.ago }
+    debate_scheduled_at { 1.day.ago }
     scheduled_debate_date { 1.week.from_now }
     debate_state { 'scheduled' }
   end

--- a/spec/requests/archived_petition_show_spec.rb
+++ b/spec/requests/archived_petition_show_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe "API request to show an archived petition", type: :request, show_
 
       expect(attributes).to match(
         a_hash_including(
+          "debate_scheduled_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),
           "scheduled_debate_date" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}\z])
         )
       )

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
 
       expect(attributes).to match(
         a_hash_including(
+          "debate_scheduled_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),
           "scheduled_debate_date" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}\z])
         )
       )


### PR DESCRIPTION
This is sort of available via the email request receipts but misses any debates scheduled without sending out emails so make it explicit.