### PR TITLE
Debug intermittent CI failures

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,6 +22,7 @@ class Site < ActiveRecord::Base
     disable_feedback_sending
     disable_collecting_signatures
     disable_petition_creation
+    disable_petition_moderation_locking
   ]
 
   class << self
@@ -264,6 +265,14 @@ class Site < ActiveRecord::Base
         stale_while_revalidate: max_age * 2,
         stale_if_error: max_age * 5
       }
+    end
+
+    def disable_petition_moderation_locking!
+      instance.update!(disable_petition_moderation_locking: true)
+    end
+
+    def enable_petition_moderation_locking!
+      instance.update!(disable_petition_moderation_locking: false)
     end
 
     def defaults

--- a/app/views/admin/admin/_edit_lock.html.erb
+++ b/app/views/admin/admin/_edit_lock.html.erb
@@ -1,21 +1,23 @@
-<div id="edit-lock">
-  <div class="edit-lock-modal">
-    <p class="edit-lock-message">
-      This petition is currently being edited by someone else.
-    </p>
-    <p class="edit-lock-actions">
-      <button id="edit-lock-override" class="button">Override</button>
-      <button id="edit-lock-cancel" class="button-secondary">Cancel</button>
-    </p>
+<% unless Site.disable_petition_moderation_locking? %>
+  <div id="edit-lock">
+    <div class="edit-lock-modal">
+      <p class="edit-lock-message">
+        This petition is currently being edited by someone else.
+      </p>
+      <p class="edit-lock-actions">
+        <button id="edit-lock-override" class="button">Override</button>
+        <button id="edit-lock-cancel" class="button-secondary">Cancel</button>
+      </p>
+    </div>
   </div>
-</div>
 
-<%= javascript_tag(nonce: true) do %>
-  $(document).ready(function() {
-    <% if @petition.is_a?(::Archived::Petition) %>
-      $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/archived/petitions', true);
-    <% else %>
-      $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/petitions', <%= @petition.moderated? %>);
-    <% end %>
-  });
+  <%= javascript_tag(nonce: true) do %>
+    $(document).ready(function() {
+      <% if @petition.is_a?(::Archived::Petition) %>
+        $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/archived/petitions', true);
+      <% else %>
+        $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/petitions', <%= @petition.moderated? %>);
+      <% end %>
+    });
+  <% end %>
 <% end %>

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -10,6 +10,30 @@ BeforeAll do
   end
 end
 
+Before do |s|
+  message = <<~TEXT
+    ================================================================================
+    =                                                                              =
+    = BEGIN: #{sprintf("%-69s", s.name)} =
+    =                                                                              =
+    ================================================================================
+  TEXT
+
+  Rails.logger.debug(message)
+end
+
+After do |s|
+  message = <<~TEXT
+    ================================================================================
+    =                                                                              =
+    = AFTER: #{sprintf("%-69s", s.name)} =
+    =                                                                              =
+    ================================================================================
+  TEXT
+
+  Rails.logger.debug(message)
+end
+
 Before do
   default_url_options[:protocol] = 'https'
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -82,6 +82,14 @@ Before do
   Parliament.reset!(government: "TBC", opening_at: 2.weeks.ago)
 end
 
+Before('@locking') do
+  Site.enable_petition_moderation_locking!
+end
+
+Before('not @locking') do
+  Site.disable_petition_moderation_locking!
+end
+
 Before("@javascript") do
   next unless page.driver.respond_to?(:invalid_element_errors)
 


### PR DESCRIPTION
There are intermittent failures in the "Moderator responds to petition" cucumber scenario but it's hard to spot in the logs where the failure is. This commit adds logging of the scenario name before and after its execution so it's easier to spot.