### PR TITLE
Show petition title, creator, and text in signing flows

### DIFF
--- a/app/views/signatures/_petition_context.html.erb
+++ b/app/views/signatures/_petition_context.html.erb
@@ -1,0 +1,28 @@
+<p class="margin-bottom-2">
+  You’re signing the petition:
+  <% if full_text %>
+    <strong><%= petition.action %></strong>
+  <% else %>
+    <strong><%= link_to "#{petition.action}", petition_path(petition), target: "_blank" %></strong>
+  <% end %>
+</p>
+
+<% if (creator = petition.creator) && !creator.anonymized? %>
+  <span class="form-hint margin-bottom-7">
+    Created by <strong><%= creator.name %></strong>
+  </span>
+<% end %>
+
+<% if full_text %>
+  <details class="margin-bottom-7">
+    <summary>Show petition text</summary>
+
+    <div class="panel-indent">
+      <%= auto_link(simple_format(h(petition.background)), html: { rel: 'nofollow' }) %>
+
+      <% unless petition.additional_details.blank? %>
+        <%= auto_link(simple_format(h(petition.additional_details)), html: { rel: 'nofollow' }) %>
+      <% end %>
+    </div>
+  </details>
+<% end %>

--- a/app/views/signatures/create/_check_and_submit_stage.html.erb
+++ b/app/views/signatures/create/_check_and_submit_stage.html.erb
@@ -11,6 +11,8 @@
   <div class="grid-column-two-thirds-from-laptop">
     <%= form.button "Back", name: "move_back", value: "signature", class: "button-back" %>
 
+    <%= render 'signatures/petition_context', petition: @petition, full_text: false %>
+
     <h1>
       Check and sign this petition
     </h1>

--- a/app/views/signatures/create/_non_citizen_stage.html.erb
+++ b/app/views/signatures/create/_non_citizen_stage.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row margin-top-7">
   <div class="grid-column-two-thirds-from-laptop">
+    <%= render 'signatures/petition_context', petition: @petition, full_text: false %>
+
     <h1>
       Sorry, you can’t sign this petition
     </h1>

--- a/app/views/signatures/create/_signature_stage.html.erb
+++ b/app/views/signatures/create/_signature_stage.html.erb
@@ -4,6 +4,8 @@
   <div class="grid-column-two-thirds-from-laptop">
     <%= form.button "Back", name: "move_back", value: "uk_citizenship", class: "button-back" %>
 
+    <%= render 'signatures/petition_context', petition: @petition, full_text: false %>
+
     <h1>
       Confirm your details
     </h1>

--- a/app/views/signatures/create/_uk_citizenship_stage.html.erb
+++ b/app/views/signatures/create/_uk_citizenship_stage.html.erb
@@ -7,6 +7,8 @@
 
 <div class="grid-row margin-top-7">
   <div class="grid-column">
+    <%= render 'signatures/petition_context', petition: @petition, full_text: false %>
+
     <fieldset>
       <legend>
         <h1>

--- a/app/views/sponsors/create/_check_and_submit_stage.html.erb
+++ b/app/views/sponsors/create/_check_and_submit_stage.html.erb
@@ -11,6 +11,8 @@
   <div class="grid-column-two-thirds-from-laptop">
     <%= form.button "Back", name: "move_back", value: "signature", class: "button-back" %>
 
+    <%= render 'signatures/petition_context', petition: @petition, full_text: true %>
+
     <h1>
       Check and sign this petition
     </h1>

--- a/app/views/sponsors/create/_non_citizen_stage.html.erb
+++ b/app/views/sponsors/create/_non_citizen_stage.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row margin-top-7">
   <div class="grid-column-two-thirds-from-laptop">
+    <%= render 'signatures/petition_context', petition: @petition, full_text: true %>
+
     <h1>
       Sorry, you can’t sign this petition
     </h1>

--- a/app/views/sponsors/create/_signature_stage.html.erb
+++ b/app/views/sponsors/create/_signature_stage.html.erb
@@ -4,6 +4,8 @@
   <div class="grid-column-two-thirds-from-laptop">
     <%= form.button "Back", name: "move_back", value: "uk_citizenship", class: "button-back" %>
 
+    <%= render 'signatures/petition_context', petition: @petition, full_text: true %>
+
     <h1>
       Confirm your details
     </h1>

--- a/app/views/sponsors/create/_uk_citizenship_stage.html.erb
+++ b/app/views/sponsors/create/_uk_citizenship_stage.html.erb
@@ -7,6 +7,8 @@
 
 <div class="grid-row margin-top-7">
   <div class="grid-column">
+    <%= render 'signatures/petition_context', petition: @petition, full_text: true %>
+
     <fieldset>
       <legend>
         <h1>


### PR DESCRIPTION
Currently during the sponsor and signing flows there's no information about the petition you are actually signing, which means people can't be sure what they are about to sign if someone sends them a link directly!

This introduces a header to all sponsor and signing flows that lists the petition title and creator. If the petition is already public it also links to the petition page, and if it is still in the sponsorship phase it shows the petition text under an expander instead.

My ruby is extremely rusty so this may need someone with actual talent to finesse it, and while I've tried to copy the standard design patterns this may not be up to scratch. I did my best!

### This is what it looks like in the sponsor flow (after being expanded):
<img width="1019" height="729" alt="image" src="https://github.com/user-attachments/assets/1b6e8b9f-31fe-4ab7-8085-d2fe6863b104" />

### And this is what it looks like in the regular signature flow:
<img width="783" height="565" alt="image" src="https://github.com/user-attachments/assets/8e111f64-92b6-4404-93c6-e97dd0035169" />
