### PR TITLE
Allow indirect dependency updates for rubygems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: daily
     versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "indirect"
     groups:
       aws:
         applies-to: version-updates


### PR DESCRIPTION
The GitHub reviewing of security advisories is backlogged so allow indirect dependencies in regular dependabot updates for the rubygems ecosystem.