### PR TITLE
Add opening date to petition details in moderation

### DIFF
--- a/app/views/admin/archived/petitions/_petition_details.html.erb
+++ b/app/views/admin/archived/petitions/_petition_details.html.erb
@@ -35,6 +35,11 @@
     <% end %>
   <% end %>
 
+  <% if @petition.opened_at? %>
+    <dt>Opened</dt>
+    <dd><%= date_format_admin(@petition.opened_at) %></dd>
+  <% end %>
+
   <% if @petition.removed? %>
     <dt>Removed</dt>
     <dd><%= date_time_format(@petition.removed_at) %></dd>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -61,25 +61,29 @@
 <% end %>
 
 <% if @petition.in_todo_list? %>
-  <dt>Created on</dt>
+  <dt>Created</dt>
   <dd><%= date_time_format(@petition.created_at) %></dd>
 
   <% if @petition.moderation_threshold_reached_at? %>
-    <dt>Sponsored on</dt>
+    <dt>Sponsored</dt>
     <dd><%= date_time_format(@petition.moderation_threshold_reached_at) %></dd>
   <% end %>
 <% else %>
+  <% if @petition.opened_at? %>
+    <dt>Opened</dt>
+    <dd><%= date_format_admin(@petition.opened_at) %></dd>
+  <% end %>
   <% if @petition.open? %>
     <dt>Deadline</dt>
     <dd><%= date_format_admin(@petition.deadline) %></dd>
   <% elsif @petition.rejection? %>
-    <dt>Rejected on</dt>
+    <dt>Rejected</dt>
     <dd><%= date_format_admin(@petition.rejected_at) %></dd>
   <% elsif @petition.stopped? %>
-    <dt>Stopped on</dt>
+    <dt>Stopped</dt>
     <dd><%= date_format_admin(@petition.stopped_at) %></dd>
   <% elsif @petition.closed? %>
-    <dt>Closed on</dt>
+    <dt>Closed</dt>
     <dd><%= date_format_admin(@petition.closed_at) %></dd>
   <% end %>
 


### PR DESCRIPTION
Whilst most of the time the opening date is merely subtracting six from the month number it's a bit tricky for petitions opened at the end of August when their closing date is the end of February which could be a leap year.