### PR TITLE
Ignore additional actions in Appsignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -13,7 +13,17 @@ default: &defaults
 
   # Actions that should not be monitored by AppSignal
   ignore_actions:
-    - Admin::UserSessionsController#status
+    - Admin::LocksController#create
+    - Admin::LocksController#destroy
+    - Admin::LocksController#show
+    - Admin::SessionsController#status
+    - DeliverDebateOutcomeEmailJob#perform
+    - DeliverDebateScheduledEmailJob#perform
+    - DeliverPetitionEmailJob#perform
+    - DeliverPetitionMailshotJob#perform
+    - DeliverThresholdResponseEmailJob#perform
+    - EmailConfirmationForSignerEmailJob#perform
+    - EmailDuplicateSignaturesEmailJob#perform
     - PetitionsController#count
     - PingController#ping
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -37,7 +37,7 @@
     {
       "warning_type": "Unmaintained Dependency",
       "warning_code": 123,
-      "fingerprint": "715ee6d743a8af33c7b930d728708ce19c765fb40e2ad9d2b974db04d92dc7d1",
+      "fingerprint": "40be17ee84017c91503dab23873e24bdd71665ab665bf6f351cfc09ff83e6582",
       "check_name": "EOLRuby",
       "message": "Support for Ruby 3.2.9 ends on 2026-03-31",
       "file": ".ruby-version",
@@ -47,7 +47,7 @@
       "render_path": null,
       "location": null,
       "user_input": null,
-      "confidence": "Weak",
+      "confidence": "Medium",
       "cwe_id": [
         1104
       ],
@@ -187,6 +187,6 @@
       "note": ""
     }
   ],
-  "updated": "2026-02-05 16:12:41 +0000",
+  "updated": "2026-03-03 16:39:46 +0000",
   "brakeman_version": "6.2.2"
 }

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -3,3 +3,12 @@ if ENV["SERVER_TYPE"] == "counter"
     Appsignal.set_gauge("delayed_job_queue_length", Delayed::Job.count)
   }
 end
+
+unless ENV["APPSIGNAL_APP_NAME"] == "epetitions-production"
+  Appsignal.configure do |config|
+    config.ignore_actions += [
+      "UpdatePetitionStatisticsJob#perform",
+      "UpdateSignatureCountsJob#perform"
+    ]
+  end
+end


### PR DESCRIPTION
These actions never create exceptions and are never inspected other than to confirm that an email was sent which we can verify by other means.

This amounts to tens of millions of requests per month saved.