### PR TITLE
Change DatabaseCleaner strategy to truncation

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -27,7 +27,7 @@ ActionController::Base.allow_rescue = false
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
-  DatabaseCleaner.strategy = :transaction
+  DatabaseCleaner.strategy = :truncation
 rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end


### PR DESCRIPTION
We get intermittent deadlocks on action runs which appear to be from transactions in scenarios that are using the Rack::Test driver.